### PR TITLE
add Dwelling class

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -195,7 +195,7 @@ variable-rgx=[a-z_][a-z0-9_]{2,30}$
 variable-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct constant names
-const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+const-rgx=(([A-Z_][A-Z0-9_a-z]*)|(__.*__))$
 
 # Naming hint for constant names
 const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -18,7 +18,7 @@ class Dwelling:
         self._house_id = house_id
 
     @staticmethod
-    def verify_schema(data: DwellingData):
+    def _verify_schema(data: DwellingData):
         for row in data:
             if 'EVAL_ID' not in row.keys():
                 raise InvalidInputDataException()
@@ -27,7 +27,7 @@ class Dwelling:
     def from_data(cls, data: DwellingData) -> 'Dwelling':
         data = list(data)
         if data:
-            cls.verify_schema(data)
+            cls._verify_schema(data)
             house_id = data[0]['EVAL_ID']
             return Dwelling(house_id=house_id)
         else:

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -1,0 +1,38 @@
+import typing
+
+
+class NoInputDataException(Exception):
+    pass
+
+
+class InvalidInputDataException(Exception):
+    pass
+
+
+DwellingData = typing.Iterable[typing.Dict[str, typing.Any]]
+
+
+class Dwelling:
+
+    def __init__(self, *, house_id: int) -> None:
+        self._house_id = house_id
+
+    @staticmethod
+    def verify_schema(data: DwellingData):
+        for row in data:
+            if 'EVAL_ID' not in row.keys():
+                raise InvalidInputDataException()
+
+    @classmethod
+    def from_data(cls, data: DwellingData) -> 'Dwelling':
+        data = list(data)
+        if data:
+            cls.verify_schema(data)
+            house_id = data[0]['EVAL_ID']
+            return Dwelling(house_id=house_id)
+        else:
+            raise NoInputDataException()
+
+    @property
+    def house_id(self) -> int:
+        return self._house_id

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -1,0 +1,31 @@
+import typing
+import pytest
+from energuide import dwelling
+
+
+@pytest.fixture
+def sample() -> dwelling.DwellingData:
+    return [
+        {
+            'EVAL_ID': 123,
+        }, {
+            'EVAL_ID': 123,
+        }
+    ]
+
+
+def test_house_id(sample: dwelling.DwellingData) -> None:
+    output = dwelling.Dwelling.from_data(sample)
+    assert output.house_id == 123
+
+
+def test_no_data() -> None:
+    data: typing.List[typing.Any] = []
+    with pytest.raises(dwelling.NoInputDataException):
+        dwelling.Dwelling.from_data(data)
+
+
+def test_bad_data() -> None:
+    data = [{'foo': 123}]
+    with pytest.raises(dwelling.InvalidInputDataException):
+        dwelling.Dwelling.from_data(data)


### PR DESCRIPTION
Adds a new `Dwelling` class to be used by the transform logic. Right now it only extracts a single field, but we will add on to this class as we go. Also, this will serve as a great logical interface point for loading an iterable of `Dwelling`s to MongoDB.
