### PR TITLE
Improve extracted_datatypes

### DIFF
--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -167,13 +167,13 @@ class Ceiling(_Ceiling):
         'schema': {
             'type': 'dict',
             'schema': {
-                'label': {'type': 'string', 'required': True},
-                'typeEnglish': {'type': 'string', 'required': True},
-                'typeFrench': {'type': 'string', 'required': True},
-                'nominalRsi': {'type': 'float', 'required': True, 'coerce': float},
-                'effectiveRsi': {'type': 'float', 'required': True, 'coerce': float},
-                'area': {'type': 'float', 'required': True, 'coerce': float},
-                'length': {'type': 'float', 'required': True, 'coerce': float}
+                'label': {'type': 'string', 'required': True, 'nullable': True},
+                'typeEnglish': {'type': 'string', 'required': True, 'nullable': True},
+                'typeFrench': {'type': 'string', 'required': True, 'nullable': True},
+                'nominalRsi': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'effectiveRsi': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'area': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'length': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True}
             }
         }
     }
@@ -215,11 +215,11 @@ class Floor(_Floor):
         'schema': {
             'type': 'dict',
             'schema': {
-                'label': {'type': 'string', 'required': True},
-                'nominalRsi': {'type': 'float', 'required': True, 'coerce': float},
-                'effectiveRsi': {'type': 'float', 'required': True, 'coerce': float},
-                'area': {'type': 'float', 'required': True, 'coerce': float},
-                'length': {'type': 'float', 'required': True, 'coerce': float}
+                'label': {'type': 'string', 'required': True, 'nullable': True},
+                'nominalRsi': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'effectiveRsi': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'area': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+                'length': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True}
             }
         }
     }

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -68,7 +68,7 @@ class TestWall:
             'height': 2.4384,
         }
 
-    def test_from_data(self, sample, codes) -> None:
+    def test_from_data(self, sample: typing.Dict[str, typing.Any], codes: extracted_datatypes.Codes) -> None:
         output = extracted_datatypes.Wall.from_data(sample, codes.wall)
         assert output.label == 'Second level'
         assert output.perimeter == 42.9768

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -48,7 +48,7 @@ class TestWallCode:
 
 class TestCodes:
 
-    def test_from_data(self, raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]):
+    def test_from_data(self, raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> None:
         output = extracted_datatypes.Codes.from_data(raw_codes)
         assert len(output.wall) == 2
         assert output.wall['Code 1'].structure_type_english == 'Wood frame'
@@ -68,10 +68,27 @@ class TestWall:
             'height': 2.4384,
         }
 
-    def test_from_data(self, sample, codes):
+    def test_from_data(self, sample, codes) -> None:
         output = extracted_datatypes.Wall.from_data(sample, codes.wall)
         assert output.label == 'Second level'
         assert output.perimeter == 42.9768
+
+    def test_missing_optional_fields(self,
+                                     sample: typing.Dict[str, typing.Any],
+                                     codes: extracted_datatypes.Codes) -> None:
+        wall = sample.copy()
+        wall.pop('constructionTypeCode')
+        wall.pop('constructionTypeValue')
+        output = extracted_datatypes.Wall.from_data(wall, codes.wall)
+        assert output.label == 'Second level'
+        assert output.perimeter == 42.9768
+        assert output.component_type_size_english is None
+
+    def test_to_dict(self,
+                     sample: typing.Dict[str, typing.Any],
+                     codes: extracted_datatypes.Codes) -> None:
+        output = extracted_datatypes.Wall.from_data(sample, codes.wall).to_dict()
+        assert output['areaMetres'] == sample['perimeter'] * sample['height']
 
 
 class TestCeiling:
@@ -88,16 +105,20 @@ class TestCeiling:
             'length': 23.875,
         }
 
-    def test_from_data(self, sample):
+    def test_from_data(self, sample: typing.Dict[str, typing.Any]):
         output = extracted_datatypes.Ceiling.from_data(sample)
         assert output.label == 'Main attic'
         assert output.area_metres == 46.4515
+
+    def test_to_dict(self, sample: typing.Dict[str, typing.Any]) -> None:
+        output = extracted_datatypes.Ceiling.from_data(sample).to_dict()
+        assert output['areaMetres'] == sample['area']
 
 
 class TestFloor:
 
     @pytest.fixture
-    def sample(self):
+    def sample(self) -> typing.Dict[str, typing.Any]:
         return {
             'label': 'Rm over garage',
             'nominalRsi': 2.46,
@@ -106,7 +127,11 @@ class TestFloor:
             'length': 3.048,
         }
 
-    def test_from_data(self, sample):
+    def test_from_data(self, sample: typing.Dict[str, typing.Any]) -> None:
         output = extracted_datatypes.Floor.from_data(sample)
         assert output.label == 'Rm over garage'
         assert output.area_metres == 9.2903
+
+    def test_to_dict(self, sample: typing.Dict[str, typing.Any]) -> None:
+        output = extracted_datatypes.Floor.from_data(sample).to_dict()
+        assert output['areaMetres'] == sample['area']


### PR DESCRIPTION
This PR factors out some misc test improvements, as well as adds the `nullable` keyword to the schema of the types in extracted_datatypes marking them as possibly `None`.

This functionality was factored out of #79 