### PR TITLE
pull ceilings data out of raw_xml in extractor

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,3 +8,4 @@ dnspython==1.15.0
 pymongo==3.6.0
 cerberus==1.1
 python-dateutil==2.6.1
+lxml==4.1.1

--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -52,7 +52,7 @@ def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterato
         doc = ElementTree.fromstring(row['RAW_XML'])
         house = doc.find('House')
         if house:
-            extra_data = snippets.snip_house(house) if house else None
+            extra_data = snippets.snip_house(house)
 
             for key, value in extra_data.items():
                 assert key not in row

--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -2,10 +2,12 @@ import csv
 import itertools
 import json
 import typing
+from xml.etree import ElementTree
 import sys
 import zipfile
 import cerberus
 from energuide import reader
+from energuide import snippets
 
 
 DROP_FIELDS = ['ENTRYBY',
@@ -46,6 +48,16 @@ def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
 def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterator[reader.InputData]:
     for row in data:
         row['ForwardSortationArea'] = row['CLIENTPCODE'][:3]
+
+        doc = ElementTree.fromstring(row['RAW_XML'])
+        house = doc.find('House')
+        if house:
+            extra_data = snippets.snip_house(house) if house else None
+
+            for key, value in extra_data.items():
+                assert key not in row
+                row[key] = value
+
         yield row
 
 

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -1,8 +1,8 @@
 import typing
-from xml.etree import ElementTree
+from lxml import etree
 
 
-def _ceiling_snippet(ceiling: ElementTree) -> typing.Dict[str, typing.Any]:
+def _ceiling_snippet(ceiling: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     label = ceiling.findtext('Label')
     type_english = ceiling.findtext('Construction/Type/English')
     type_french = ceiling.findtext('Construction/Type/French')
@@ -20,7 +20,7 @@ def _ceiling_snippet(ceiling: ElementTree) -> typing.Dict[str, typing.Any]:
     }
 
 
-def snip_house(house: ElementTree) -> typing.Dict[str, typing.Any]:
+def snip_house(house: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     ceilings = house.findall('Components/Ceiling')
     return {
         'ceilings': [_ceiling_snippet(node) for node in ceilings]

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -1,0 +1,27 @@
+import typing
+from xml.etree import ElementTree
+
+
+def _ceiling_snippet(ceiling: ElementTree) -> typing.Dict[str, typing.Any]:
+    label = ceiling.findtext('Label')
+    type_english = ceiling.findtext('Construction/Type/English')
+    type_french = ceiling.findtext('Construction/Type/French')
+
+    nominal_rsi_node = ceiling.find('Construction/CeilingType')
+    nominal_rsi = nominal_rsi_node.attrib['nominalInsulation'] if nominal_rsi_node is not None else None
+    effective_rsi_node = ceiling.find('Construction/CeilingType')
+    effective_rsi = effective_rsi_node.attrib['rValue'] if effective_rsi_node is not None else None
+    return {
+        'label': label,
+        'type_english': type_english,
+        'type_french': type_french,
+        'nominal_rsi': nominal_rsi,
+        'effective_rsi': effective_rsi,
+    }
+
+
+def snip_house(house: ElementTree) -> typing.Dict[str, typing.Any]:
+    ceilings = house.findall('Components/Ceiling')
+    return {
+        'ceilings': [_ceiling_snippet(node) for node in ceilings]
+    }

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -81,6 +81,7 @@ def test_extract_with_snippets(tmpdir: py._path.local.LocalPath) -> None:
         'MAIL_ADDR': '123 Main st.',
         'MAIL_PCODE': 'M5E 1W5',
         'TAXNUMBER': '999999999999',
+        'BUILDER': '4D01D00002',
         'RAW_XML': xml_data,
     }
 

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -86,7 +86,7 @@ def test_extract_with_snippets(tmpdir: py._path.local.LocalPath) -> None:
 
     input_file = tmpdir.join('input.csv')
     with open(input_file, 'w') as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=data.keys())
+        writer = csv.DictWriter(csvfile, fieldnames=list(data.keys()))
         writer.writeheader()
         writer.writerow(data)
 

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -1,21 +1,21 @@
 import os
-from xml.etree import ElementTree
+from lxml import etree
 import pytest
 from energuide import snippets
 
 
 @pytest.fixture
-def house() -> ElementTree:
+def house() -> etree.ElementTree:
     sample_filename = os.path.join(os.path.dirname(__file__), 'sample.h2k')
     with open(sample_filename, 'r') as h2k:
-        doc = ElementTree.parse(h2k)
+        doc = etree.ElementTree.parse(h2k)
 
     house_node = doc.find('House')
     assert house_node
     return house_node
 
 
-def test_ceiling_snippet(house: ElementTree) -> None:
+def test_ceiling_snippet(house: etree.ElementTree) -> None:
     output = snippets.snip_house(house)
     assert 'ceilings' in output
     assert len(output['ceilings']) == 2

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -1,0 +1,22 @@
+import os
+from xml.etree import ElementTree
+import pytest
+from energuide import snippets
+
+
+@pytest.fixture
+def house() -> ElementTree:
+    sample_filename = os.path.join(os.path.dirname(__file__), 'sample.h2k')
+    with open(sample_filename, 'r') as h2k:
+        doc = ElementTree.parse(h2k)
+
+    house_node = doc.find('House')
+    assert house_node
+    return house_node
+
+
+def test_ceiling_snippet(house: ElementTree) -> None:
+    output = snippets.snip_house(house)
+    assert 'ceilings' in output
+    assert len(output['ceilings']) == 2
+    assert output['ceilings'][0]['nominal_rsi'] == '2.864'

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -8,10 +8,10 @@ from energuide import snippets
 def house() -> etree.ElementTree:
     sample_filename = os.path.join(os.path.dirname(__file__), 'sample.h2k')
     with open(sample_filename, 'r') as h2k:
-        doc = etree.ElementTree.parse(h2k)
+        doc = etree.parse(h2k)
 
     house_node = doc.find('House')
-    assert house_node
+    assert house_node is not None
     return house_node
 
 


### PR DESCRIPTION
This PR adds the first XML parsing to the extractor. It pulls out all the `ceilings` data and adds it to each row. The data is a list of dicts containing all the needed information from each ceiling.