### PR TITLE
add to_dict, split up dwelling

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -157,6 +157,14 @@ class Evaluation:
     def modification_date(self) -> datetime.datetime:
         return self._modification_date
 
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'evaluationType': self.evaluation_type.name,
+            'entryDate': self.entry_date,
+            'creationDate': self.creation_date,
+            'modificationDate': self.modification_date,
+        }
+
 
 class Dwelling:
 
@@ -219,3 +227,13 @@ class Dwelling:
     @property
     def evaluations(self) -> typing.List[Evaluation]:
         return self._evaluations
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'houseId': self.house_id,
+            'yearBuilt': self.year_built,
+            'city': self.city,
+            'region': self.region,
+            'forwardSortationArea': self.forward_sortation_area,
+            'evaluations': [evaluation.to_dict() for evaluation in self.evaluations]
+        }

--- a/python/src/energuide/interpreter.py
+++ b/python/src/energuide/interpreter.py
@@ -1,0 +1,115 @@
+import datetime
+import enum
+import typing
+import cerberus
+from dateutil import parser
+
+
+class InvalidInputDataException(Exception):
+    pass
+
+
+InputData = typing.Dict[str, typing.Any]
+
+
+@enum.unique
+class EvaluationType(enum.Enum):
+    PRE_RETROFIT = 'D'
+    POST_RETROFIT = 'E'
+
+    @classmethod
+    def from_code(cls, code: str) -> 'EvaluationType':
+        if code == cls.PRE_RETROFIT.value:
+            return EvaluationType.PRE_RETROFIT
+        elif code == cls.POST_RETROFIT.value:
+            return EvaluationType.POST_RETROFIT
+        else:
+            raise InvalidInputDataException()
+
+
+@enum.unique
+class Region(enum.Enum):
+    BRITISH_COLUMBIA = 'BC'
+    ALBERTA = 'AB'
+    SASKATCHEWAN = 'SK'
+    MANITOBA = 'MB'
+    ONTARIO = 'ON'
+    QUEBEC = 'QC'
+    NEW_BRUNSWICK = 'NB'
+    PRINCE_EDWARD_ISLAND = 'PE'
+    NOVA_SCOTIA = 'NS'
+    NEWFOUNDLAND_AND_LABRADOR = 'NL'
+    YUKON = 'YT'
+    NORTHWEST_TERRITORIES = 'NT'
+    NUNAVUT = 'NU'
+    UNKNOWN = '??'
+
+    @classmethod
+    def _from_name(cls, name: str) -> typing.Optional['Region']:
+        snake_name = name.upper().replace(' ', '_')
+        return Region[snake_name] if snake_name in Region.__members__ else None
+
+    @classmethod
+    def _from_code(cls, code: str) -> typing.Optional['Region']:
+        code = code.upper()
+        for region in Region:
+            if code == region.value:
+                return region
+        return None
+
+    @classmethod
+    def from_data(cls, data: str) -> 'Region':
+        output = cls._from_name(data)
+        if not output:
+            output = cls._from_code(data)
+        if not output:
+            output = Region.UNKNOWN
+        return output
+
+
+class _ParsedDwellingDataRow(typing.NamedTuple):
+    eval_id: int
+    eval_type: EvaluationType
+    entry_date: datetime.date
+    creation_date: datetime.datetime
+    modification_date: datetime.datetime
+    year_built: int
+    city: str
+    region: Region
+    postal_code: str
+    forward_sortation_area: str
+
+
+class ParsedDwellingDataRow(_ParsedDwellingDataRow):
+
+    _SCHEMA = {
+        'EVAL_ID': {'type': 'integer', 'required': True},
+        'EVAL_TYPE': {'type': 'string', 'required': True, 'allowed': [eval_type.value for eval_type in EvaluationType]},
+        'ENTRYDATE': {'type': 'string', 'required': True},
+        'CREATIONDATE': {'type': 'string', 'required': True},
+        'MODIFICATIONDATE': {'type': 'string', 'required': True},
+        'YEARBUILT': {'type': 'integer', 'required': True},
+        'CLIENTCITY': {'type': 'string', 'required': True},
+        'CLIENTPCODE': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z] [0-9][A-Z][0-9]'},
+        'HOUSEREGION': {'type': 'string', 'required': True},
+    }
+
+    @classmethod
+    def from_row(cls, row: InputData) -> 'ParsedDwellingDataRow':
+        validator = cerberus.Validator(cls._SCHEMA, allow_unknown=True)
+        if not validator.validate(row):
+            error_keys = ', '.join(validator.errors.keys())
+            raise InvalidInputDataException(f'Validator failed on keys: {error_keys}')
+
+        return ParsedDwellingDataRow(
+            eval_id=row['EVAL_ID'],
+            eval_type=EvaluationType.from_code(row['EVAL_TYPE']),
+            entry_date=parser.parse(row['ENTRYDATE']).date(),
+            creation_date=parser.parse(row['CREATIONDATE']),
+            modification_date=parser.parse(row['MODIFICATIONDATE']),
+            year_built=row['YEARBUILT'],
+            city=row['CLIENTCITY'],
+            region=Region.from_data(row['HOUSEREGION']),
+            postal_code=row['CLIENTPCODE'],
+            forward_sortation_area=row['CLIENTPCODE'][0:3]
+        )

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -1,175 +1,91 @@
 import datetime
 import typing
 import pytest
