### PR TITLE
custom validator

### DIFF
--- a/python/src/energuide/validator.py
+++ b/python/src/energuide/validator.py
@@ -1,0 +1,18 @@
+import typing
+import cerberus
+from lxml import etree
+
+
+class DwellingValidator(cerberus.Validator):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
+
+    def _validate_type_xml(self, value: typing.Any) -> bool:  # pylint: disable=no-self-use
+        return isinstance(value, etree._Element)
+
+    def _normalize_coerce_parse_xml(self, value: typing.Any) -> typing.Optional[etree._Element]:
+        if isinstance(value, str):
+            return etree.fromstring(value.encode('utf-8'), self._parser)
+        return None

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -68,12 +68,97 @@ def window_input() -> typing.Dict[str, str]:
         'height': '1322.0699',
     }
 
+
 @pytest.fixture
 def heated_floor_area_input() -> typing.Dict[str, str]:
     return {
         'aboveGrade': '185.8',
         'belowGrade': '92.9',
     }
+
+
+@pytest.fixture
+def heating_cooling_input() -> str:
+    return """
+    <HeatingCooling id="25">
+            <Label>Heating/Cooling System</Label>
+            <CoolingSeason>
+                <Start code="1">January</Start>
+                <End code="12">December</End>
+                <Design code="7">July</Design>
+            </CoolingSeason>
+            <Type1>
+                <FansAndPump hasEnergyEfficientMotor="false">
+                    <Mode code="1">
+                        <English>Auto</English>
+                        <French>Auto</French>
+                    </Mode>
+                    <Power isCalculated="true" low="0" high="640.2" />
+                </FansAndPump>
+                <Furnace>
+                    <EquipmentInformation energystar="false">
+                        <Manufacturer>Wizard SPH man</Manufacturer>
+                    </EquipmentInformation>
+                    <Equipment isBiEnergy="false" switchoverTemperature="0">
+                        <EnergySource code="2">
+                            <English>Natural gas</English>
+                            <French>Gaz naturel</French>
+                        </EnergySource>
+                        <EquipmentType code="1">
+                            <English>Furnace w/ continuous pilot</English>
+                            <French>Fournaise avec veilleuse permanente</French>
+                        </EquipmentType>
+                    </Equipment>
+                    <Specifications sizingFactor="1.1" efficiency="78" isSteadyState="true" pilotLight="25.3" flueDiameter="152.4">
+                        <OutputCapacity code="2" value="33" uiUnits="btu/hr">
+                            <English>Calculated</English>
+                            <French>Calculé</French>
+                        </OutputCapacity>
+                    </Specifications>
+                </Furnace>
+            </Type1>
+            <Type2 shadingInF280Cooling="AccountedFor" />
+            <MultipleSystems>
+                <Summary energySaverHeatingSystems="0" energySaverAirSourceHeatPump="0" woodAppliances="0" epaCsaHeatingSystems="0" />
+            </MultipleSystems>
+            <SupplementaryHeatingSystems>
+                <System rank="1">
+                    <EquipmentInformation csaEpa="false" />
+                    <Equipment>
+                        <EnergySource code="5">
+                            <English>Mixed Wood</English>
+                            <French>Bois mélangé</French>
+                        </EnergySource>
+                        <Type code="1">
+                            <English>Advanced airtight wood stove</English>
+                            <French>Poêle à bois étanche avancé</French>
+                        </Type>
+                    </Equipment>
+                    <Specifications efficiency="30" damperClosed="false">
+                        <YearMade code="7">
+                            <English>1970-79</English>
+                            <French>1970-79</French>
+                        </YearMade>
+                        <Usage code="1">
+                            <English>Never</English>
+                            <French>Jamais</French>
+                        </Usage>
+                        <LocationHeated code="1" value="12.0031">
+                            <English>Main Floors</English>
+                            <French>Plancher Principaux</French>
+                        </LocationHeated>
+                        <Flue isInterior="true" diameter="127">
+                            <Type code="1">
+                                <English>Brick</English>
+                                <French>Brique</French>
+                            </Type>
+                        </Flue>
+                        <OutputCapacity value="2" uiUnits="kW" />
+                    </Specifications>
+                </System>
+            </SupplementaryHeatingSystems>
+        </HeatingCooling>
+    """
 
 
 @pytest.fixture
@@ -139,6 +224,7 @@ def sample_input_d(ceiling_input: reader.InputData,
                    door_input: typing.Dict[str, str],
                    window_input: typing.Dict[str, str],
                    heated_floor_area_input: typing.Dict[str, str],
+                   heating_cooling_input: str,
                    raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> reader.InputData:
     return {
         'EVAL_ID': '123',
@@ -168,6 +254,7 @@ def sample_input_d(ceiling_input: reader.InputData,
         'heatedFloorArea': [
             heated_floor_area_input
         ],
+        'heating_cooling': heating_cooling_input,
 
         'codes': raw_codes,
     }

--- a/python/tests/test_validator.py
+++ b/python/tests/test_validator.py
@@ -1,0 +1,25 @@
+from lxml import etree
+from energuide import validator
+
+
+def test_validates_xml() -> None:
+    raw_xml = '<Foo />'
+    doc = etree.fromstring(raw_xml)
+    data = {'raw_xml': doc}
+    checker = validator.DwellingValidator({'raw_xml': {'type': 'xml'}})
+    assert checker.validate(data)
+
+
+def test_string_fails_validation() -> None:
+    raw_xml = '<Foo />'
+    data = {'raw_xml': raw_xml}
+    checker = validator.DwellingValidator({'raw_xml': {'type': 'xml'}})
+    assert not checker.validate(data)
+
+
+def test_coerce_to_xml() -> None:
+    raw_xml = '<Foo />'
+    data = {'raw_xml': raw_xml}
+    checker = validator.DwellingValidator({'raw_xml': {'type': 'xml', 'coerce': 'parse_xml'}})
+    assert checker.validate(data)
+    assert isinstance(checker.document['raw_xml'], etree._Element)


### PR DESCRIPTION
This PR adds (and switches to) a custom validator with support for a new data type: `xml`, and a new coercion option `parse_xml`.