### PR TITLE
load wall data

### DIFF
--- a/python/tests/randomized_energuide_data.csv
+++ b/python/tests/randomized_energuide_data.csv
@@ -415,6 +415,13 @@ EVAL_ID,IDNUMBER,PARTNER,EVALUATOR,PREVIOUSFILEID,STATUS,CREATIONDATE,MODIFICATI
                     </Slope>
                 </Measurements>
             </Ceiling>
+            <Wall>
+                <Label>Test wall</Label>
+                <Construction>
+                    <Type rValue=""2.6892"" nominalInsulation=""3.3615"" idref=""Code 1"">12345678</Type>
+                </Construction>
+                <Measurements height=""2.5999"" perimeter=""35.7616"" />
+            </Wall>
             <Wall adjacentEnclosedSpace=""false"" id=""2"">
                 <Label>Main floor</Label>
                 <Construction corners=""4"" intersections=""4"">
@@ -679,9 +686,55 @@ EVAL_ID,IDNUMBER,PARTNER,EVALUATOR,PREVIOUSFILEID,STATUS,CREATIONDATE,MODIFICATI
         </Components>
     </House>
     <Codes>
+        <Wall>
+            <Standard>
+                <Code id=""Code 1"" value=""1201101121"" nominalRValue=""1.432"">
+                    <Label>1201101121</Label>
+                    <Description>1201101121</Description>
+                    <Layers>
+                        <StructureType code=""2"">
+                            <English>Wood frame</English>
+                            <French>Ossature de bois</French>
+                        </StructureType>
+                        <ComponentTypeSize code=""0"">
+                            <English>38x89 mm (2x4 in)</English>
+                            <French>38x89 (2x4)</French>
+                        </ComponentTypeSize>
+                        <Spacing code=""1"">
+                            <English>400 mm (16 in)</English>
+                            <French>400 mm (16 po)</French>
+                        </Spacing>
+                        <InsulationLayer1 code=""1"">
+                            <English>RSI 1.41 @ 64 mm  (R  8 @ 2.5'') batt</English>
+                            <French>RSI 1.41 @ 64 mm  (R  8 @ 2.5'') natte</French>
+                        </InsulationLayer1>
+                        <InsulationLayer2 code=""0"">
+                            <English>None</English>
+                            <French>Aucun</French>
+                        </InsulationLayer2>
+                        <Interior code=""1"">
+                            <English>12 mm (0.5 in) gypsum board</English>
+                            <French>12 mm (0.5 po) Plaque de plâtre (P de p)</French>
+                        </Interior>
+                        <Sheathing code=""1"">
+                            <English>Waferboard/OSB  9.5 mm (3/8 in)</English>
+                            <French>Panneau copeaux/OSB  9.5 mm (3/8 po)</French>
+                        </Sheathing>
+                        <Exterior code=""2"">
+                            <English>Hollow metal/vinyl cladding</English>
+                            <French>Revêt. en métal creux/vinyle</French>
+                        </Exterior>
+                        <StudsCornerIntersection code=""1"">
+                            <English>3 studs</English>
+                            <French>3 poteaux</French>
+                        </StudsCornerIntersection>
+                    </Layers>
+                </Code>
+            </Standard>
+        </Wall>
         <Lintel>
             <Standard>
-                <Code id=""Code 1"" value=""100"" nominalRValue=""0"">
+                <Code id=""Code 2"" value=""100"" nominalRValue=""0"">
                     <Label>100</Label>
                     <Description>100</Description>
                     <Layers>

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -33,6 +33,19 @@ def floor_input() -> reader.InputData:
 
 
 @pytest.fixture
