### PR TITLE
expose _Element.attrib

### DIFF
--- a/python/src/energuide/element.py
+++ b/python/src/energuide/element.py
@@ -15,6 +15,10 @@ class Element:
     def findtext(self, *args, **kwargs) -> typing.Optional[str]:
         return self.__node.findtext(*args, **kwargs)
 
+    @property
+    def attrib(self) -> typing.Dict[str, typing.Any]:
+        return self.__node.attrib
+
     def xpath(self, *args, **kwargs) -> typing.List[typing.Any]:
         output = self.__node.xpath(*args, **kwargs)
         return [Element(node) if isinstance(node, etree._Element) else node for node in output]


### PR DESCRIPTION
Exposes `_Element.attrib` through `element.Element`, to allow us to replace calls like:
```
node.xpath('@foo')[0]
```
with
```
node.attrib['foo']
```
