### PR TITLE
split load into transform and load

### DIFF
--- a/python/src/energuide/transform.py
+++ b/python/src/energuide/transform.py
@@ -1,0 +1,17 @@
+import pandas as pd
+from energuide import database
+
+
+CHUNKSIZE = 1000
+
+
+def clean(dataframe: pd.DataFrame) -> pd.DataFrame:
+    return dataframe.where((pd.notnull(dataframe)), None)
+
+
+def run(coords: database.DatabaseCoordinates, filename: str) -> None:
+    chunks = pd.read_csv(filename, chunksize=CHUNKSIZE)
+
+    for chunk in chunks:
+        cleaned = clean(chunk)
+        database.load(coords, cleaned)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -57,3 +57,8 @@ def mongo_client(database_coordinates: database.DatabaseCoordinates) -> typing.I
     client: pymongo.MongoClient
     with database.mongo_client(database_coordinates) as client:
         yield client
+
+
+@pytest.fixture
+def energuide_fixture() -> str:
+    return os.path.join(os.path.dirname(__file__), 'sample.csv')

--- a/python/tests/test_database.py
+++ b/python/tests/test_database.py
@@ -1,18 +1,17 @@
-import os
-
+import pandas as pd
 import pymongo
 import pytest
 from energuide import database
 
 
 @pytest.fixture
-def energuide_data() -> str:
-    return os.path.join(os.path.dirname(__file__), 'sample.csv')
+def energuide_data(energuide_fixture: str) -> pd.DataFrame:
+    return pd.read_csv(energuide_fixture)
 
 
 def test_load_all(database_coordinates: database.DatabaseCoordinates,
                   mongo_client: pymongo.MongoClient,
-                  energuide_data: str) -> None:
+                  energuide_data: pd.DataFrame) -> None:
 
     database_name = database_coordinates.database
     collection_name = database_coordinates.collection

--- a/python/tests/test_transform.py
+++ b/python/tests/test_transform.py
@@ -1,0 +1,25 @@
+import pandas as pd
+import numpy as np
+import pymongo
+from energuide import database
+from energuide import transform
+
+
+def test_clean() -> None:
+    dataframe = pd.DataFrame.from_dict({'foo': [np.NaN]}, orient='columns')
+    output = transform.clean(dataframe).to_dict('records')
+
+    expected = [{'foo': None}]
+    assert output == expected
+
+
+def test_run(database_coordinates: database.DatabaseCoordinates,
+             mongo_client: pymongo.MongoClient,
+             energuide_fixture: str) -> None:
+
+    database_name = database_coordinates.database
+    collection_name = database_coordinates.collection
+    mongo_client[database_name][collection_name].drop()
+
+    transform.run(database_coordinates, energuide_fixture)
+    assert mongo_client[database_name][collection_name].count() == 3


### PR DESCRIPTION
Splits up the existing `load` step, which: 
- given a path, opens a file
- interprets in into a DataFrame
- does some cleanup on that DF
- loads it into Mongo

Removed some (I believe) currently unnecessary functionality to simplify. This will give us a hook to start Transforming the DataFrame(s) between Reading and Loading.