### PR TITLE
adding regional information and year_built fields

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -31,12 +31,57 @@ class EvaluationType(enum.Enum):
             raise InvalidInputDataException()
 
 
+@enum.unique
+class Region(enum.Enum):
+    BRITISH_COLUMBIA = 'BC'
+    ALBERTA = 'AB'
+    SASKATCHEWAN = 'SK'
+    MANITOBA = 'MB'
+    ONTARIO = 'ON'
+    QUEBEC = 'QC'
+    NEW_BRUNSWICK = 'NB'
+    PRINCE_EDWARD_ISLAND = 'PE'
+    NOVA_SCOTIA = 'NS'
+    NEWFOUNDLAND_AND_LABRADOR = 'NL'
+    YUKON = 'YT'
+    NORTHWEST_TERRITORIES = 'NT'
+    NUNAVUT = 'NU'
+    UNKNOWN = '??'
+
+    @classmethod
+    def _from_name(cls, name: str) -> typing.Optional['Region']:
+        snake_name = name.upper().replace(' ', '_')
+        if snake_name in Region.__members__:
+            return Region[snake_name]
+
+    @classmethod
+    def _from_code(cls, code: str) -> typing.Optional['Region']:
+        code = code.upper()
+        for region in Region:
+            if code == region.value:
+                return region
+
+    @classmethod
+    def from_data(cls, data: str) -> 'Region':
+        output = cls._from_name(data)
+        if not output:
+            output = cls._from_code(data)
+        if not output:
+            output = Region.UNKNOWN
+        return output
+
+
 class _ParsedDwellingDataRow(typing.NamedTuple):
     eval_id: int
     eval_type: EvaluationType
     entry_date: datetime.date
     creation_date: datetime.datetime
     modification_date: datetime.datetime
+    year_built: int
+    city: str
+    region: Region
+    postal_code: str
+    forward_sortation_area: str
 
 
 class ParsedDwellingDataRow(_ParsedDwellingDataRow):
@@ -47,13 +92,18 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'ENTRYDATE': {'type': 'string', 'required': True},
         'CREATIONDATE': {'type': 'string', 'required': True},
         'MODIFICATIONDATE': {'type': 'string', 'required': True},
+        'YEARBUILT': {'type': 'integer', 'required': True},
+        'CLIENTCITY': {'type': 'string', 'required': True},
+        'CLIENTPCODE': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z] [0-9][A-Z][0-9]'},
+        'HOUSEREGION': {'type': 'string', 'required': True},
     }
 
     @classmethod
     def from_row(cls, row: EvaluationData) -> 'ParsedDwellingDataRow':
         validator = cerberus.Validator(cls._SCHEMA, allow_unknown=True)
         if not validator.validate(row):
-            raise InvalidInputDataException()
+            error_keys = ', '.join(validator.errors.keys())
+            raise InvalidInputDataException(f'Validator failed on keys: {error_keys}')
 
         return ParsedDwellingDataRow(
             eval_id=row['EVAL_ID'],
@@ -61,6 +111,11 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             entry_date=parser.parse(row['ENTRYDATE']).date(),
             creation_date=parser.parse(row['CREATIONDATE']),
             modification_date=parser.parse(row['MODIFICATIONDATE']),
+            year_built=row['YEARBUILT'],
+            city=row['CLIENTCITY'],
+            region=Region.from_data(row['HOUSEREGION']),
+            postal_code=row['CLIENTPCODE'],
+            forward_sortation_area=row['CLIENTPCODE'][0:3]
         )
 
 

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -51,8 +51,7 @@ class Region(enum.Enum):
     @classmethod
     def _from_name(cls, name: str) -> typing.Optional['Region']:
         snake_name = name.upper().replace(' ', '_')
-        if snake_name in Region.__members__:
-            return Region[snake_name]
+        return Region[snake_name] if snake_name in Region.__members__ else None
 
     @classmethod
     def _from_code(cls, code: str) -> typing.Optional['Region']:
@@ -60,6 +59,7 @@ class Region(enum.Enum):
         for region in Region:
             if code == region.value:
                 return region
+        return None
 
     @classmethod
     def from_data(cls, data: str) -> 'Region':

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -162,8 +162,18 @@ class Dwelling:
 
     def __init__(self, *,
                  house_id: int,
+                 year_built: int,
+                 city: str,
+                 region: Region,
+                 postal_code: str,
+                 forward_sortation_area: str,
                  evaluations: typing.List[Evaluation]) -> None:
         self._house_id = house_id
+        self._year_built = year_built
+        self._city = city
+        self._region = region
+        self._postal_code = postal_code
+        self._forward_sortation_area = forward_sortation_area
         self._evaluations = evaluations
 
     @classmethod
@@ -172,6 +182,11 @@ class Dwelling:
             evaluations = [Evaluation.from_data(row) for row in data]
             return Dwelling(
                 house_id=data[0].eval_id,
+                year_built=data[0].year_built,
+                city=data[0].city,
+                region=data[0].region,
+                postal_code=data[0].postal_code,
+                forward_sortation_area=data[0].forward_sortation_area,
                 evaluations=evaluations,
             )
         else:
