### PR TITLE
Extract query construction logic from resolver

### DIFF
--- a/api/src/__tests__/utilities.test.js
+++ b/api/src/__tests__/utilities.test.js
@@ -1,4 +1,8 @@
-import { comparators, hasMoreThanOneComparator } from '../utilities'
+import {
+  comparators,
+  createQuery,
+  hasMoreThanOneComparator,
+} from '../utilities'
 
 describe('Utilities', () => {
   describe('comparators', () => {
@@ -10,6 +14,59 @@ describe('Utilities', () => {
       expect(comparators.gt).toEqual('$gt')
       expect(comparators.lt).toEqual('$lt')
       expect(comparators.eq).toEqual('$eq')
+    })
+  })
+
+  describe('createQuery', () => {
+    describe('with a greater than filter', () => {
+      it('returns a MongoDB $gt query object', () => {
+        let fsa = 'C1A'
+        let filter = { field: 'yearBuilt', gt: '2000' }
+
+        let query = createQuery(fsa, filter)
+
+        expect(query).toEqual({
+          $and: [{ forwardSortationArea: 'C1A' }, { yearBuilt: { $gt: 2000 } }],
+        })
+      })
+    })
+
+    describe('with a less than filter', () => {
+      it('returns a MongoDB $lt query object', () => {
+        let fsa = 'C1A'
+        let filter = { field: 'yearBuilt', lt: '2000' }
+
+        let query = createQuery(fsa, filter)
+
+        expect(query).toEqual({
+          $and: [{ forwardSortationArea: 'C1A' }, { yearBuilt: { $lt: 2000 } }],
+        })
+      })
+    })
+
+    describe('with an equal to filter', () => {
+      it('returns a MongoDB $eq query object', () => {
+        let fsa = 'C1A'
+        let filter = { field: 'yearBuilt', eq: '2000' }
+
+        let query = createQuery(fsa, filter)
+
+        expect(query).toEqual({
+          $and: [{ forwardSortationArea: 'C1A' }, { yearBuilt: { $eq: 2000 } }],
+        })
+      })
+    })
+
+    describe('with no filter', () => {
+      it('returns a MongoDB $eq query object', () => {
+        let fsa = 'C1A'
+
+        let query = createQuery(fsa, undefined)
+
+        expect(query).toEqual({
+          $and: [{ forwardSortationArea: 'C1A' }],
+        })
+      })
     })
   })
 

--- a/api/src/utilities.js
+++ b/api/src/utilities.js
@@ -16,3 +16,35 @@ export function hasMoreThanOneComparator(filter) {
     return false
   }
 }
+
+export function createQuery(fsa, filter) {
+  let query = {
+    $and: [
+      {
+        forwardSortationArea: fsa,
+      },
+    ],
+  }
+
+  // { field: 'yearBuilt', gt: '1990' }
+  // XXX: not all fields are integers.
+  if (filter) {
+    if (filter.gt) {
+      query['$and'].push({
+        [filter.field]: { [comparators.gt]: parseInt(filter.gt) },
+      })
+    }
+    if (filter.lt) {
+      query['$and'].push({
+        [filter.field]: { [comparators.lt]: parseInt(filter.lt) },
+      })
+    }
+    if (filter.eq) {
+      query['$and'].push({
+        [filter.field]: { [comparators.eq]: parseInt(filter.eq) },
+      })
+    }
+  }
+
+  return query
+}


### PR DESCRIPTION
There was far to much going on in there. Extracted the construction of
the MongoDB query object in to a separate tested function in the
utilities module.