### PR TITLE
change bulk_write to insert_many

### DIFF
--- a/python/src/energuide/database.py
+++ b/python/src/energuide/database.py
@@ -68,5 +68,4 @@ def load(coords: DatabaseCoordinates, data: str, columns: typing.Optional[typing
                 columns = dataframe.columns
             dataframe = dataframe.where((pd.notnull(dataframe)), None)
 
-            inserts = [pymongo.InsertOne(record) for record in dataframe[columns].to_dict('records')]
-            collection.bulk_write(inserts)
+            collection.insert_many(dataframe[columns].to_dict('records'))


### PR DESCRIPTION
bulk_write is typically for mixed writing operations (update, delete, insert), while insert_many does just inserts. Since we are doing just inserts insert_many seems more appropriate.