### PR TITLE
Handle different data types handed to filters

### DIFF
--- a/api/src/utilities.js
+++ b/api/src/utilities.js
@@ -27,21 +27,32 @@ export function createQuery(fsa, filter) {
   }
 
   // { field: 'yearBuilt', gt: '1990' }
-  // XXX: not all fields are integers.
+  // TODO: DRY this up.
   if (filter) {
+    let value
+
     if (filter.gt) {
+      if (filter.gt.match(/^-?\d+\.?\d+$/)) {
+        value = parseFloat(filter.gt)
+      }
       query['$and'].push({
-        [filter.field]: { [comparators.gt]: parseInt(filter.gt) },
+        [filter.field]: { [comparators.gt]: value || filter.gt },
       })
     }
     if (filter.lt) {
+      if (filter.lt.match(/^-?\d+\.?\d+$/)) {
+        value = parseFloat(filter.lt)
+      }
       query['$and'].push({
-        [filter.field]: { [comparators.lt]: parseInt(filter.lt) },
+        [filter.field]: { [comparators.lt]: value || filter.lt },
       })
     }
     if (filter.eq) {
+      if (filter.eq.match(/^-?\d+\.?\d+$/)) {
+        value = parseFloat(filter.eq)
+      }
       query['$and'].push({
-        [filter.field]: { [comparators.eq]: parseInt(filter.eq) },
+        [filter.field]: { [comparators.eq]: value || filter.eq },
       })
     }
   }

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -76,6 +76,25 @@ describe('queries', () => {
           let { dwellings } = response.body.data
           expect(dwellings.length).toEqual(0)
         })
+
+        it('works on string fields', async () => {
+          let response = await request(server)
+            .post('/graphql')
+            .set('Content-Type', 'application/json; charset=utf-8')
+            .send({
+              query: `{
+                 dwellings:dwellingsInFSA(
+                  forwardSortationArea: "C1A"
+                  filter: {field: city eq: "Charlottetown"}
+                 ) {
+                   yearBuilt
+                 }
+               }`,
+            })
+
+          let { dwellings: [first] } = response.body.data
+          expect(first.yearBuilt).toEqual(1900)
+        })
       })
 
       describe('lt: less than', () => {


### PR DESCRIPTION
Filter values are passed as strings. This commit converts the value to the appropriate data type so mongo can find things.
There is some repeated logic here, but we are going to loop back and DRY it up shortly.