### PR TITLE
Retrieve data using first 3 postal code characters

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -6,6 +6,7 @@ const Schema = i18n => {
     scalar Longitude
     scalar Latitude
     scalar PostalCode
+    scalar ForwardSortationArea
 
     input GeoPoint {
       lat: Latitude!
@@ -22,8 +23,9 @@ const Schema = i18n => {
     type Query {
       evaluationsFor(account: Int! postalCode: PostalCode!): Evaluation
       evaluations(filter: Filter withinPolygon: [GeoPoint]!): [Evaluation]
+      evaluationsInFSA(filter: Filter forwardSortationArea: ForwardSortationArea!): [Evaluation]
     }
-    
+
     # ${i18n.t`This is a description of evaluations`}
     type Evaluation {
       # ${i18n.t`Year of construction`}

--- a/src/schema/types/ForwardSortationArea.js
+++ b/src/schema/types/ForwardSortationArea.js
@@ -1,0 +1,27 @@
+import { GraphQLScalarType, GraphQLError } from 'graphql'
+import { Kind } from 'graphql/language'
+
+function isFSA({ kind, value }) {
+  // Is it a string?
+  if (kind !== Kind.STRING) {
+    return null
+  }
+  // Regex taken from The Regular Expressions Cookbook:
+  // https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s15.html
+  if (value.match(/^(?!.*[DFIOQU])[A-VXY][0-9][A-Z]$/)) {
+    return value
+  } else {
+    throw new GraphQLError('Not a valid Forward Sortation Area')
+  }
+}
+
+const ForwardSortationArea = new GraphQLScalarType({
+  name: 'ForwardSortationArea',
+  description:
+    'A Forward Sortation Area as defined by Canada Post. Basically the first 3 digits of a postal code.',
+  serialize: String,
+  parseValue: isFSA, // TODO: is this truely needed?
+  parseLiteral: isFSA,
+})
+
+export default ForwardSortationArea

--- a/test/ForwardSortationArea.test.js
+++ b/test/ForwardSortationArea.test.js
@@ -1,0 +1,115 @@
+import ForwardSortationArea from '../src/schema/types/ForwardSortationArea'
+import {
+  graphql,
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLString,
+} from 'graphql'
+
+var testSchema = new GraphQLSchema({
+  query: new GraphQLObjectType({
+    name: 'Root',
+    fields: {
+      test: {
+        type: GraphQLString,
+        args: {
+          forwardSortationArea: {
+            type: ForwardSortationArea,
+          },
+        },
+        resolve: (source, { forwardSortationArea }, root, ast) => {
+          return forwardSortationArea
+        },
+      },
+    },
+  }),
+})
+
+describe('ForwardSortationArea Type', () => {
+  it('cheerfully accepts a proper FSA', async () => {
+    let query = `{
+         test(forwardSortationArea: "M8H")
+        }`
+
+    let { data: { test } } = await graphql(testSchema, query)
+
+    expect(test).toEqual('M8H')
+  })
+
+  it('does not accept a full postal code', async () => {
+    let query = `{
+         test(forwardSortationArea: "K1C 2J5")
+        }`
+
+    let response = await graphql(testSchema, query)
+
+    expect(response).toHaveProperty('errors')
+  })
+
+  describe('rejects literals with invalid characters', () => {
+    const forbiddenLetters = [...'DFIOQU']
+    forbiddenLetters.forEach(forbiddenLetter => {
+      it(`rejects an FSA that includes the letter ${forbiddenLetter}`, async () => {
+        let query = `{
+         test(forwardSortationArea: "M8${forbiddenLetter}")
+      }`
+
+        let result = await graphql(testSchema, query)
+
+        expect(result).toHaveProperty('errors')
+      })
+    })
+
+    const cannotStart = [...'WZ']
+    cannotStart.forEach(forbiddenLetter => {
+      it(`rejects an FSA that starts with the letter ${forbiddenLetter}`, async () => {
+        let query = `{
+         test(forwardSortationArea: "${forbiddenLetter}8H")
+      }`
+
+        let result = await graphql(testSchema, query)
+
+        expect(result).toHaveProperty('errors')
+      })
+    })
+  })
+
+  describe('rejects values with invalid characters', () => {
+    const forbiddenLetters = [...'DFIOQU']
+    forbiddenLetters.forEach(forbiddenLetter => {
+      it(`rejects an FSA that includes the letter ${forbiddenLetter}`, async () => {
+        let query = `query($fsa: ForwardSortationArea!) {
+         test(forwardSortationArea: $fsa)
+      }`
+
+        let result = await graphql(
+          testSchema,
+          query,
+          {},
+          { pc: `M8${forbiddenLetter} 1N1` },
+        )
+
+        expect(result).toHaveProperty('errors')
+      })
+    })
+
+    const cannotStart = [...'WZ']
+    cannotStart.forEach(forbiddenLetter => {
+      it(`rejects an FSA that starts with the letter ${forbiddenLetter}`, async () => {
+        let query = `query($fsa: ForwardSortationArea!) {
+         test(forwardSortationArea: $fsa)
+      }`
+
+        let result = await graphql(
+          testSchema,
+          query,
+          {},
+          { pc: `${forbiddenLetter}8H` },
+        )
+
+        expect(result).toHaveProperty('errors')
+      })
+    })
+  })
+})
+

--- a/test/queries.test.js
+++ b/test/queries.test.js
@@ -42,7 +42,7 @@ describe('queries', () => {
       .post('/graphql')
       .set('Content-Type', 'application/json; charset=utf-8')
       .send({
-        query: `{ 
+        query: `{
            evaluations(withinPolygon: [
             {lng: -150.82031249999997, lat: -0.3515602939922709}
             {lng: -41.8359375, lat: -0.3515602939922709},
@@ -184,5 +184,35 @@ describe('queries', () => {
       }`,
       })
     expect(response.body).toHaveProperty('errors')
+  })
+
+  it('gets evalutations within a Forward Sortation Area', async () => {
+    let geocoded = testData.slice()
+    geocoded[0].location = {
+      type: 'Point',
+      coordinates: [-79.348650200148, 43.8036022863624],
+    }
+
+    await collection.insertMany(geocoded)
+
+    let server = new Server({
+      client: collection,
+    })
+
+    let response = await request(server)
+      .post('/graphql')
+      .set('Content-Type', 'application/json; charset=utf-8')
+      .send({
+        query: `{
+           evaluations:evaluationsInFSA(
+             forwardSortationArea: "M8H"
+           ) {
+          yearBuilt
+        }
+      }`,
+      })
+
+    let { evaluations: [first] } = response.body.data
+    expect(first.yearBuilt).toEqual('1980')
   })
 })


### PR DESCRIPTION
The first three letters of a postal code are known as the Forward
Sortation Area. This commit adds a function to retrieve data using the
FSA and a custom type so we can accept that safely.