### PR TITLE
refactor snippets

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -87,7 +87,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     walls: typing.List[Wall]
     doors: typing.List[Door]
     windows: typing.List[Window]
-    heated_floor_area: typing.List[HeatedFloorArea]
+    heated_floor_area: HeatedFloorArea
 
 
 class ParsedDwellingDataRow(_ParsedDwellingDataRow):
@@ -139,8 +139,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             walls=[Wall.from_data(wall, codes.wall) for wall in parsed['walls']],
             doors=[Door.from_data(door) for door in parsed['doors']],
             windows=[Window.from_data(window, codes.window) for window in parsed['windows']],
-            heated_floor_area=[HeatedFloorArea.from_data(heated_floor_area)
-                               for heated_floor_area in parsed['heatedFloorArea']],
+            heated_floor_area=HeatedFloorArea.from_data(parsed['heatedFloorArea']),
         )
 
 
@@ -156,7 +155,7 @@ class Evaluation:
                  walls: typing.List[Wall],
                  doors: typing.List[Door],
                  windows: typing.List[Window],
-                 heated_floor_area: typing.List[HeatedFloorArea],
+                 heated_floor_area: HeatedFloorArea,
                 ) -> None:
         self._evaluation_type = evaluation_type
         self._entry_date = entry_date
@@ -221,7 +220,7 @@ class Evaluation:
         return self._windows
 
     @property
-    def heated_floor_area(self) -> typing.List[HeatedFloorArea]:
+    def heated_floor_area(self) -> HeatedFloorArea:
         return self._heated_floor_area
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
@@ -235,7 +234,7 @@ class Evaluation:
             'walls': [wall.to_dict() for wall in self.walls],
             'doors': [door.to_dict() for door in self.doors],
             'windows': [window.to_dict() for window in self.windows],
-            'heatedFloorArea': [heated_floor_area.to_dict() for heated_floor_area in self.heated_floor_area],
+            'heatedFloorArea': self.heated_floor_area.to_dict(),
         }
 
 

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -201,14 +201,11 @@ class Codes(_Codes):
 class HeatedFloorArea(_HeatedFloorArea):
 
     SCHEMA = {
-        'type': 'list',
+        'type': 'dict',
         'required': True,
         'schema': {
-            'type': 'dict',
-            'schema': {
-                'belowGrade': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
-                'aboveGrade': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
-            }
+            'belowGrade': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
+            'aboveGrade': {'type': 'float', 'required': True, 'coerce': float, 'nullable': True},
         }
     }
 

--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -71,12 +71,12 @@ def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterato
         house_node = doc.xpath('House')
         if house_node:
             house_snippets = snippets.snip_house(house_node[0])
-            row = _safe_merge(row, house_snippets)
+            row = _safe_merge(row, house_snippets.to_dict())
 
         code_node = doc.xpath('Codes')
         if code_node:
             code_snippets = snippets.snip_codes(code_node[0])
-            row = _safe_merge(row, code_snippets)
+            row = _safe_merge(row, code_snippets.to_dict())
 
         yield row
 

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -2,136 +2,361 @@ import typing
 from lxml import etree
 
 