-from energuide import dwelling
+from energuide import dwelling, interpreter
 
 # pylint: disable=no-self-use
 
 
 @pytest.fixture
-def sample_eval_d() -> dwelling.EvaluationData:
-    return {
-        'EVAL_ID': 123,
-        'EVAL_TYPE': 'D',
-        'ENTRYDATE': '2018-01-01',
-        'CREATIONDATE': '2018-01-08 09:00:00',
-        'MODIFICATIONDATE': '2018-06-01 09:00:00',
-        'CLIENTCITY': 'Ottawa',
-        'CLIENTPCODE': 'K1P 0A6',
-        'HOUSEREGION': 'Ontario',
-        'YEARBUILT': 2000,
-    }
+def sample_parsed_d() -> interpreter.ParsedDwellingDataRow:
+    return interpreter.ParsedDwellingDataRow(
+        eval_id=123,
+        eval_type=interpreter.EvaluationType.PRE_RETROFIT,
+        entry_date=datetime.date(2018, 1, 1),
+        creation_date=datetime.datetime(2018, 1, 8, 9),
+        modification_date=datetime.datetime(2018, 6, 1, 9),
+        city='Ottawa',
+        region=interpreter.Region.ONTARIO,
+        postal_code='K1P 0A6',
+        forward_sortation_area='K1P',
+        year_built=2000
+    )
 
 
 @pytest.fixture
