### PR TITLE
add cli load command

### DIFF
--- a/python/src/energuide/cli.py
+++ b/python/src/energuide/cli.py
@@ -1,2 +1,29 @@
+import click
+from energuide import database
+from energuide import transform
+
+
+@click.group()
 def main() -> None:
-    print("Hello")
+    pass
+
+
+@main.command()
+@click.option('--username', envvar=database.EnvVariables.username.value, default=database.EnvDefaults.username.value)
+@click.option('--password', envvar=database.EnvVariables.password.value, default=database.EnvDefaults.password.value)
+@click.option('--host', envvar=database.EnvVariables.host.value, default=database.EnvDefaults.host.value)
+@click.option('--port', envvar=database.EnvVariables.port.value, default=database.EnvDefaults.port.value, type=int)
+@click.option('--db_name', envvar=database.EnvVariables.database.value, default=database.EnvDefaults.database.value)
+@click.option('--collection',
+              envvar=database.EnvVariables.collection.value,
+              default=database.EnvDefaults.collection.value)
+@click.option('--filename', type=click.Path(exists=True), required=True)
+def load(username: str, password: str, host: str, port: int, db_name: str, collection: str, filename: str) -> None:
+    coords = database.DatabaseCoordinates(
+        username=username,
+        password=password,
+        host=host,
+        port=port
+    )
+
+    transform.run(coords, db_name, collection, filename)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -1,0 +1,17 @@
+from click import testing  # type: ignore
+import pymongo
+from energuide import cli
+
+
+def test_load(energuide_fixture: str, database_name: str, collection: str, mongo_client: pymongo.MongoClient) -> None:
+    runner = testing.CliRunner()
+    result = runner.invoke(cli.main, args=[
+        'load',
+        '--db_name', database_name,
+        '--filename', energuide_fixture,
+    ])
+
+    assert result.exit_code == 0
+
+    coll = mongo_client.get_database(database_name).get_collection(collection)
+    assert coll.count() == 3


### PR DESCRIPTION
This PR adds a `load` subcommand (the first) to the `energuide` main command. It loads the supplied filename to the specified (through environment variables or command-line options) mongodb collection.