+class _CeilingSnippet(typing.NamedTuple):
+    label: typing.Optional[str]
+    type_english: typing.Optional[str]
+    type_french: typing.Optional[str]
+    nominal_rsi: typing.Optional[str]
+    effective_rsi: typing.Optional[str]
+    area: typing.Optional[str]
+    length: typing.Optional[str]
+
+
+class _FloorSnippet(typing.NamedTuple):
+    label: typing.Optional[str]
+    nominal_rsi: typing.Optional[str]
+    effective_rsi: typing.Optional[str]
+    area: typing.Optional[str]
+    length: typing.Optional[str]
+
+
+class _WallSnippet(typing.NamedTuple):
+    label: typing.Optional[str]
+    construction_type_code: typing.Optional[str]
+    construction_type_value: typing.Optional[str]
+    nominal_rsi: typing.Optional[str]
+    effective_rsi: typing.Optional[str]
+    perimeter: typing.Optional[str]
+    height: typing.Optional[str]
+
+
+class _DoorSnippet(typing.NamedTuple):
+    label: typing.Optional[str]
+    type_english: typing.Optional[str]
+    type_french: typing.Optional[str]
+    rsi: typing.Optional[str]
+    height: typing.Optional[str]
+    width: typing.Optional[str]
+
+
+class _WindowSnippet(typing.NamedTuple):
+    label: typing.Optional[str]
+    construction_type_code: typing.Optional[str]
+    construction_type_value: typing.Optional[str]
+    rsi: typing.Optional[str]
+    width: typing.Optional[str]
+    height: typing.Optional[str]
+
+
+class _HeatedFloorSnippet(typing.NamedTuple):
+    above_grade: typing.Optional[str]
+    below_grade: typing.Optional[str]
+
+
+class _WallCodeSnippet(typing.NamedTuple):
+    identifier: str
+    label: typing.Optional[str]
+    structure_type_english: typing.Optional[str]
+    structure_type_french: typing.Optional[str]
+    component_type_size_english: typing.Optional[str]
+    component_type_size_french: typing.Optional[str]
+
+
+class _WindowCodeSnippet(typing.NamedTuple):
+    identifier: str
+    label: typing.Optional[str]
+    glazing_types_english: typing.Optional[str]
+    glazing_types_french: typing.Optional[str]
+    coatings_tints_english: typing.Optional[str]
+    coatings_tints_french: typing.Optional[str]
+    fill_type_english: typing.Optional[str]
+    fill_type_french: typing.Optional[str]
+    spacer_type_english: typing.Optional[str]
+    spacer_type_french: typing.Optional[str]
+    type_english: typing.Optional[str]
+    type_french: typing.Optional[str]
+    frame_material_english: typing.Optional[str]
+    frame_material_french: typing.Optional[str]
+
+
+class WallCodeSnippet(_WallCodeSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'id': self.identifier,
+            'label': self.label,
+            'structureTypeEnglish': self.structure_type_english,
+            'structureTypeFrench': self.structure_type_french,
+            'componentTypeSizeEnglish': self.component_type_size_english,
+            'componentTypeSizeFrench': self.component_type_size_french,
+        }
+
+
+
+class WindowCodeSnippet(_WindowCodeSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'id': self.identifier,
+            'label': self.label,
+            'glazingTypesEnglish': self.glazing_types_english,
+            'glazingTypesFrench': self.glazing_types_french,
+            'coatingsTintsEnglish': self.coatings_tints_english,
+            'coatingsTintsFrench': self.coatings_tints_french,
+            'fillTypeEnglish': self.fill_type_english,
+            'fillTypeFrench': self.fill_type_french,
+            'spacerTypeEnglish': self.spacer_type_english,
+            'spacerTypeFrench': self.spacer_type_french,
+            'typeEnglish': self.type_english,
+            'typeFrench': self.type_french,
+            'frameMaterialEnglish': self.frame_material_english,
+            'frameMaterialFrench': self.frame_material_french,
+        }
+
+
+class _Codes(typing.NamedTuple):
+    wall: typing.List[WallCodeSnippet]
+    window: typing.List[WindowCodeSnippet]
+
+
+class Codes(_Codes):
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'codes': {
+                'wall': [wall.to_dict() for wall in self.wall],
+                'window': [window.to_dict() for window in self.window],
+            }
+        }
+
+
+class CeilingSnippet(_CeilingSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'label': self.label,
+            'typeEnglish': self.type_english,
+            'typeFrench': self.type_french,
+            'nominalRsi': self.nominal_rsi,
+            'effectiveRsi': self.effective_rsi,
+            'area': self.area,
+            'length': self.length,
+        }
+
+
+class FloorSnippet(_FloorSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'label': self.label,
+            'nominalRsi': self.nominal_rsi,
+            'effectiveRsi': self.effective_rsi,
+            'area': self.area,
+            'length': self.length,
+        }
+
+
+class WallSnippet(_WallSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'label': self.label,
+            'constructionTypeCode': self.construction_type_code,
+            'constructionTypeValue': self.construction_type_value,
+            'nominalRsi': self.nominal_rsi,
+            'effectiveRsi': self.effective_rsi,
+            'perimeter': self.perimeter,
+            'height': self.height,
+        }
+
+
+class DoorSnippet(_DoorSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'label': self.label,
+            'typeEnglish': self.type_english,
+            'typeFrench': self.type_french,
+            'rsi': self.rsi,
+            'height': self.height,
+            'width': self.width,
+        }
+
+
+class WindowSnippet(_WindowSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'label': self.label,
+            'constructionTypeCode': self.construction_type_code,
+            'constructionTypeValue': self.construction_type_value,
+            'rsi': self.rsi,
+            'width': self.width,
+            'height': self.height,
+        }
+
+
+class HeatedFloorSnippet(_HeatedFloorSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
+        return {
+            'aboveGrade': self.above_grade,
+            'belowGrade': self.below_grade,
+        }
+
+
+class _HouseSnippet(typing.NamedTuple):
+    ceilings: typing.List[CeilingSnippet]
+    floors: typing.List[FloorSnippet]
+    walls: typing.List[WallSnippet]
+    doors: typing.List[DoorSnippet]
+    windows: typing.List[WindowSnippet]
+    heated_floor_area: HeatedFloorSnippet
+    heating_cooling: str
+
+
+class HouseSnippet(_HouseSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'ceilings': [ceiling.to_dict() for ceiling in self.ceilings],
+            'floors': [floor.to_dict() for floor in self.floors],
+            'walls': [wall.to_dict() for wall in self.walls],
+            'doors': [door.to_dict() for door in self.doors],
+            'windows': [window.to_dict() for window in self.windows],
+            'heatedFloorArea': self.heated_floor_area.to_dict() if self.heated_floor_area is not None else None,
+            'heating_cooling': self.heating_cooling,
+        }
+
+
 def _extract_values(node: etree._Element,
                     xpath_mapping: typing.Dict[str, str]) -> typing.Dict[str, typing.Optional[str]]:
     output = {key: node.xpath(value) for key, value in xpath_mapping.items()}
     return {key: value[0] if value else None for key, value in output.items()}
 
 
-def _ceiling_snippet(ceiling: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(ceiling, {
+def _ceiling_snippet(ceiling: etree._Element) -> CeilingSnippet:
+    return CeilingSnippet(**_extract_values(ceiling, {
         'label': 'Label/text()',
-        'typeEnglish': 'Construction/Type/English/text()',
-        'typeFrench': 'Construction/Type/French/text()',
-        'nominalRsi': 'Construction/CeilingType/@nominalInsulation',
-        'effectiveRsi': 'Construction/CeilingType/@rValue',
+        'type_english': 'Construction/Type/English/text()',
+        'type_french': 'Construction/Type/French/text()',
+        'nominal_rsi': 'Construction/CeilingType/@nominalInsulation',
+        'effective_rsi': 'Construction/CeilingType/@rValue',
         'area': 'Measurements/@area',
         'length': 'Measurements/@length',
-    })
+    }))
 
 
-def _floor_snippet(floor: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(floor, {
+def _floor_snippet(floor: etree._Element) -> FloorSnippet:
+    return FloorSnippet(**_extract_values(floor, {
         'label': 'Label/text()',
-        'nominalRsi': 'Construction/Type/@nominalInsulation',
-        'effectiveRsi': 'Construction/Type/@rValue',
+        'nominal_rsi': 'Construction/Type/@nominalInsulation',
+        'effective_rsi': 'Construction/Type/@rValue',
         'area': 'Measurements/@area',
         'length': 'Measurements/@length',
-    })
+    }))
 
 
-def _wall_snippet(wall: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(wall, {
+def _wall_snippet(wall: etree._Element) -> WallSnippet:
+    return WallSnippet(**_extract_values(wall, {
         'label': 'Label/text()',
-        'constructionTypeCode': 'Construction/Type/@idref',
-        'constructionTypeValue': 'Construction/Type/text()',
-        'nominalRsi': 'Construction/Type/@nominalInsulation',
-        'effectiveRsi': 'Construction/Type/@rValue',
+        'construction_type_code': 'Construction/Type/@idref',
+        'construction_type_value': 'Construction/Type/text()',
+        'nominal_rsi': 'Construction/Type/@nominalInsulation',
+        'effective_rsi': 'Construction/Type/@rValue',
         'perimeter': 'Measurements/@perimeter',
         'height': 'Measurements/@height',
-    })
+    }))
 
 
-def _door_snippet(door: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(door, {
+def _door_snippet(door: etree._Element) -> DoorSnippet:
+    return DoorSnippet(**_extract_values(door, {
         'label': 'Label/text()',
-        'typeEnglish': 'Construction/Type/English/text()',
-        'typeFrench': 'Construction/Type/French/text()',
+        'type_english': 'Construction/Type/English/text()',
+        'type_french': 'Construction/Type/French/text()',
         'rsi': 'Construction/Type/@value',
         'height': 'Measurements/@height',
         'width': 'Measurements/@width',
-    })
+    }))
 
 
-def _window_snippet(window: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(window, {
+def _window_snippet(window: etree._Element) -> WindowSnippet:
+    return WindowSnippet(**_extract_values(window, {
         'label': 'Label/text()',
-        'constructionTypeCode': 'Construction/Type/@idref',
-        'constructionTypeValue': 'Construction/Type/text()',
+        'construction_type_code': 'Construction/Type/@idref',
+        'construction_type_value': 'Construction/Type/text()',
         'rsi': 'Construction/Type/@rValue',
         'width': 'Measurements/@width',
         'height': 'Measurements/@height',
-    })
+    }))
 
 
-def _heated_floor_area_snippet(heated_floor_area: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(heated_floor_area, {
-        'aboveGrade': '@aboveGrade',
-        'belowGrade': '@belowGrade',
-    })
+def _heated_floor_area_snippet(heated_floor_area: etree._Element) -> HeatedFloorSnippet:
+    return HeatedFloorSnippet(**_extract_values(heated_floor_area, {
+        'above_grade': '@aboveGrade',
+        'below_grade': '@belowGrade',
+    }))
 
 
-def snip_house(house: etree._Element) -> typing.Dict[str, typing.List[typing.Dict[str, typing.Optional[str]]]]:
+def snip_house(house: etree._Element) -> HouseSnippet:
     ceilings = house.xpath('Components/Ceiling')
     floors = house.xpath('Components/Floor')
     walls = house.xpath('Components/Wall')
     doors = house.xpath('Components//Components/Door')
     windows = house.xpath('Components//Components/Window')
-    heated_floor_areas = house.xpath('Specifications/HeatedFloorArea')
+    heated_floor_area = house.xpath('Specifications/HeatedFloorArea')
     heating_cooling = house.xpath('HeatingCooling')
     heating_cooling_string = (
         etree.tostring(heating_cooling[0], encoding='unicode') if heating_cooling else None
     )
 
-    return {
-        'ceilings': [_ceiling_snippet(node) for node in ceilings],
-        'floors': [_floor_snippet(node) for node in floors],
-        'walls': [_wall_snippet(node) for node in walls],
-        'doors': [_door_snippet(door) for door in doors],
-        'windows': [_window_snippet(node) for node in windows],
-        'heatedFloorArea': [_heated_floor_area_snippet(heated_floor_area) for heated_floor_area in heated_floor_areas],
-        'heating_cooling': heating_cooling_string,
-    }
+    return HouseSnippet(
+        ceilings=[_ceiling_snippet(node) for node in ceilings],
+        floors=[_floor_snippet(node) for node in floors],
+        walls=[_wall_snippet(node) for node in walls],
+        doors=[_door_snippet(door) for door in doors],
+        windows=[_window_snippet(node) for node in windows],
+        heated_floor_area=_heated_floor_area_snippet(heated_floor_area[0]) if heated_floor_area else None,
+        heating_cooling=heating_cooling_string,
+    )
 
 
-def _wall_code_snippet(wall_code: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(wall_code, {
-        'id': '@id',
+def _wall_code_snippet(wall_code: etree._Element) -> WallCodeSnippet:
+    return WallCodeSnippet(**_extract_values(wall_code, {
+        'identifier': '@id',
         'label': 'Label/text()',
-        'structureTypeEnglish': 'Layers/StructureType/English/text()',
-        'structureTypeFrench': 'Layers/StructureType/French/text()',
-        'componentTypeSizeEnglish': 'Layers/ComponentTypeSize/English/text()',
-        'componentTypeSizeFrench': 'Layers/ComponentTypeSize/French/text()',
-    })
+        'structure_type_english': 'Layers/StructureType/English/text()',
+        'structure_type_french': 'Layers/StructureType/French/text()',
+        'component_type_size_english': 'Layers/ComponentTypeSize/English/text()',
+        'component_type_size_french': 'Layers/ComponentTypeSize/French/text()',
+    }))
 
 
-def _window_code_snippet(window_code: etree._Element) -> typing.Dict[str, typing.Optional[str]]:
-    return _extract_values(window_code, {
-        'id': '@id',
+def _window_code_snippet(window_code: etree._Element) -> WindowCodeSnippet:
+    return WindowCodeSnippet(**_extract_values(window_code, {
+        'identifier': '@id',
         'label': 'Label/text()',
-        'glazingTypesEnglish': 'Layers/GlazingTypes/English/text()',
-        'glazingTypesFrench': 'Layers/GlazingTypes/French/text()',
-        'coatingsTintsEnglish': 'Layers/CoatingsTints/English/text()',
-        'coatingsTintsFrench': 'Layers/CoatingsTints/French/text()',
-        'fillTypeEnglish': 'Layers/FillType/English/text()',
-        'fillTypeFrench': 'Layers/FillType/French/text()',
-        'spacerTypeEnglish': 'Layers/SpacerType/English/text()',
-        'spacerTypeFrench': 'Layers/SpacerType/French/text()',
-        'typeEnglish': 'Layers/Type/English/text()',
-        'typeFrench': 'Layers/Type/French/text()',
-        'frameMaterialEnglish': 'Layers/FrameMaterial/English/text()',
-        'frameMaterialFrench': 'Layers/FrameMaterial/French/text()',
-    })
+        'glazing_types_english': 'Layers/GlazingTypes/English/text()',
+        'glazing_types_french': 'Layers/GlazingTypes/French/text()',
+        'coatings_tints_english': 'Layers/CoatingsTints/English/text()',
+        'coatings_tints_french': 'Layers/CoatingsTints/French/text()',
+        'fill_type_english': 'Layers/FillType/English/text()',
+        'fill_type_french': 'Layers/FillType/French/text()',
+        'spacer_type_english': 'Layers/SpacerType/English/text()',
+        'spacer_type_french': 'Layers/SpacerType/French/text()',
+        'type_english': 'Layers/Type/English/text()',
+        'type_french': 'Layers/Type/French/text()',
+        'frame_material_english': 'Layers/FrameMaterial/English/text()',
+        'frame_material_french': 'Layers/FrameMaterial/French/text()',
+    }))
 
 
 def snip_codes(codes: etree._Element
-              ) -> typing.Dict[str, typing.Dict[str, typing.List[typing.Dict[str, typing.Optional[str]]]]]:
+              ) -> Codes:
     wall_codes = codes.xpath('Wall/*/Code')
     window_codes = codes.xpath('Window/*/Code')
 
-    return {
-        'codes': {
-            'wall': [_wall_code_snippet(node) for node in wall_codes],
-            'window': [_window_code_snippet(node) for node in window_codes],
-        }
-    }
+    return Codes(
+        wall=[_wall_code_snippet(node) for node in wall_codes],
+        window=[_window_code_snippet(node) for node in window_codes],
+    )

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -251,10 +251,8 @@ def sample_input_d(ceiling_input: reader.InputData,
         'windows': [
             window_input
         ],
-        'heatedFloorArea': [
-            heated_floor_area_input
-        ],
         'heating_cooling': heating_cooling_input,
+        'heatedFloorArea': heated_floor_area_input,
 
         'codes': raw_codes,
     }
@@ -398,12 +396,10 @@ class TestParsedDwellingDataRow:
                     height=1.3220699,
                 )
             ],
-            heated_floor_area=[
-                extracted_datatypes.HeatedFloorArea(
-                    area_above_grade=185.8,
-                    area_below_grade=92.9,
-                )
-            ],
+            heated_floor_area=extracted_datatypes.HeatedFloorArea(
+                area_above_grade=185.8,
+                area_below_grade=92.9,
+            ),
         )
 
     def test_bad_postal_code(self, sample_input_d: reader.InputData) -> None:

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -28,9 +28,21 @@ def code(doc: etree._ElementTree) -> etree._Element:
 
 def test_ceiling_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert 'ceilings' in output
-    assert len(output['ceilings']) == 2
-    assert output['ceilings'][0] == {
+    assert len(output.ceilings) == 2
+    assert output.ceilings[0] == snippets.CeilingSnippet(
+        label='Main attic',
+        type_english='Attic/gable',
+        type_french='Combles/pignon',
+        nominal_rsi='2.864',
+        effective_rsi='2.9463',
+        area='46.4515',
+        length='23.875',
+    )
+
+
+def test_ceiling_snippet_to_dict(house: etree._Element) -> None:
+    output = snippets.snip_house(house)
+    assert output.ceilings[0].to_dict() == {
         'label': 'Main attic',
         'typeEnglish': 'Attic/gable',
         'typeFrench': 'Combles/pignon',
@@ -43,9 +55,19 @@ def test_ceiling_snippet(house: etree._Element) -> None:
 
 def test_floor_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert 'floors' in output
-    assert len(output['floors']) == 1
-    assert output['floors'][0] == {
+    assert len(output.floors) == 1
+    assert output.floors[0] == snippets.FloorSnippet(
+        label='Rm over garage',
+        nominal_rsi='2.11',
+        effective_rsi='2.61',
+        area='9.2903',
+        length='3.048',
+    )
+
+
+def test_floor_snippet_to_dict(house: etree._Element) -> None:
+    output = snippets.snip_house(house)
+    assert output.floors[0].to_dict() == {
         'label': 'Rm over garage',
         'nominalRsi': '2.11',
         'effectiveRsi': '2.61',
@@ -56,9 +78,21 @@ def test_floor_snippet(house: etree._Element) -> None:
 
 def test_wall_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert 'walls' in output
-    assert len(output['walls']) == 3
-    assert sorted(output['walls'], key=lambda row: row['label'])[0] == {
+    assert len(output.walls) == 3
+    assert sorted(output.walls, key=lambda row: row.label)[0] == snippets.WallSnippet(
+        label='End Wall',
+        construction_type_code='Code 1',
+        construction_type_value='1201101121',
+        effective_rsi='1.7435',
+        nominal_rsi='1.432',
+        perimeter='7.367',
+        height='1.2283',
+    )
+
+
+def test_wall_snippet_to_dict(house: etree._Element) -> None:
+    output = snippets.snip_house(house)
+    assert sorted(output.walls, key=lambda row: row.label)[0].to_dict() == {
         'label': 'End Wall',
         'constructionTypeCode': 'Code 1',
         'constructionTypeValue': '1201101121',
@@ -71,9 +105,20 @@ def test_wall_snippet(house: etree._Element) -> None:
 
 def test_window_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert 'windows' in output
-    assert len(output['windows']) == 10
-    assert sorted(output['windows'], key=lambda row: row['label'])[0] == {
+    assert len(output.windows) == 10
+    assert sorted(output.windows, key=lambda row: row.label)[0] == snippets.WindowSnippet(
+        label='East0001',
+        construction_type_code='Code 12',
+        construction_type_value='234002',
+        rsi='0.4779',
+        height='1967.738',
+        width='1322.0699',
+    )
+
+
+def test_window_snippet_to_dict(house: etree._Element) -> None:
+    output = snippets.snip_house(house)
+    assert sorted(output.windows, key=lambda row: row.label)[0].to_dict() == {
         'label': 'East0001',
         'constructionTypeCode': 'Code 12',
         'constructionTypeValue': '234002',
@@ -85,9 +130,16 @@ def test_window_snippet(house: etree._Element) -> None:
 
 def test_heated_floor_area_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert 'heatedFloorArea' in output
-    assert output['heatedFloorArea'][0]['aboveGrade'] == '185.8'
-    assert output['heatedFloorArea'][0]['belowGrade'] == '92.9'
+    assert output.heated_floor_area.above_grade == '185.8'
+    assert output.heated_floor_area.below_grade == '92.9'
+
+
+def test_heated_floor_area_snippet_to_dict(house: etree._Element) -> None:
+    output = snippets.snip_house(house).heated_floor_area.to_dict()
+    assert output == {
+        'aboveGrade': '185.8',
+        'belowGrade': '92.9'
+    }
 
 
 def test_user_specified_wall_snippet() -> None:
@@ -104,23 +156,24 @@ def test_user_specified_wall_snippet() -> None:
 
     doc = etree.fromstring(xml_text)
     output = snippets.snip_house(doc)
-    assert output == {
-        'ceilings': [],
-        'floors': [],
-        'windows': [],
-        'walls': [{
-            'label': 'Test Floor',
-            'constructionTypeCode': None,
-            'constructionTypeValue': 'User specified',
-            'nominalRsi': '3.3615',
-            'effectiveRsi': '2.6892',
-            'perimeter': None,
-            'height': None,
-        }],
-        'doors': [],
-        'heatedFloorArea': [],
-        'heating_cooling': None,
-    }
+
+    assert output == snippets.HouseSnippet(
+        ceilings=[],
+        floors=[],
+        windows=[],
+        walls=[snippets.WallSnippet(
+            label='Test Floor',
+            construction_type_code=None,
+            construction_type_value='User specified',
+            nominal_rsi='3.3615',
+            effective_rsi='2.6892',
+            perimeter=None,
+            height=None,
+        )],
+        doors=[],
+        heated_floor_area=None,
+        heating_cooling=None,
+    )
 
 
 def test_deeply_embedded_components() -> None:
@@ -187,32 +240,38 @@ def test_deeply_embedded_components() -> None:
 
     doc = etree.fromstring(xml_text)
     output = snippets.snip_house(doc)
-    assert len(output['windows']) == 2
-    assert len(output['doors']) == 2
+    assert len(output.windows) == 2
+    assert len(output.doors) == 2
 
 
-def test_wall_code_snippet(code: etree._Element) -> None:
+def test_wall_code_snippet_to_dict(code: etree._Element) -> None:
     output = snippets.snip_codes(code)
-    assert output['codes']['wall'] == [{
+    assert sorted(output.wall, key=lambda row: row.label)[0].to_dict() == {
         'id': 'Code 1',
         'label': '1201101121',
         'structureTypeEnglish': 'Wood frame',
         'structureTypeFrench': 'Ossature de bois',
         'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
         'componentTypeSizeFrench': '38x89 (2x4)',
-    }, {
-        'id': 'Code 2',
-        'label': '1201401121',
-        'structureTypeEnglish': 'Wood frame',
-        'structureTypeFrench': 'Ossature de bois',
-        'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-        'componentTypeSizeFrench': '38x89 (2x4)',
-    }]
+    }
 
 
-def test_window_code_snippet(code: etree._Element) -> None:
+def test_wall_code_snippet(code: etree._Element) -> None:
     output = snippets.snip_codes(code)
-    assert sorted(output['codes']['window'], key=lambda row: row['label'])[0] == {
+    assert len(output.wall) == 2
+    assert sorted(output.wall, key=lambda row: row.label)[0] == snippets.WallCodeSnippet(
+        identifier='Code 1',
+        label='1201101121',
+        structure_type_english='Wood frame',
+        structure_type_french='Ossature de bois',
+        component_type_size_english='38x89 mm (2x4 in)',
+        component_type_size_french='38x89 (2x4)',
+    )
+
+
+def test_window_code_snippet_to_dict(code: etree._Element) -> None:
+    output = snippets.snip_codes(code)
+    assert sorted(output.window, key=lambda row: row.label)[0].to_dict() == {
         'id': 'Code 11',
         'label': '202002',
         'glazingTypesEnglish': 'Double/double with 1 coat',
@@ -229,24 +288,43 @@ def test_window_code_snippet(code: etree._Element) -> None:
         'frameMaterialFrench': 'Bois',
     }
 
+def test_window_code_snippet(code: etree._Element) -> None:
+    output = snippets.snip_codes(code)
+    assert sorted(output.window, key=lambda row: row.label)[0] == snippets.WindowCodeSnippet(
+        identifier='Code 11',
+        label='202002',
+        glazing_types_english='Double/double with 1 coat',
+        glazing_types_french='Double/double, 1 couche',
+        coatings_tints_english='Clear',
+        coatings_tints_french='Transparent',
+        fill_type_english='6 mm Air',
+        fill_type_french="6 mm d'air",
+        spacer_type_english='Metal',
+        spacer_type_french='Métal',
+        type_english='Picture',
+        type_french='Fixe',
+        frame_material_english='Wood',
+        frame_material_french='Bois',
+    )
+
 
 def test_door_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    doors_output = sorted(output['doors'], key=lambda x: x['label'])
+    doors_output = sorted(output.doors, key=lambda x: x.label)
     assert len(doors_output) == 2
-    assert doors_output[0] == {
-        'label': 'Back door',
-        'typeEnglish': 'Solid wood',
-        'typeFrench': 'Bois massif',
-        'rsi': '0.39',
-        'height': '1.9799',
-        'width': '0.8499',
-    }
+    assert doors_output[0] == snippets.DoorSnippet(
+        label='Back door',
+        type_english='Solid wood',
+        type_french='Bois massif',
+        rsi='0.39',
+        height='1.9799',
+        width='0.8499',
+    )
 
 
 def test_heating_cooling_snippet(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    doc = etree.fromstring(output['heating_cooling'])
+    doc = etree.fromstring(output.heating_cooling)
     child_tags = {node.tag for node in doc}
     assert 'Label' in child_tags
     assert len(child_tags) == 6


### PR DESCRIPTION
This PR refactors the snippets module to replace the dictionaries with NamedTuples to allow for more strict static type checking

This PR is larger than I would like, but the majority of it are things like class definitions, which does inflate the line count.