@@ -180,6 +195,26 @@ class Dwelling:
     @property
     def house_id(self) -> int:
         return self._house_id
+
+    @property
+    def year_built(self) -> int:
+        return self._year_built
+
+    @property
+    def city(self) -> str:
+        return self._city
+
+    @property
+    def region(self) -> Region:
+        return self._region
+
+    @property
+    def postal_code(self) -> str:
+        return self._postal_code
+
+    @property
+    def forward_sortation_area(self) -> str:
+        return self._forward_sortation_area
 
     @property
     def evaluations(self) -> typing.List[Evaluation]:

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -14,6 +14,10 @@ def sample_eval_d() -> dwelling.EvaluationData:
         'ENTRYDATE': '2018-01-01',
         'CREATIONDATE': '2018-01-08 09:00:00',
         'MODIFICATIONDATE': '2018-06-01 09:00:00',
+        'CLIENTCITY': 'Ottawa',
+        'CLIENTPCODE': 'K1P 0A6',
+        'HOUSEREGION': 'Ontario',
+        'YEARBUILT': 2000,
     }
 
 
@@ -30,6 +34,10 @@ def sample_eval_e() -> dwelling.EvaluationData:
         'ENTRYDATE': '2018-02-01',
         'CREATIONDATE': '2018-02-08 09:00:00',
         'MODIFICATIONDATE': '2018-06-01 09:00:00',
+        'CLIENTCITY': 'Montreal',
+        'CLIENTPCODE': 'G1A 1A3',
+        'HOUSEREGION': 'Quebec',
+        'YEARBUILT': 2001,
     }
 
 
@@ -56,14 +64,26 @@ class TestParsedDwellingDataRow:
             entry_date=datetime.date(2018, 1, 1),
             creation_date=datetime.datetime(2018, 1, 8, 9),
             modification_date=datetime.datetime(2018, 6, 1, 9),
+            year_built=2000,
+            city='Ottawa',
+            region=dwelling.Region.ONTARIO,
+            postal_code='K1P 0A6',
+            forward_sortation_area='K1P',
         )
+
+    def test_bad_postal_code(self, sample_eval_d: dwelling.EvaluationData) -> None:
+        sample_eval_d['CLIENTPCODE'] = 'K1P 016'
+        with pytest.raises(dwelling.InvalidInputDataException):
+            dwelling.ParsedDwellingDataRow.from_row(sample_eval_d)
 
     def test_from_bad_row(self) -> None:
         input_data = {
-            'eval_id': 123
+            'EVAL_ID': 123
         }
-        with pytest.raises(dwelling.InvalidInputDataException):
+        with pytest.raises(dwelling.InvalidInputDataException) as ex:
             dwelling.ParsedDwellingDataRow.from_row(input_data)
+        assert 'EVAL_TYPE' in ex.exconly()
+        assert 'EVAL_ID' not in ex.exconly()
 
 
 class TestDwellingEvaluation:

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -154,6 +154,17 @@ class TestDwelling:
         output = dwelling.Dwelling.from_data(sample)
         assert output.house_id == 123
 
+    def test_year_built(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+        output = dwelling.Dwelling.from_data(sample)
+        assert output.year_built == 2000
+
+    def test_address_data(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+        output = dwelling.Dwelling.from_data(sample)
+        assert output.city == 'Ottawa'
+        assert output.region == dwelling.Region.ONTARIO
+        assert output.postal_code == 'K1P 0A6'
+        assert output.forward_sortation_area == 'K1P'
+
     def test_evaluations(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample)
         assert len(output.evaluations) == 2

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -54,6 +54,42 @@ class TestEvaluationType:
         assert output == dwelling.EvaluationType.PRE_RETROFIT
 
 
+class TestRegion:
+
+    def test_from_name(self):
+        data = [
+            'Ontario',
+            'british columbia',
+            'NOVA SCOTIA',
+        ]
+        output = [dwelling.Region.from_data(row) for row in data]
+
+        assert output == [
+            dwelling.Region.ONTARIO,
+            dwelling.Region.BRITISH_COLUMBIA,
+            dwelling.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_name(self):
+        assert dwelling.Region.from_data('foo') == dwelling.Region.UNKNOWN
+
+    def test_from_code(self):
+        data = [
+            'ON',
+            'bc',
+            'Ns',
+        ]
+        output = [dwelling.Region.from_data(row) for row in data]
+        assert output == [
+            dwelling.Region.ONTARIO,
+            dwelling.Region.BRITISH_COLUMBIA,
+            dwelling.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_code(self):
+        assert dwelling.Region.from_data('CA') == dwelling.Region.UNKNOWN
+
+
 class TestParsedDwellingDataRow:
 
     def test_from_row(self, sample_eval_d: dwelling.EvaluationData) -> None:


### PR DESCRIPTION
This PR brings us up to feature parity with the existing `transform` capability around data scrubbing. Adds city, province, postal code, and year the house was built to the main `Dwelling` class.