### PR TITLE
extract exterior doors

### DIFF
--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -67,14 +67,36 @@ def _wall_snippet(wall: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     }
 
 
+def _door_snippet(door: etree.ElementTree) -> typing.Dict[str, typing.Any]:
+    type_english = door.findtext('Construction/Type/English')
+    type_french = door.findtext('Construction/Type/French')
+
+    type_node = door.find('Construction/Type')
+    rsi = type_node.attrib['value'] if type_node is not None else None
+
+    measurements_node = door.find('Measurements')
+    height = measurements_node.attrib['height'] if measurements_node is not None else None
+    width = measurements_node.attrib['width'] if measurements_node is not None else None
+
+    return {
+        'typeEnglish': type_english,
+        'typeFrench': type_french,
+        'rsi': rsi,
+        'height': height,
+        'width': width,
+    }
+
+
 def snip_house(house: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     ceilings = house.findall('Components/Ceiling')
     floors = house.findall('Components/Floor')
     walls = house.findall('Components/Wall')
+    doors = house.findall('Components/Wall/Components/Door')
     return {
         'ceilings': [_ceiling_snippet(node) for node in ceilings],
         'floors': [_floor_snippet(node) for node in floors],
         'walls': [_wall_snippet(node) for node in walls],
+        'doors': [_door_snippet(door) for door in doors],
     }
 
 
@@ -94,6 +116,7 @@ def _wall_code_snippet(wall_code: etree.ElementTree) -> typing.Dict[str, typing.
         'componentTypeSizeEnglish': component_type_size_english,
         'componentTypeSizeFrench': component_type_size_french,
     }
+
 
 def _window_code_snippet(window_code: etree.ElementTree) -> typing.Dict[str, typing.Any]:
     code_id = window_code.attrib['id']
@@ -133,7 +156,6 @@ def _window_code_snippet(window_code: etree.ElementTree) -> typing.Dict[str, typ
         'frameMaterialEnglish': frame_material_english,
         'frameMaterialFrench': frame_material_french,
     }
-
 
 
 def snip_codes(codes: etree.ElementTree) -> typing.Dict[str, typing.Any]:

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -94,7 +94,8 @@ def test_user_specified_wall_snippet() -> None:
             'effectiveRsi': '2.6892',
             'perimeter': None,
             'height': None,
-        }]
+        }],
+        'doors': [],
     }
 
 
@@ -116,6 +117,7 @@ def test_wall_code_snippet(code: etree.ElementTree) -> None:
         'componentTypeSizeFrench': '38x89 (2x4)',
     }]
 
+
 def test_window_code_snippet(code: etree.ElementTree) -> None:
     output = snippets.snip_codes(code)
     assert sorted(output['codes']['window'], key=lambda row: row['label'])[0] == {
@@ -134,3 +136,16 @@ def test_window_code_snippet(code: etree.ElementTree) -> None:
         'frameMaterialEnglish': 'Wood',
         'frameMaterialFrench': 'Bois',
     }
+
+
+def test_door_snippet(house: etree.ElementTree) -> None:
+    output = snippets.snip_house(house)
+    assert len(output['doors']) == 2
+    assert output['doors'][0] == {
+        'typeEnglish': 'Solid wood',
+        'typeFrench': 'Bois massif',
+        'rsi': '0.39',
+        'height': '1.9799',
+        'width': '0.8499',
+    }
+    assert output['doors'][0] == output['doors'][1]


### PR DESCRIPTION
This PR adds extraction of the raw `door` data. `Door`s are always embedded within a `Wall`, which makes logical sense.

https://trello.com/c/L9320zNP/106-extract-load-door-data