### PR TITLE
Lookup individual dwelling details by account only

### DIFF
--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -3,7 +3,6 @@ import { makeExecutableSchema } from 'graphql-tools'
 
 const Schema = i18n => {
   const typeDefs = `
-    scalar PostalCode
     scalar ForwardSortationArea
 
     input Filter {
@@ -51,7 +50,7 @@ const Schema = i18n => {
     # ${i18n.t`The root query type`}
     type Query {
       # ${i18n.t`Details for a specific dwelling`}
-      evaluationsFor(account: Int! postalCode: PostalCode!): Dwelling
+      evaluationsFor(account: Int!): Dwelling
       dwellingsInFSA(filter: Filter forwardSortationArea: ForwardSortationArea!): [Dwelling]
     }
 

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -1,4 +1,3 @@
-import PostalCode from './types/PostalCode'
 import ForwardSortationArea from './types/ForwardSortationArea'
 import { GraphQLError } from 'graphql'
 import {
@@ -8,20 +7,14 @@ import {
 } from '../utilities'
 
 const resolvers = {
-  PostalCode,
   ForwardSortationArea,
   Query: {
-    evaluationsFor: async (root, { account, postalCode }, { client }) => {
+    evaluationsFor: async (root, { account }, { client }) => {
       let query = {
         houseId: account,
-        // XXX This is a temporary hack to work around the lack of postal codes in the data.
-        forwardSortationArea: postalCode.split(' ')[0],
       }
 
-      let cursor = await client.find(query)
-
-      let results = await cursor.toArray()
-      return results[0] // XXX: clean this up too.
+      return client.findOne(query)
     },
     dwellingsInFSA: async (root, args, { client }) => {
       const { filter, forwardSortationArea } = args

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -27,7 +27,7 @@ describe('queries', () => {
         .set('Content-Type', 'application/json; charset=utf-8')
         .send({
           query: `{
-          evaluations:evaluationsFor(account: 189250 postalCode: "C1A 1N1") {
+          evaluations:evaluationsFor(account: 189250) {
             yearBuilt
           }
         }`,


### PR DESCRIPTION
Previously we were thinking that a combination of account number/houseId
plus postal code. This seems to be simpler and just as effective.