+def wall_input() -> typing.Dict[str, str]:
+    return {
+        'label': 'Second level',
+        'constructionTypeCode': 'Code 1',
+        'constructionTypeValue': '1201101121',
+        'nominalRsi': '1.432',
+        'effectiveRsi': '1.8016',
+        'perimeter': '42.9768',
+        'height': '2.4384',
+    }
+
+
+@pytest.fixture
 def raw_codes() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
     return {
         'wall': [
@@ -58,6 +71,7 @@ def raw_codes() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
 @pytest.fixture
 def sample_input_d(ceiling_input: reader.InputData,
                    floor_input: reader.InputData,
+                   wall_input: typing.Dict[str, str],
                    raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> reader.InputData:
     return {
         'EVAL_ID': '123',
@@ -75,7 +89,10 @@ def sample_input_d(ceiling_input: reader.InputData,
         'floors': [
             floor_input
         ],
-        'codes': raw_codes
+        'walls': [
+            wall_input
+        ],
+        'codes': raw_codes,
     }
 
 
@@ -172,6 +189,19 @@ class TestParsedDwellingDataRow:
                     effective_rsi=2.9181,
                     area_metres=9.2903,
                     length_metres=3.048,
+                )
+            ],
+            walls=[
+                extracted_datatypes.Wall(
+                    label='Second level',
+                    structure_type_english='Wood frame',
+                    structure_type_french='Ossature de bois',
+                    component_type_size_english='38x89 mm (2x4 in)',
+                    component_type_size_french='38x89 (2x4)',
+                    nominal_rsi=1.432,
+                    effective_rsi=1.8016,
+                    perimeter=42.9768,
+                    height=2.4384,
                 )
             ]
         )

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -1,34 +1,10 @@
 import typing
 import pytest
-from energuide import reader
 from energuide import extracted_datatypes
 
 
 # pylint: disable=no-self-use
 
-
-@pytest.fixture
-def ceiling_input() -> reader.InputData:
-    return {
-        'label': 'Main attic',
-        'typeEnglish': 'Attic/gable',
-        'typeFrench': 'Combles/pignon',
-        'nominalRsi': '2.864',
-        'effectiveRsi': '2.9463',
-        'area': '46.4515',
-        'length': '23.875',
-    }
-
-
-@pytest.fixture
-def floor_input() -> reader.InputData:
-    return {
-        'label': 'Rm over garage',
-        'nominalRsi': '2.46',
-        'effectiveRsi': '2.9181',
-        'area': '9.2903',
-        'length': '3.048',
-    }
 
 @pytest.fixture
 def raw_codes() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
@@ -58,30 +34,6 @@ def codes(raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> ex
     return extracted_datatypes.Codes.from_data(raw_codes)
 
 
-@pytest.fixture
-def sample_input_d(ceiling_input: reader.InputData,
-                   floor_input: reader.InputData,
-                   raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> reader.InputData:
-    return {
-        'EVAL_ID': '123',
-        'EVAL_TYPE': 'D',
-        'ENTRYDATE': '2018-01-01',
-        'CREATIONDATE': '2018-01-08 09:00:00',
-        'MODIFICATIONDATE': '2018-06-01 09:00:00',
-        'CLIENTCITY': 'Ottawa',
-        'forwardSortationArea': 'K1P',
-        'HOUSEREGION': 'Ontario',
-        'YEARBUILT': '2000',
-        'ceilings': [
-            ceiling_input
-        ],
-        'floors': [
-            floor_input
-        ],
-        'codes': raw_codes,
-    }
-
-
 class TestWallCode:
 
     @pytest.fixture
@@ -102,16 +54,39 @@ class TestCodes:
         assert output.wall['Code 1'].structure_type_english == 'Wood frame'
 
 
+class TestWall:
+
+    @pytest.fixture
+    def sample(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': 'Second level',
+            'constructionTypeCode': 'Code 1',
+            'constructionTypeValue': '1201101121',
+            'nominalRsi': 1.432,
+            'effectiveRsi': 1.8016,
+            'perimeter': 42.9768,
+            'height': 2.4384,
+        }
+
+    def test_from_data(self, sample, codes):
+        output = extracted_datatypes.Wall.from_data(sample, codes.wall)
+        assert output.label == 'Second level'
+        assert output.perimeter == 42.9768
+
+
 class TestCeiling:
 
     @pytest.fixture
-    def sample(self, sample_input_d: reader.InputData):
-        ceiling = sample_input_d['ceilings'][0]
-        ceiling['nominalRsi'] = float(ceiling['nominalRsi'])
-        ceiling['effectiveRsi'] = float(ceiling['effectiveRsi'])
-        ceiling['area'] = float(ceiling['area'])
-        ceiling['length'] = float(ceiling['length'])
-        return ceiling
+    def sample(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': 'Main attic',
+            'typeEnglish': 'Attic/gable',
+            'typeFrench': 'Combles/pignon',
+            'nominalRsi': 2.864,
+            'effectiveRsi': 2.9463,
+            'area': 46.4515,
+            'length': 23.875,
+        }
 
     def test_from_data(self, sample):
         output = extracted_datatypes.Ceiling.from_data(sample)
@@ -122,13 +97,14 @@ class TestCeiling:
 class TestFloor:
 
     @pytest.fixture
-    def sample(self, sample_input_d: reader.InputData):
-        floor = sample_input_d['floors'][0]
-        floor['nominalRsi'] = float(floor['nominalRsi'])
-        floor['effectiveRsi'] = float(floor['effectiveRsi'])
-        floor['area'] = float(floor['area'])
-        floor['length'] = float(floor['length'])
-        return floor
+    def sample(self):
+        return {
+            'label': 'Rm over garage',
+            'nominalRsi': 2.46,
+            'effectiveRsi': 2.9181,
+            'area': 9.2903,
+            'length': 3.048,
+        }
 
     def test_from_data(self, sample):
         output = extracted_datatypes.Floor.from_data(sample)


### PR DESCRIPTION
This PR factors out the `Wall` class and it's usage from #79 
It also modifies the test fixture data somewhat to add a wall to one of the entries that uses a code, instead of just being User Specified.