### PR TITLE
Water heating extraction

### DIFF
--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -32,7 +32,8 @@ DROP_FIELDS = ['ENTRYBY',
 REQUIRED_FIELDS = DROP_FIELDS + [
     'EVAL_ID',
     'EVAL_TYPE',
-    'BUILDER'
+    'BUILDER',
+    'DHWHPCOP',
 ]
 
 _SCHEMA = {field: {'type': 'string', 'required': True} for field in REQUIRED_FIELDS}

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -27,6 +27,7 @@ class _HouseSnippet(typing.NamedTuple):
     heated_floor_area: str
     heating_cooling: str
     ventilation: typing.List[str]
+    water_heating: typing.List[str]
 
 
 class HouseSnippet(_HouseSnippet):
@@ -41,6 +42,7 @@ class HouseSnippet(_HouseSnippet):
             'heatedFloorArea': self.heated_floor_area,
             'heating_cooling': self.heating_cooling,
             'ventilations': self.ventilation,
+            'waterHeating': self.water_heating,
         }
 
 
@@ -64,6 +66,10 @@ def snip_house(house: etree._Element) -> HouseSnippet:
     ventilation = house.xpath('Ventilation/WholeHouseVentilatorList/Hrv')
     ventilation_strings = [etree.tostring(hrv, encoding='unicode') for hrv in ventilation]
 
+    water_heating = house.xpath('Components/HotWater/*[self::Primary or self::Secondary]')
+    water_heating_strings = [etree.tostring(hot_water, encoding='unicode') for hot_water in water_heating]
+
+
     return HouseSnippet(
         ceilings=[etree.tostring(node, encoding='unicode') for node in ceilings],
         floors=[etree.tostring(node, encoding='unicode') for node in floors],
@@ -73,6 +79,7 @@ def snip_house(house: etree._Element) -> HouseSnippet:
         heated_floor_area=etree.tostring(heated_floor_area[0], encoding='unicode') if heated_floor_area else None,
         heating_cooling=heating_cooling_string,
         ventilation=ventilation_strings,
+        water_heating=water_heating_strings,
     )
 
 

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -66,8 +66,10 @@ def snip_house(house: etree._Element) -> HouseSnippet:
     ventilation = house.xpath('Ventilation/WholeHouseVentilatorList/Hrv')
     ventilation_strings = [etree.tostring(hrv, encoding='unicode') for hrv in ventilation]
 
-    water_heating = house.xpath('Components/HotWater/*[self::Primary or self::Secondary]')
-    water_heating_strings = [etree.tostring(hot_water, encoding='unicode') for hot_water in water_heating]
+    water_heating = house.xpath('Components/HotWater')
+    water_heating_string = (
+        etree.tostring(water_heating[0], encoding='unicode') if water_heating else None
+    )
 
 
     return HouseSnippet(
@@ -79,7 +81,7 @@ def snip_house(house: etree._Element) -> HouseSnippet:
         heated_floor_area=etree.tostring(heated_floor_area[0], encoding='unicode') if heated_floor_area else None,
         heating_cooling=heating_cooling_string,
         ventilation=ventilation_strings,
-        water_heating=water_heating_strings,
+        water_heating=water_heating_string,
     )
 
 

--- a/python/tests/sample.h2k
+++ b/python/tests/sample.h2k
@@ -825,6 +825,32 @@
                         <French>Sous-sol</French>
                     </TankLocation>
                 </Primary>
