### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Mike Williamson <mike.williamson@tbs-sct.gc.ca>",
   "license": "MIT",
   "scripts": {
-    "test": "jest",
+    "test": "jest src",
+    "integration": "jest test/",
     "start": "node dist/index.js",
     "build": "babel src --copy-files --out-dir dist",
     "dockerize": "yarn build && docker build -t cdssnc/nrcan_api .",

--- a/src/__tests__/server.test.js
+++ b/src/__tests__/server.test.js
@@ -1,5 +1,5 @@
 import request from 'supertest'
-import Server from '../src/server'
+import Server from '../server'
 
 let server = new Server({
   client: jest.fn(),

--- a/src/__tests__/utilities.test.js
+++ b/src/__tests__/utilities.test.js
@@ -1,4 +1,4 @@
-import { comparators, hasMoreThanOneComparator } from '../src/utilities'
+import { comparators, hasMoreThanOneComparator } from '../utilities'
 
 describe('Utilities', () => {
   describe('comparators', () => {

--- a/src/schema/types/__tests__/ForwardSortationArea.test.js
+++ b/src/schema/types/__tests__/ForwardSortationArea.test.js
@@ -1,4 +1,4 @@
-import ForwardSortationArea from '../src/schema/types/ForwardSortationArea'
+import ForwardSortationArea from '../ForwardSortationArea'
 import {
   graphql,
   GraphQLSchema,

--- a/src/schema/types/__tests__/Latitude.test.js
+++ b/src/schema/types/__tests__/Latitude.test.js
@@ -1,4 +1,4 @@
-import Latitude from '../src/schema/types/Latitude'
+import Latitude from '../Latitude'
 import {
   graphql,
   GraphQLSchema,

--- a/src/schema/types/__tests__/Longitude.test.js
+++ b/src/schema/types/__tests__/Longitude.test.js
@@ -1,4 +1,4 @@
-import Longitude from '../src/schema/types/Longitude'
+import Longitude from '../Longitude'
 import {
   graphql,
   GraphQLSchema,

--- a/src/schema/types/__tests__/PostalCode.test.js
+++ b/src/schema/types/__tests__/PostalCode.test.js
@@ -1,4 +1,4 @@
-import PostalCode from '../src/schema/types/PostalCode'
+import PostalCode from '../PostalCode'
 import {
   graphql,
   GraphQLSchema,


### PR DESCRIPTION
The idea here is to colocate the unit tests with the code under tests,
which is generally what Facebook crew is reccomending. The integration
test, which test more than one piece of code then live in the the `test`
folder.

Integration tests can now be run with `yarn integration` while unit
tests can be run with `yarn test` as normal.

Ping @buckley-w-david. Next stop, CircleCI. 