### PR TITLE
extract wall details

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -183,10 +183,10 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{2,120}$
 
 # Naming hint for function names
-function-name-hint=[a-z_][a-z0-9_]{2,30}$
+function-name-hint=[a-z_][a-z0-9_]{2,120}$
 
 # Regular expression matching correct variable names
 variable-rgx=[a-z_][a-z0-9_]{2,30}$
@@ -237,10 +237,10 @@ module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
 
 # Regular expression matching correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,120}$
 
 # Naming hint for method names
-method-name-hint=[a-z_][a-z0-9_]{2,30}$
+method-name-hint=[a-z_][a-z0-9_]{2,120}$
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -44,12 +44,37 @@ def _floor_snippet(floor: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     }
 
 
+def _wall_snippet(wall: etree.ElementTree) -> typing.Dict[str, typing.Any]:
+    label = wall.findtext('Label')
+
+    construction_type_node = wall.find('Construction/Type')
+    construction_type_code = construction_type_node.attrib.get('idref') if construction_type_node is not None else None
+    nominal_rsi = construction_type_node.attrib['nominalInsulation'] if construction_type_node is not None else None
+    effective_rsi = construction_type_node.attrib['rValue'] if construction_type_node is not None else None
+
+    measurements_node = wall.find('Measurements')
+    perimeter = measurements_node.attrib['perimeter'] if measurements_node is not None else None
+    height = measurements_node.attrib['height'] if measurements_node is not None else None
+
+    return {
+        'label': label,
+        'constructionTypeCode': construction_type_code,
+        'constructionTypeValue': construction_type_node.text,
+        'nominalRsi': nominal_rsi,
+        'effectiveRsi': effective_rsi,
+        'perimeter': perimeter,
+        'height': height,
+    }
+
+
 def snip_house(house: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     ceilings = house.findall('Components/Ceiling')
     floors = house.findall('Components/Floor')
+    walls = house.findall('Components/Wall')
     return {
         'ceilings': [_ceiling_snippet(node) for node in ceilings],
         'floors': [_floor_snippet(node) for node in floors],
+        'walls': [_wall_snippet(node) for node in walls],
     }
 
 

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -54,6 +54,50 @@ def test_floor_snippet(house: etree.ElementTree) -> None:
     }
 
 
+def test_wall_snippet(house: etree.ElementTree) -> None:
+    output = snippets.snip_house(house)
+    assert 'walls' in output
+    assert len(output['walls']) == 3
+    assert sorted(output['walls'], key=lambda row: row['label'])[0] == {
+        'label': 'End Wall',
+        'constructionTypeCode': 'Code 1',
+        'constructionTypeValue': '1201101121',
+        'effectiveRsi': '1.7435',
+        'nominalRsi': '1.432',
+        'perimeter': '7.367',
+        'height': '1.2283',
+    }
+
+
+def test_user_specified_wall_snippet() -> None:
+    xml_text = """
+<House><Components>
+    <Wall>
+        <Label>Test Floor</Label>
+        <Construction>
+            <Type rValue="2.6892" nominalInsulation="3.3615">User specified</Type>
+        </Construction>
+    </Wall>
+</Components></House>
+    """
+
+    doc = etree.fromstring(xml_text)
+    output = snippets.snip_house(doc)
+    assert output == {
+        'ceilings': [],
+        'floors': [],
+        'walls': [{
+            'label': 'Test Floor',
+            'constructionTypeCode': None,
+            'constructionTypeValue': 'User specified',
+            'nominalRsi': '3.3615',
+            'effectiveRsi': '2.6892',
+            'perimeter': None,
+            'height': None,
+        }]
+    }
+
+
 def test_code_snippet(code: etree.ElementTree) -> None:
     output = snippets.snip_codes(code)
     assert output == {


### PR DESCRIPTION
This PR requires changing the base to master before merging.

This PR adds the ability to extract wall details from the house components. Combined with the new wall codes information, this provides all the wall information present in the HOIS.