+                <Secondary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="76.2" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0" pilotEnergy="0">
+                    <EquipmentInformation>
+                        <Manufacturer>Wizard DHW man</Manufacturer>
+                        <Model>Wizard DHW mod</Model>
+                    </EquipmentInformation>
+                    <EnergySource code="2">
+                        <English>Natural gas</English>
+                        <French>Gaz naturel</French>
+                    </EnergySource>
+                    <TankType code="2">
+                        <English>Conventional tank</English>
+                        <French>Réservoir classique</French>
+                    </TankType>
+                    <TankVolume code="3" value="151.4">
+                        <English>151.4 L, 33.3 Imp, 40 US gal</English>
+                        <French>151.4 L, 33.3 imp, 40 gal ÉU</French>
+                    </TankVolume>
+                    <EnergyFactor code="2" value="0.554" inputCapacity="0">
+                        <English>User specified</English>
+                        <French>Spécifié par l'utilisateur</French>
+                    </EnergyFactor>
+                    <TankLocation code="2">
+                        <English>Basement</English>
+                        <French>Sous-sol</French>
+                    </TankLocation>
+                </Secondary>
             </HotWater>
             <Crawlspace isExposedSurface="true" exposedSurfacePerimeter="9.144" id="29">
                 <Label>Crawl</Label>

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -23,6 +23,7 @@ def data1() -> typing.Dict[str, typing.Optional[str]]:
         'TAXNUMBER': '999999999999',
         'RAW_XML': '<tag>thing</tag>',
         'BUILDER': '4K13D01404',
+        'DHWHPCOP': '0',
         'INFO1': None,
         'INFO2': None,
         'INFO3': None,

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -22,6 +22,7 @@ def data1() -> typing.Dict[str, typing.Optional[str]]:
         'TAXNUMBER': '999999999999',
         'RAW_XML': '<tag>thing</tag>',
         'BUILDER': '4K13D01404',
+        'DHWHPCOP': '0',
         'INFO1': None,
         'INFO2': None,
         'INFO3': None,

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -203,5 +203,5 @@ def test_water_heating(house: etree._Element) -> None:
     }, allow_unknown=True)
     doc = {'water_heating': output.water_heating}
     assert checker.validate(doc)
-    for water_heating in checker.document['water_heating']:
-        assert water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
+    assert all([water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
+                for water_heating in checker.document['water_heating']])

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -197,11 +197,9 @@ def test_ventilation_snippet(house: etree._Element) -> None:
 
 def test_water_heating(house: etree._Element) -> None:
     output = snippets.snip_house(house)
-    assert len(output.water_heating) == 2
-    checker = validator.DwellingValidator({
-        'water_heating': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
-    }, allow_unknown=True)
-    doc = {'water_heating': output.water_heating}
-    assert checker.validate(doc)
+    doc = etree.fromstring(output.water_heating)
+    nodes = doc.xpath('*[self::Primary or self::Secondary]')
+    assert len(nodes) == 2
+
     assert all([water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
-                for water_heating in checker.document['water_heating']])
+                for water_heating in nodes])

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -29,7 +29,7 @@ def code(doc: etree._ElementTree) -> etree._Element:
 
 def test_house_snippet_to_dict(house: etree._Element) -> None:
     output = snippets.snip_house(house).to_dict()
-    assert len(output) == 8
+    assert len(output) == 9
 
 
 def test_ceiling_snippet(house: etree._Element) -> None:
@@ -193,3 +193,15 @@ def test_ventilation_snippet(house: etree._Element) -> None:
     child_tags = {node.tag for node in doc}
     assert 'VentilatorType' in child_tags
     assert len(child_tags) == 3
+
+
+def test_water_heating(house: etree._Element) -> None:
+    output = snippets.snip_house(house)
+    assert len(output.water_heating) == 2
+    checker = validator.DwellingValidator({
+        'water_heating': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
+    }, allow_unknown=True)
+    doc = {'water_heating': output.water_heating}
+    assert checker.validate(doc)
+    for water_heating in checker.document['water_heating']:
+        assert water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'


### PR DESCRIPTION
This PR adds functionality for as much water heating extraction as we currently have the information to do.

There exists a property in the `Primary` and `Secondary` water heater nodes (`hasDrainWaterHeatRecovery`) which indicates that an additional row is to be extracted from this node. We do not have the required information to know what that node looks like until we get more sample data that has an example of it. As such that is not being extracted.

An assertion to the water_heating extraction test is to indicate this field is `"false"`, when we have data that has these extra rows it will fail the tests and we can add in the required functionality.

https://trello.com/c/pqClWxf9/110-extract-load-water-heating-data