### PR TITLE
Add checks for multiple filters

### DIFF
--- a/src/schema/resolvers.js
+++ b/src/schema/resolvers.js
@@ -1,6 +1,8 @@
 import Longitude from './types/Longitude'
 import Latitude from './types/Latitude'
 import PostalCode from './types/PostalCode'
+import {GraphQLError} from 'graphql'
+import { comparators, hasMoreThanOneComparator } from '../utilities'
 
 const resolvers = {
   Longitude,
@@ -19,6 +21,12 @@ const resolvers = {
       return Object.assign({}, ...results)
     },
     evaluations: async (root, { filter, withinPolygon }, { client }) => {
+
+      if (hasMoreThanOneComparator(filter)) {
+        return new GraphQLError(
+          `You can only use ${Object.keys(comparators)} one at a time`,
+        )
+      }
       let coordinates = withinPolygon.map(el => [el.lng, el.lat])
       let query = {
         $and: [
@@ -33,13 +41,6 @@ const resolvers = {
             },
           },
         ],
-      }
-
-      // Mongodb filter map:
-      const comparators = {
-        gt: '$gt',
-        lt: '$lt',
-        eq: '$eq',
       }
 
       // { field: 'yearBuilt', gt: '1990' }

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,0 +1,18 @@
+// Mongodb filter map:
+export const comparators = {
+  gt: '$gt',
+  lt: '$lt',
+  eq: '$eq',
+}
+
+export function hasMoreThanOneComparator(filter) {
+  if (filter) {
+    return (
+      Object.keys(filter)
+        .filter(x => x !== 'field') // Remove field. It's supposed to be there.
+        .filter(x => Object.keys(comparators).includes(x)).length > 1
+    ) // more than one left?
+  } else {
+    return false
+  }
+}

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -153,4 +153,36 @@ describe('queries', () => {
     let { evaluations: [first] } = response.body.data
     expect(first.yearBuilt).toEqual('1980')
   })
+
+  it('complains about multiple comparators', async () => {
+    let geocoded = testData.slice()
+    geocoded[0].location = {
+      type: 'Point',
+      coordinates: [-79.348650200148, 43.8036022863624],
+    }
+
+    await collection.insertMany(geocoded)
+
+    let server = new Server({
+      client: collection,
+    })
+
+    let response = await request(server)
+      .post('/graphql')
+      .set('Content-Type', 'application/json; charset=utf-8')
+      .send({
+        query: `{
+           evaluations(filter: {field: yearBuilt gt: "1979", eq: "1979"} withinPolygon: [
+            {lng: -150.82031249999997, lat: -0.3515602939922709}
+            {lng: -41.8359375, lat: -0.3515602939922709},
+            {lng: -41.8359375, lat: 73.62778879339942},
+            {lng: -150.82031249999997, lat: 73.62778879339942},
+            {lng: -150.82031249999997, lat: -0.3515602939922709},
+          ]) {
+          yearBuilt
+        }
+      }`,
+      })
+    expect(response.body).toHaveProperty('errors')
+  })
 })

--- a/test/utilities.test.js
+++ b/test/utilities.test.js
@@ -1,0 +1,36 @@
+import { comparators, hasMoreThanOneComparator } from '../src/utilities'
+
+describe('Utilities', () => {
+  describe('comparators', () => {
+    it('exports a comparators object', () => {
+      let keys = Object.keys(comparators)
+      expect(keys).toContain('gt', 'lt', 'eq')
+    })
+    it('maps generic comparators to Mongo specific ones', () => {
+      expect(comparators.gt).toEqual('$gt')
+      expect(comparators.lt).toEqual('$lt')
+      expect(comparators.eq).toEqual('$eq')
+    })
+  })
+
+  describe('hasMoreThanOneComparator()', () => {
+    it('returns true if more than one comparator appears in a filter object', () => {
+      let filter = { field: 'yearBuilt', gt: '1990', lt: '1990' }
+      expect(hasMoreThanOneComparator(filter)).toEqual(true)
+    })
+
+    it('returns false if there is only one comparator', () => {
+      let filter = { field: 'yearBuilt', gt: '1990' }
+      expect(hasMoreThanOneComparator(filter)).toEqual(false)
+    })
+
+    it('returns false if fed a falsy value', () => {
+      expect(hasMoreThanOneComparator(false)).toEqual(false)
+    })
+
+    it('returns false if fed a undefined', () => {
+      // for some reason this breaks the world in a way that falsy values don't
+      expect(hasMoreThanOneComparator(undefined)).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
This commit ensures that filters that include multiple (likely
contadictory) comparison operators are rejected:

{field: yearBuilt gt: "1979", eq: "1979"}

In this situation the correct thing would be to return an error, which
is now what happens.