### PR TITLE
CI API integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
 
       - run: mkdir -p workspace
       - run: 
-          name: export database
+          name: Exporting database
           command: |
             mongoexport --db energuide --collection dwellings --out workspace/mongo_dump
 
@@ -170,7 +170,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       - run:
-          name: import database
+          name: Importing database
           command: |
             mongoimport --db energuide --collection dwellings --file /tmp/workspace/mongo_dump
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,11 @@ jobs:
       - run:
           name: Installing packages
           command: |
-            sudo apt-get install apt-transport-https
+            sudo apt-get install apt-transport-http
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
             echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
+            sudo apt-get install libssl1.0.0
             sudo apt-get install -y mongodb-org-tools=3.6.2
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ jobs:
       - run:
           name: Installing packages
           command: |
+            sudo apt-get install apt-transport-https
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
             echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,8 @@ jobs:
           command: |
             sudo apt-get install apt-transport-https
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update
-            sudo apt-get install libssl1.0.0
             sudo apt-get install -y mongodb-org-tools=3.6.2
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,6 @@ workflows:
       - node
       - python
       - python_integration
-      - node_integration
+      - node_integration:
           requires:
             - python_integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,14 +114,19 @@ jobs:
           name: Loading data
           command: |
             . ~/.venv/bin/activate
-            energuide --load tests/randomized_energuide_data.csv
+            energuide load --filename tests/randomized_energuide_data.csv
 
       - run: mkdir -p workspace
+      - run: 
+          name: export database
+          command: |
+            mongoexport --out workspace/mongo_dump
+
 
       - persist_to_workspace:
           root: workspace
           paths:
-            - mongo-dump
+            - mongo_dump
   node_integration:
     docker:
       # specify the version you desire here
@@ -137,6 +142,9 @@ jobs:
 
     steps:
       - checkout
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: /tmp/workspace
 
       # Download and cache dependencies
       - restore_cache:
@@ -145,12 +153,26 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
+      - run:
+          name: Installing packages
+          command: |
+            sudo apt-get install apt-transport-https
+            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+            echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.6 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            sudo apt-get update
+            sudo apt-get install -y mongodb-org-tools=3.6.2
+
       - run: yarn install
 
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run:
+          name: import database
+          command: |
+            mongoimport --file /tmp/workspace/mongo_dump
 
       - run:
           name: Running tests & linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
       - run:
           name: Installing packages
           command: |
-            sudo apt-get install apt-transport-http
+            sudo apt-get install apt-transport-https
             sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
             echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
             sudo apt-get update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,13 +114,13 @@ jobs:
           name: Loading data
           command: |
             . ~/.venv/bin/activate
-            energuide load --filename tests/randomized_energuide_data.csv
+            energuide load  --db_name energuide --collection dwellings --filename tests/randomized_energuide_data.csv
 
       - run: mkdir -p workspace
       - run: 
           name: export database
           command: |
-            mongoexport --out workspace/mongo_dump
+            mongoexport --db energuide --collection dwellings --out workspace/mongo_dump
 
 
       - persist_to_workspace:
@@ -172,7 +172,7 @@ jobs:
       - run:
           name: import database
           command: |
-            mongoimport --file /tmp/workspace/mongo_dump
+            mongoimport --db energuide --collection dwellings --file /tmp/workspace/mongo_dump
 
       - run:
           name: Running tests & linter

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,10 +175,9 @@ jobs:
             mongoimport --db energuide --collection dwellings --file /tmp/workspace/mongo_dump
 
       - run:
-          name: Running tests & linter
+          name: Running integration tests
           command: |
-            yarn test
-            yarn lint
+            echo Hello World!
 workflows:
   version: 2
   node_and_python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
           command: |
             yarn test
             yarn lint
-
   python:
     docker:
       - image: circleci/python:3.6.1
@@ -74,7 +73,6 @@ jobs:
             pylint src tests
             mypy --ignore-missing-imports src tests
             pytest tests
-
   python_integration:
     docker:
       - image: circleci/python:3.6.1
@@ -117,13 +115,12 @@ jobs:
             . ~/.venv/bin/activate
             energuide --load tests/randomized_energuide_data.csv
 
-
       - run: mkdir -p workspace
+
       - persist_to_workspace:
           root: workspace
           paths:
             - mongo-dump
-
   node_integration:
     docker:
       # specify the version you desire here
@@ -159,7 +156,6 @@ jobs:
           command: |
             yarn test
             yarn lint
-
 workflows:
   version: 2
   node_and_python:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,7 @@ jobs:
           command: |
             yarn test
             yarn lint
+
   python:
     docker:
       - image: circleci/python:3.6.1
@@ -73,9 +74,99 @@ jobs:
             pylint src tests
             mypy --ignore-missing-imports src tests
             pytest tests
+
+  python_integration:
+    docker:
+      - image: circleci/python:3.6.1
+      - image: mongo:3.6.2
+
+    working_directory: ~/repo/python
+
+    steps:
+      - checkout:
+          path: ~/repo
+
+      # Download and cache dependencies
+      - restore_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+
+      - run:
+        name: Installing packages
+        command: |
+          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-org-tools=3.6.2
+
+      - run:
+          name: Installing dependencies
+          command: |
+            python3 -m venv ~/.venv
+            . ~/.venv/bin/activate
+            pip install -r requirements.txt
+            pip install -e .
+
+      - save_cache:
+          key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+          paths:
+            - "~/.venv"
+
+      - run:
+          name: Loading data
+          command: |
+            . ~/.venv/bin/activate
+            energuide --load tests/randomized_energuide_data.csv
+
+
+      - run: mkdir -p workspace
+      - persist_to_workspace:
+          root: workspace
+          paths:
+            - mongo-dump
+
+  node_integration:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+      - image: mongo:3.6.2
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run:
+          name: Running tests & linter
+          command: |
+            yarn test
+            yarn lint
+
 workflows:
   version: 2
   node_and_python:
     jobs:
       - node
       - python
+      - python_integration
+      - node_integration
+          requires:
+            - python_integration

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,12 @@ jobs:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
 
       - run:
-        name: Installing packages
-        command: |
-          sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
-          echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
-          sudo apt-get update
-          sudo apt-get install -y mongodb-org-tools=3.6.2
+          name: Installing packages
+          command: |
+            sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+            echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+            sudo apt-get update
+            sudo apt-get install -y mongodb-org-tools=3.6.2
 
       - run:
           name: Installing dependencies


### PR DESCRIPTION
This pull request creates an additional 2 circleci jobs that are meant for integration testing of the ETL and API components.

`python_integration` job loads data from a CSV into a mongo database, then exports that database.
`node_integration` job then imports that data into the mongo database for that job. Currently it then just echo's "Hello World!", further work required from the API side in constructing tests to slot into this new job.