### PR TITLE
clean up database creation on fixture teardown

### DIFF
--- a/python/src/energuide/database.py
+++ b/python/src/energuide/database.py
@@ -30,8 +30,6 @@ class DatabaseCoordinates(typing.NamedTuple):
     password: str
     host: str
     port: int
-    database: str
-    collection: str
 
 
 def _is_prod() -> bool:
@@ -39,7 +37,7 @@ def _is_prod() -> bool:
 
 
 def _build_connection_string(coords: DatabaseCoordinates) -> str:
-    username, password, host, port, _, _ = coords
+    username, password, host, port = coords
 
     if _is_prod():
         connection_string = f'mongodb+srv://{username}:{password}@{host}'
@@ -58,9 +56,9 @@ def mongo_client(database_coordinates: DatabaseCoordinates) -> typing.Iterable[p
 
 
 def load(coords: DatabaseCoordinates,
+         database_name: str,
+         collection_name: str,
          dataframe: pd.DataFrame) -> None:
-    database_name = coords.database
-    collection_name = coords.collection
 
     client: pymongo.MongoClient
     with mongo_client(coords) as client:

--- a/python/src/energuide/transform.py
+++ b/python/src/energuide/transform.py
@@ -9,9 +9,9 @@ def clean(dataframe: pd.DataFrame) -> pd.DataFrame:
     return dataframe.where((pd.notnull(dataframe)), None)
 
 
-def run(coords: database.DatabaseCoordinates, filename: str) -> None:
+def run(coords: database.DatabaseCoordinates, database_name: str, collection: str, filename: str) -> None:
     chunks = pd.read_csv(filename, chunksize=CHUNKSIZE)
 
     for chunk in chunks:
         cleaned = clean(chunk)
-        database.load(coords, cleaned)
+        database.load(coords, database_name, collection, cleaned)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import random
 import typing
 
 import pymongo
@@ -26,8 +27,15 @@ def port() -> int:
 
 
 @pytest.fixture
-def database_name():
-    return os.environ.get(database.EnvVariables.database.value, database.EnvDefaults.database.value)
+def database_name(database_coordinates: database.DatabaseCoordinates) -> typing.Iterable[str]:
+    db_name = os.environ.get(database.EnvVariables.database.value, database.EnvDefaults.database.value)
+    db_name = f'{db_name}_test_{random.randint(1000, 9999)}'
+
+    yield db_name
+
+    client: pymongo.MongoClient
+    with database.mongo_client(database_coordinates) as client:
+        client.drop_database(db_name)
 
 
 @pytest.fixture
@@ -39,16 +47,12 @@ def collection() -> str:
 def database_coordinates(username: str,
                          password: str,
                          host: str,
-                         port: int,
-                         database_name: str,
-                         collection: str) -> database.DatabaseCoordinates:
+                         port: int) -> database.DatabaseCoordinates:
     return database.DatabaseCoordinates(
         username=username,
         password=password,
         host=host,
         port=port,
-        database=database_name,
-        collection=collection
     )
 
 

--- a/python/tests/test_database.py
+++ b/python/tests/test_database.py
@@ -11,12 +11,10 @@ def energuide_data(energuide_fixture: str) -> pd.DataFrame:
 
 def test_load_all(database_coordinates: database.DatabaseCoordinates,
                   mongo_client: pymongo.MongoClient,
+                  database_name: str,
+                  collection: str,
                   energuide_data: pd.DataFrame) -> None:
 
-    database_name = database_coordinates.database
-    collection_name = database_coordinates.collection
+    database.load(database_coordinates, database_name, collection, energuide_data)
 
-    mongo_client[database_name][collection_name].drop()
-    database.load(database_coordinates, energuide_data)
-
-    assert mongo_client[database_name][collection_name].count() == 3
+    assert mongo_client[database_name][collection].count() == 3

--- a/python/tests/test_transform.py
+++ b/python/tests/test_transform.py
@@ -15,11 +15,9 @@ def test_clean() -> None:
 
 def test_run(database_coordinates: database.DatabaseCoordinates,
              mongo_client: pymongo.MongoClient,
+             database_name: str,
+             collection: str,
              energuide_fixture: str) -> None:
 
-    database_name = database_coordinates.database
-    collection_name = database_coordinates.collection
-    mongo_client[database_name][collection_name].drop()
-
-    transform.run(database_coordinates, energuide_fixture)
-    assert mongo_client[database_name][collection_name].count() == 3
+    transform.run(database_coordinates, database_name, collection, energuide_fixture)
+    assert mongo_client[database_name][collection].count() == 3


### PR DESCRIPTION
Our existing test fixtures had a side-effect - they were creating a database that was not then torn down when done. This is a bad pattern - it can lead to flaky tests that are hard to diagnose.

The existing tests were getting around it by making sure to tear down the database at the beginning of the test, but that's too easy to forget to do. This way it is a fresh database each time, with no possibility of colliding with an existing database used for dev purposes on a local install.