-def sample_parsed_d(sample_eval_d: dwelling.EvaluationData) -> dwelling.ParsedDwellingDataRow:
-    return dwelling.ParsedDwellingDataRow.from_row(sample_eval_d)  # pylint: disable=no-member
-
-
-@pytest.fixture
-def sample_eval_e() -> dwelling.EvaluationData:
-    return {
-        'EVAL_ID': 123,
-        'EVAL_TYPE': 'E',
-        'ENTRYDATE': '2018-02-01',
-        'CREATIONDATE': '2018-02-08 09:00:00',
-        'MODIFICATIONDATE': '2018-06-01 09:00:00',
-        'CLIENTCITY': 'Montreal',
-        'CLIENTPCODE': 'G1A 1A3',
-        'HOUSEREGION': 'Quebec',
-        'YEARBUILT': 2001,
-    }
-
-
-@pytest.fixture
-def sample_parsed_e(sample_eval_e: dwelling.EvaluationData) -> dwelling.ParsedDwellingDataRow:
-    return dwelling.ParsedDwellingDataRow.from_row(sample_eval_e)
-
-
-class TestEvaluationType:
-
-    def test_from_code(self):
-        code = dwelling.EvaluationType.PRE_RETROFIT.value
-        output = dwelling.EvaluationType.from_code(code)
-        assert output == dwelling.EvaluationType.PRE_RETROFIT
-
-
-class TestRegion:
-
-    def test_from_name(self):
-        data = [
-            'Ontario',
-            'british columbia',
-            'NOVA SCOTIA',
-        ]
-        output = [dwelling.Region.from_data(row) for row in data]
-
-        assert output == [
-            dwelling.Region.ONTARIO,
-            dwelling.Region.BRITISH_COLUMBIA,
-            dwelling.Region.NOVA_SCOTIA,
-        ]
-
-    def test_from_unknown_name(self):
-        assert dwelling.Region.from_data('foo') == dwelling.Region.UNKNOWN
-
-    def test_from_code(self):
-        data = [
-            'ON',
-            'bc',
-            'Ns',
-        ]
-        output = [dwelling.Region.from_data(row) for row in data]
-        assert output == [
-            dwelling.Region.ONTARIO,
-            dwelling.Region.BRITISH_COLUMBIA,
-            dwelling.Region.NOVA_SCOTIA,
-        ]
-
-    def test_from_unknown_code(self):
-        assert dwelling.Region.from_data('CA') == dwelling.Region.UNKNOWN
-
-
-class TestParsedDwellingDataRow:
-
-    def test_from_row(self, sample_eval_d: dwelling.EvaluationData) -> None:
-        output = dwelling.ParsedDwellingDataRow.from_row(sample_eval_d)
-        assert output == dwelling.ParsedDwellingDataRow(
-            eval_id=123,
-            eval_type=dwelling.EvaluationType.PRE_RETROFIT,
-            entry_date=datetime.date(2018, 1, 1),
-            creation_date=datetime.datetime(2018, 1, 8, 9),
-            modification_date=datetime.datetime(2018, 6, 1, 9),
-            year_built=2000,
-            city='Ottawa',
-            region=dwelling.Region.ONTARIO,
-            postal_code='K1P 0A6',
-            forward_sortation_area='K1P',
-        )
-
-    def test_bad_postal_code(self, sample_eval_d: dwelling.EvaluationData) -> None:
-        sample_eval_d['CLIENTPCODE'] = 'K1P 016'
-        with pytest.raises(dwelling.InvalidInputDataException):
-            dwelling.ParsedDwellingDataRow.from_row(sample_eval_d)
-
-    def test_from_bad_row(self) -> None:
-        input_data = {
-            'EVAL_ID': 123
-        }
-        with pytest.raises(dwelling.InvalidInputDataException) as ex:
-            dwelling.ParsedDwellingDataRow.from_row(input_data)
-        assert 'EVAL_TYPE' in ex.exconly()
-        assert 'EVAL_ID' not in ex.exconly()
+def sample_parsed_e() -> interpreter.ParsedDwellingDataRow:
+    return interpreter.ParsedDwellingDataRow(
+        eval_id=123,
+        eval_type=interpreter.EvaluationType.POST_RETROFIT,
+        entry_date=datetime.date(2018, 2, 1),
+        creation_date=datetime.datetime(2018, 2, 8, 9),
+        modification_date=datetime.datetime(2018, 6, 1, 9),
+        city='Montreal',
+        region=interpreter.Region.QUEBEC,
+        postal_code='G1A 1A3',
+        forward_sortation_area='G1A',
+        year_built=2001,
+    )
 
 
 class TestDwellingEvaluation:
 
