### PR TITLE
include ceiling measurements in extracted data

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -87,7 +87,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'MODIFICATIONDATE': {'type': 'string', 'required': True},
         'YEARBUILT': {'type': 'integer', 'required': True, 'coerce': int},
         'CLIENTCITY': {'type': 'string', 'required': True},
-        'ForwardSortationArea': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z]'},
+        'forwardSortationArea': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z]'},
         'HOUSEREGION': {'type': 'string', 'required': True},
     }
 
@@ -107,7 +107,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             year_built=row['YEARBUILT'],
             city=row['CLIENTCITY'],
             region=Region.from_data(row['HOUSEREGION']),
-            forward_sortation_area=row['ForwardSortationArea']
+            forward_sortation_area=row['forwardSortationArea']
         )
 
 

--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -57,7 +57,7 @@ def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
 
 def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterator[reader.InputData]:
     for row in data:
-        row['ForwardSortationArea'] = row['CLIENTPCODE'][:3]
+        row['forwardSortationArea'] = row['CLIENTPCODE'][:3]
 
         doc = ElementTree.fromstring(row['RAW_XML'])
         house = doc.find('House')

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -11,12 +11,17 @@ def _ceiling_snippet(ceiling: etree.ElementTree) -> typing.Dict[str, typing.Any]
     nominal_rsi = nominal_rsi_node.attrib['nominalInsulation'] if nominal_rsi_node is not None else None
     effective_rsi_node = ceiling.find('Construction/CeilingType')
     effective_rsi = effective_rsi_node.attrib['rValue'] if effective_rsi_node is not None else None
+    measurements_node = ceiling.find('Measurements')
+    area = measurements_node.attrib['area'] if measurements_node is not None else None
+    length = measurements_node.attrib['length'] if measurements_node is not None else None
     return {
         'label': label,
         'type_english': type_english,
         'type_french': type_french,
         'nominal_rsi': nominal_rsi,
         'effective_rsi': effective_rsi,
+        'area': area,
+        'length': length,
     }
 
 

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -16,7 +16,7 @@ def sample_input_d() -> reader.InputData:
         'CREATIONDATE': '2018-01-08 09:00:00',
         'MODIFICATIONDATE': '2018-06-01 09:00:00',
         'CLIENTCITY': 'Ottawa',
-        'ForwardSortationArea': 'K1P',
+        'forwardSortationArea': 'K1P',
         'HOUSEREGION': 'Ontario',
         'YEARBUILT': 2000,
     }
@@ -31,7 +31,7 @@ def sample_input_e() -> reader.InputData:
         'CREATIONDATE': '2018-02-08 09:00:00',
         'MODIFICATIONDATE': '2018-06-01 09:00:00',
         'CLIENTCITY': 'Montreal',
-        'ForwardSortationArea': 'G1A',
+        'forwardSortationArea': 'G1A',
         'HOUSEREGION': 'Quebec',
         'YEARBUILT': 2001,
     }
@@ -108,7 +108,7 @@ class TestParsedDwellingDataRow:
         )
 
     def test_bad_postal_code(self, sample_input_d: reader.InputData) -> None:
-        sample_input_d['ForwardSortationArea'] = 'K16'
+        sample_input_d['forwardSortationArea'] = 'K16'
         with pytest.raises(reader.InvalidInputDataException):
             dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
 

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -19,4 +19,12 @@ def test_ceiling_snippet(house: etree.ElementTree) -> None:
     output = snippets.snip_house(house)
     assert 'ceilings' in output
     assert len(output['ceilings']) == 2
-    assert output['ceilings'][0]['nominal_rsi'] == '2.864'
+    assert output['ceilings'][0] == {
+        'label': 'Main attic',
+        'type_english': 'Attic/gable',
+        'type_french': 'Combles/pignon',
+        'nominal_rsi': '2.864',
+        'effective_rsi': '2.9463',
+        'area': '46.4515',
+        'length': '23.875',
+    }


### PR DESCRIPTION
This PR:
- adds area and length to the extracted ceiling information
- renames `ForwardSortationArea` to `forwardSortationArea` to be consistent with `ceilings`
- updates the ceilings snippets test to be more specific about the extracted data
- updates tests & test fixtures accordingly to the above
