### PR TITLE
Add debug script: yarn run dbg

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node dist/index.js",
     "build": "babel src --copy-files --out-dir dist",
     "dockerize": "yarn build && docker build -t cdssnc/nrcan_api .",
+    "dbg": "node --inspect-brk node_modules/jest/bin/jest.js",
     "extract": "lingui extract",
     "compile": "lingui compile",
     "precommit": "lint-staged",


### PR DESCRIPTION
This script runs jest with nodes `--inspect-brk` flag set allows
debugging via the Chrome Devtools.