### PR TITLE
add python scaffolding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 #
 version: 2
 jobs:
-  build:
+  node:
     docker:
       # specify the version you desire here
       - image: circleci/node:7.10
@@ -39,3 +39,39 @@ jobs:
           command: |
             yarn test
             yarn lint
+  python:
+    docker:
+      - image: circleci/python:3.6.1
+      - image: mongo:3.6.2
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "python/requirements.txt" }}
+
+      - run:
+          name: Installing dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r python/requirements.txt
+
+      - save_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "python/requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Running tests
+          command: |
+            . venv/bin/activate
+            pytest python/tests
+workflows:
+  version: 2
+  node_and_python:
+    jobs:
+      - node
+      - python

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 dist
 *.swp
+**/*.egg-info
+**/__pycache__
+**/*.pyc

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,9 @@
+## Energuide API - ETL component
+
+### Installation
+
+Inside a virtualenv, run:
+```
+pip install -r requirements.txt
+pip install -e .
+```

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,6 @@
+setuptools==38.4.0
+astroid==1.5.3
+pylint==1.8.1
+pytest==3.3.2
+mypy==0.560
+click==6.7

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,22 @@
+import setuptools
+
+
+setuptools.setup(
+    name='energuide-etl',
+    version='0.0.1',
+    long_description='',
+    author='CDS-SNC',
+    url='https://github.com/cds-snc/nrcan_api',
+    packages=setuptools.find_packages('src'),
+    package_dir={'': 'src'},
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+    ],
+    entry_points='''
+        [console_scripts]
+        energuide=energuide.cli:main
+    '''
+)

--- a/python/src/energuide/cli.py
+++ b/python/src/energuide/cli.py
@@ -1,0 +1,2 @@
+def main() -> None:
+    print("Hello")

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -1,0 +1,2 @@
+def test_nothing() -> None:
+    assert True


### PR DESCRIPTION
Adds basic Python scaffolding to a separate folder within this repo. Also adds to CircleCI - Node & Python now run in parallel in a workflow.

/cc @sleepycat @evadb 