-    def test_eval_type(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+    def test_eval_type(self, sample_parsed_d: interpreter.ParsedDwellingDataRow) -> None:
         output = dwelling.Evaluation.from_data(sample_parsed_d)
-        assert output.evaluation_type == dwelling.EvaluationType.PRE_RETROFIT
+        assert output.evaluation_type == interpreter.EvaluationType.PRE_RETROFIT
 
-    def test_entry_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+    def test_entry_date(self, sample_parsed_d: interpreter.ParsedDwellingDataRow) -> None:
         output = dwelling.Evaluation.from_data(sample_parsed_d)
         assert output.entry_date == datetime.date(2018, 1, 1)
 
-    def test_creation_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+    def test_creation_date(self, sample_parsed_d: interpreter.ParsedDwellingDataRow) -> None:
         output = dwelling.Evaluation.from_data(sample_parsed_d)
         assert output.creation_date == datetime.datetime(2018, 1, 8, 9)
 
-    def test_modification_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+    def test_modification_date(self, sample_parsed_d: interpreter.ParsedDwellingDataRow) -> None:
         output = dwelling.Evaluation.from_data(sample_parsed_d)
         assert output.modification_date == datetime.datetime(2018, 6, 1, 9)
 
-    def test_to_dict(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+    def test_to_dict(self, sample_parsed_d: interpreter.ParsedDwellingDataRow) -> None:
         output = dwelling.Evaluation.from_data(sample_parsed_d).to_dict()
-        assert output['evaluationType'] == 'PRE_RETROFIT'
+        assert output['evaluationType'] == interpreter.EvaluationType.PRE_RETROFIT
 
 
 class TestDwelling:
 
     @pytest.fixture
     def sample(self,
-               sample_parsed_d: dwelling.ParsedDwellingDataRow,
-               sample_parsed_e: dwelling.ParsedDwellingDataRow,
-              ) -> typing.List[dwelling.ParsedDwellingDataRow]:
+               sample_parsed_d: interpreter.ParsedDwellingDataRow,
+               sample_parsed_e: interpreter.ParsedDwellingDataRow,
+              ) -> typing.List[interpreter.ParsedDwellingDataRow]:
         return [sample_parsed_d, sample_parsed_e]
 
-    def test_house_id(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+    def test_house_id(self, sample: typing.List[interpreter.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample)
         assert output.house_id == 123
 
-    def test_year_built(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+    def test_year_built(self, sample: typing.List[interpreter.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample)
         assert output.year_built == 2000
 
-    def test_address_data(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+    def test_address_data(self, sample: typing.List[interpreter.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample)
         assert output.city == 'Ottawa'
-        assert output.region == dwelling.Region.ONTARIO
+        assert output.region == interpreter.Region.ONTARIO
         assert output.postal_code == 'K1P 0A6'
         assert output.forward_sortation_area == 'K1P'
 
-    def test_evaluations(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+    def test_evaluations(self, sample: typing.List[interpreter.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample)
         assert len(output.evaluations) == 2
 
@@ -178,7 +94,7 @@ class TestDwelling:
         with pytest.raises(dwelling.NoInputDataException):
             dwelling.Dwelling.from_data(data)
 
-    def test_to_dict(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+    def test_to_dict(self, sample: typing.List[interpreter.ParsedDwellingDataRow]) -> None:
         output = dwelling.Dwelling.from_data(sample).to_dict()
         assert output['houseId'] == 123
         assert len(output['evaluations']) == 2

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -140,6 +140,10 @@ class TestDwellingEvaluation:
         output = dwelling.Evaluation.from_data(sample_parsed_d)
         assert output.modification_date == datetime.datetime(2018, 6, 1, 9)
 
+    def test_to_dict(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d).to_dict()
+        assert output['evaluationType'] == 'PRE_RETROFIT'
+
 
 class TestDwelling:
 
@@ -173,3 +177,9 @@ class TestDwelling:
         data: typing.List[typing.Any] = []
         with pytest.raises(dwelling.NoInputDataException):
             dwelling.Dwelling.from_data(data)
+
+    def test_to_dict(self, sample: typing.List[dwelling.ParsedDwellingDataRow]) -> None:
+        output = dwelling.Dwelling.from_data(sample).to_dict()
+        assert output['houseId'] == 123
+        assert len(output['evaluations']) == 2
+        assert 'postalCode' not in output

--- a/python/tests/test_interpreter.py
+++ b/python/tests/test_interpreter.py
@@ -1,0 +1,121 @@
+import datetime
+import pytest
+from energuide import interpreter
+
+# pylint: disable=no-self-use
+
+
+@pytest.fixture
+def sample_eval_d() -> interpreter.InputData:
+    return {
+        'EVAL_ID': 123,
+        'EVAL_TYPE': 'D',
+        'ENTRYDATE': '2018-01-01',
+        'CREATIONDATE': '2018-01-08 09:00:00',
+        'MODIFICATIONDATE': '2018-06-01 09:00:00',
+        'CLIENTCITY': 'Ottawa',
+        'CLIENTPCODE': 'K1P 0A6',
+        'HOUSEREGION': 'Ontario',
+        'YEARBUILT': 2000,
+    }
+
+
+@pytest.fixture
+def sample_parsed_d(sample_eval_d: interpreter.InputData) -> interpreter.ParsedDwellingDataRow:
+    return interpreter.ParsedDwellingDataRow.from_row(sample_eval_d)  # pylint: disable=no-member
+
+
+@pytest.fixture
+def sample_eval_e() -> interpreter.InputData:
+    return {
+        'EVAL_ID': 123,
+        'EVAL_TYPE': 'E',
+        'ENTRYDATE': '2018-02-01',
+        'CREATIONDATE': '2018-02-08 09:00:00',
+        'MODIFICATIONDATE': '2018-06-01 09:00:00',
+        'CLIENTCITY': 'Montreal',
+        'CLIENTPCODE': 'G1A 1A3',
+        'HOUSEREGION': 'Quebec',
+        'YEARBUILT': 2001,
+    }
+
+
+@pytest.fixture
+def sample_parsed_e(sample_eval_e: interpreter.InputData) -> interpreter.ParsedDwellingDataRow:
+    return interpreter.ParsedDwellingDataRow.from_row(sample_eval_e)
+
+
+class TestEvaluationType:
+
+    def test_from_code(self):
+        code = interpreter.EvaluationType.PRE_RETROFIT.value
+        output = interpreter.EvaluationType.from_code(code)
+        assert output == interpreter.EvaluationType.PRE_RETROFIT
+
+
+class TestRegion:
+
+    def test_from_name(self):
+        data = [
+            'Ontario',
+            'british columbia',
+            'NOVA SCOTIA',
+        ]
+        output = [interpreter.Region.from_data(row) for row in data]
+
+        assert output == [
+            interpreter.Region.ONTARIO,
+            interpreter.Region.BRITISH_COLUMBIA,
+            interpreter.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_name(self):
+        assert interpreter.Region.from_data('foo') == interpreter.Region.UNKNOWN
+
+    def test_from_code(self):
+        data = [
+            'ON',
+            'bc',
+            'Ns',
+        ]
+        output = [interpreter.Region.from_data(row) for row in data]
+        assert output == [
+            interpreter.Region.ONTARIO,
+            interpreter.Region.BRITISH_COLUMBIA,
+            interpreter.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_code(self):
+        assert interpreter.Region.from_data('CA') == interpreter.Region.UNKNOWN
+
+
+class TestParsedDwellingDataRow:
+
+    def test_from_row(self, sample_eval_d: interpreter.InputData) -> None:
+        output = interpreter.ParsedDwellingDataRow.from_row(sample_eval_d)
+        assert output == interpreter.ParsedDwellingDataRow(
+            eval_id=123,
+            eval_type=interpreter.EvaluationType.PRE_RETROFIT,
+            entry_date=datetime.date(2018, 1, 1),
+            creation_date=datetime.datetime(2018, 1, 8, 9),
+            modification_date=datetime.datetime(2018, 6, 1, 9),
+            year_built=2000,
+            city='Ottawa',
+            region=interpreter.Region.ONTARIO,
+            postal_code='K1P 0A6',
+            forward_sortation_area='K1P',
+        )
+
+    def test_bad_postal_code(self, sample_eval_d: interpreter.InputData) -> None:
+        sample_eval_d['CLIENTPCODE'] = 'K1P 016'
+        with pytest.raises(interpreter.InvalidInputDataException):
+            interpreter.ParsedDwellingDataRow.from_row(sample_eval_d)
+
+    def test_from_bad_row(self) -> None:
+        input_data = {
+            'EVAL_ID': 123
+        }
+        with pytest.raises(interpreter.InvalidInputDataException) as ex:
+            interpreter.ParsedDwellingDataRow.from_row(input_data)
+        assert 'EVAL_TYPE' in ex.exconly()
+        assert 'EVAL_ID' not in ex.exconly()


### PR DESCRIPTION
With the exception of adding `to_dict` methods to `Evaluation` and `Dwelling`, this PR just moves functionality out of the `dwelling` module to the new `interpreter` module.

The logic here is that there is a first step for validating and parsing the raw data (including converting raw strings to datetimes, custom enums, etc). This is now handled in the `interpreter` module. This is distinct from the `dwelling` module that handles the hierarchical nature of the data structures.

Still not completely satisfied with the way it's laid out (custom types mixed in with datetimes, etc), but it's a step in the right direction. The PR is a bit bigger than I usually like, but most of it is cut/paste from one module to another.