### PR TITLE
Fix parseValue function for PostalCode type

### DIFF
--- a/src/schema/types/PostalCode.js
+++ b/src/schema/types/PostalCode.js
@@ -1,11 +1,7 @@
 import { GraphQLScalarType, GraphQLError } from 'graphql'
 import { Kind } from 'graphql/language'
 
-function isPostalCode({ kind, value }) {
-  // Is it a string?
-  if (kind !== Kind.STRING) {
-    return null
-  }
+function isPostalCode(value) {
   // Regex taken from The Regular Expressions Cookbook:
   // https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s15.html
   if (value.match(/^(?!.*[DFIOQU])[A-VXY][0-9][A-Z] ?[0-9][A-Z][0-9]$/)) {
@@ -19,8 +15,21 @@ const PostalCode = new GraphQLScalarType({
   name: 'PostalCode',
   description: 'A Canadian Postal Code as defined by Canada Post.',
   serialize: String,
-  parseValue: isPostalCode, // TODO: is this truely needed?
-  parseLiteral: isPostalCode,
+  parseValue: value => {
+    if (isPostalCode(value)) {
+      return value
+    } else {
+      throw new GraphQLError('Not a valid Postal Code')
+    }
+  },
+  parseLiteral: ({ kind, value }) => {
+    // Is it a string?
+    if (kind === Kind.STRING && isPostalCode(value)) {
+      return value
+    } else {
+      throw new GraphQLError('Not a valid Postal Code')
+    }
+  },
 })
 
 export default PostalCode


### PR DESCRIPTION
parseValue is handed a single value while parseLiteral is passed a
chunk of the AST. Handling these properly now.