### PR TITLE
refactor wall and window codes transformation logic out of extractor

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -94,6 +94,9 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
 
 class ParsedDwellingDataRow(_ParsedDwellingDataRow):
 
+    _XML_SCHEMA = {'type': 'xml', 'coerce': 'parse_xml'}
+    _XML_LIST_SCHEMA = {'type': 'list', 'required': True, 'schema': _XML_SCHEMA}
+
     _SCHEMA = {
         'EVAL_ID': {'type': 'integer', 'required': True, 'coerce': int},
         'EVAL_TYPE': {'type': 'string', 'required': True, 'allowed': [eval_type.value for eval_type in EvaluationType]},
@@ -105,16 +108,16 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'forwardSortationArea': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z]'},
         'HOUSEREGION': {'type': 'string', 'required': True},
 
-        'ceilings': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
-        'floors': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
-        'walls': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
-        'doors': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
-        'windows': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
-        'heatedFloorArea': {'type': 'xml', 'coerce': 'parse_xml'},
+        'ceilings': _XML_LIST_SCHEMA,
+        'floors': _XML_LIST_SCHEMA,
+        'walls': _XML_LIST_SCHEMA,
+        'doors': _XML_LIST_SCHEMA,
+        'windows': _XML_LIST_SCHEMA,
+        'heatedFloorArea': _XML_SCHEMA,
         'heating_cooling': {'type': 'xml', 'required': True, 'coerce': 'parse_xml'},
-        'ventilations': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}},
+        'ventilations': _XML_LIST_SCHEMA,
 
-        'codes': Codes.SCHEMA,
+        'codes': {'type': 'dict', 'required': True, 'schema': {'wall': _XML_LIST_SCHEMA, 'window': _XML_LIST_SCHEMA}},
     }
 
     @classmethod

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -74,11 +74,11 @@ class _Ventilation(typing.NamedTuple):
 
 class _WallCode(typing.NamedTuple):
     identifier: str
-    label: typing.Optional[str]
-    structure_type_english: typing.Optional[str]
-    structure_type_french: typing.Optional[str]
-    component_type_size_english: typing.Optional[str]
-    component_type_size_french: typing.Optional[str]
+    label: str
+    structure_type_english: str
+    structure_type_french: str
+    component_type_size_english: str
+    component_type_size_french: str
 
 
 class _WindowCode(typing.NamedTuple):
@@ -107,77 +107,37 @@ _MILLIMETRES_TO_METRES = 1000
 
 class WallCode(_WallCode):
 
-    SCHEMA = {
-        'type': 'list',
-        'required': True,
-        'schema': {
-            'type': 'dict',
-            'schema': {
-                'id': {'type': 'string', 'required': True},
-                'label': {'type': 'string', 'required': True, 'nullable': True},
-                'structureTypeEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'structureTypeFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'componentTypeSizeEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'componentTypeSizeFrench': {'type': 'string', 'required': True, 'nullable': True},
-            }
-        }
-    }
-
     @classmethod
-    def from_data(cls, wall_code: typing.Dict[str, typing.Optional[str]]) -> 'WallCode':
+    def from_data(cls, wall_code: element.Element) -> 'WallCode':
         return WallCode(
-            identifier=wall_code['id'],
-            label=wall_code['label'],
-            structure_type_english=wall_code['structureTypeEnglish'],
-            structure_type_french=wall_code['structureTypeFrench'],
-            component_type_size_english=wall_code['componentTypeSizeEnglish'],
-            component_type_size_french=wall_code['componentTypeSizeFrench'],
+            identifier=wall_code.attrib['id'],
+            label=wall_code.findtext('Label'),
+            structure_type_english=wall_code.findtext('Layers/StructureType/English'),
+            structure_type_french=wall_code.findtext('Layers/StructureType/French'),
+            component_type_size_english=wall_code.findtext('Layers/ComponentTypeSize/English'),
+            component_type_size_french=wall_code.findtext('Layers/ComponentTypeSize/French'),
         )
 
 
 class WindowCode(_WindowCode):
 
-    SCHEMA = {
-        'type': 'list',
-        'required': True,
-        'schema': {
-            'type': 'dict',
-            'schema': {
-                'id':  {'type': 'string', 'required': True},
-                'label': {'type': 'string', 'required': True, 'nullable': True},
-                'glazingTypesEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'glazingTypesFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'coatingsTintsEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'coatingsTintsFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'fillTypeEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'fillTypeFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'spacerTypeEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'spacerTypeFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'typeEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'typeFrench': {'type': 'string', 'required': True, 'nullable': True},
-                'frameMaterialEnglish': {'type': 'string', 'required': True, 'nullable': True},
-                'frameMaterialFrench': {'type': 'string', 'required': True, 'nullable': True},
-            }
-        }
-    }
-
     @classmethod
-    def from_data(cls, wall_code: typing.Dict[str, typing.Optional[str]]) -> 'WindowCode':
+    def from_data(cls, window_code: element.Element) -> 'WindowCode':
         return WindowCode(
-            identifier=wall_code['id'],
-            label=wall_code['label'],
-            glazing_types_english=wall_code['glazingTypesEnglish'],
-            glazing_types_french=wall_code['glazingTypesFrench'],
-            coatings_tints_english=wall_code['coatingsTintsEnglish'],
-            coatings_tints_french=wall_code['coatingsTintsFrench'],
-            fill_type_english=wall_code['fillTypeEnglish'],
-            fill_type_french=wall_code['fillTypeFrench'],
-            spacer_type_english=wall_code['spacerTypeEnglish'],
-            spacer_type_french=wall_code['spacerTypeFrench'],
-            type_english=wall_code['typeEnglish'],
-            type_french=wall_code['typeFrench'],
-            frame_material_english=wall_code['frameMaterialEnglish'],
-            frame_material_french=wall_code['frameMaterialFrench'],
+            identifier=window_code.attrib['id'],
+            label=window_code.findtext('Label'),
+            glazing_types_english=window_code.findtext('Layers/GlazingTypes/English'),
+            glazing_types_french=window_code.findtext('Layers/GlazingTypes/French'),
+            coatings_tints_english=window_code.findtext('Layers/CoatingsTints/English'),
+            coatings_tints_french=window_code.findtext('Layers/CoatingsTints/French'),
+            fill_type_english=window_code.findtext('Layers/FillType/English'),
+            fill_type_french=window_code.findtext('Layers/FillType/French'),
+            spacer_type_english=window_code.findtext('Layers/SpacerType/English'),
+            spacer_type_french=window_code.findtext('Layers/SpacerType/French'),
+            type_english=window_code.findtext('Layers/Type/English'),
+            type_french=window_code.findtext('Layers/Type/French'),
+            frame_material_english=window_code.findtext('Layers/FrameMaterial/English'),
+            frame_material_french=window_code.findtext('Layers/FrameMaterial/French'),
         )
 
 
@@ -188,19 +148,10 @@ class _Codes(typing.NamedTuple):
 
 class Codes(_Codes):
 
-    SCHEMA = {
-        'type': 'dict',
-        'required': True,
-        'schema': {
-            'wall': WallCode.SCHEMA,
-            'window': WindowCode.SCHEMA,
-        }
-    }
-
     @classmethod
-    def from_data(cls, codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]):
-        wall_code_list = (WallCode.from_data(wall_code) for wall_code in codes['wall'])
-        window_code_list = (WindowCode.from_data(window_code) for window_code in codes['window'])
+    def from_data(cls, codes: typing.Dict[str, typing.List[element.Element]]) -> 'Codes':
+        wall_code_list = [WallCode.from_data(wall_code) for wall_code in codes['wall']]
+        window_code_list = [WindowCode.from_data(window_code) for window_code in codes['window']]
 
         wall_codes = {wall_code.identifier: wall_code for wall_code in wall_code_list}
         window_codes = {window_code.identifier: window_code for window_code in window_code_list}

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -2,78 +2,18 @@ import typing
 from lxml import etree
 
 
-class _WallCodeSnippet(typing.NamedTuple):
-    identifier: str
-    label: typing.Optional[str]
-    structure_type_english: typing.Optional[str]
-    structure_type_french: typing.Optional[str]
-    component_type_size_english: typing.Optional[str]
-    component_type_size_french: typing.Optional[str]
-
-
-class _WindowCodeSnippet(typing.NamedTuple):
-    identifier: str
-    label: typing.Optional[str]
-    glazing_types_english: typing.Optional[str]
-    glazing_types_french: typing.Optional[str]
-    coatings_tints_english: typing.Optional[str]
-    coatings_tints_french: typing.Optional[str]
-    fill_type_english: typing.Optional[str]
-    fill_type_french: typing.Optional[str]
-    spacer_type_english: typing.Optional[str]
-    spacer_type_french: typing.Optional[str]
-    type_english: typing.Optional[str]
-    type_french: typing.Optional[str]
-    frame_material_english: typing.Optional[str]
-    frame_material_french: typing.Optional[str]
-
-
-class WallCodeSnippet(_WallCodeSnippet):
-
-    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
-        return {
-            'id': self.identifier,
-            'label': self.label,
-            'structureTypeEnglish': self.structure_type_english,
-            'structureTypeFrench': self.structure_type_french,
-            'componentTypeSizeEnglish': self.component_type_size_english,
-            'componentTypeSizeFrench': self.component_type_size_french,
-        }
-
-
-class WindowCodeSnippet(_WindowCodeSnippet):
-
-    def to_dict(self) -> typing.Dict[str, typing.Optional[str]]:
-        return {
-            'id': self.identifier,
-            'label': self.label,
-            'glazingTypesEnglish': self.glazing_types_english,
-            'glazingTypesFrench': self.glazing_types_french,
-            'coatingsTintsEnglish': self.coatings_tints_english,
-            'coatingsTintsFrench': self.coatings_tints_french,
-            'fillTypeEnglish': self.fill_type_english,
-            'fillTypeFrench': self.fill_type_french,
-            'spacerTypeEnglish': self.spacer_type_english,
-            'spacerTypeFrench': self.spacer_type_french,
-            'typeEnglish': self.type_english,
-            'typeFrench': self.type_french,
-            'frameMaterialEnglish': self.frame_material_english,
-            'frameMaterialFrench': self.frame_material_french,
-        }
-
-
 class _Codes(typing.NamedTuple):
-    wall: typing.List[WallCodeSnippet]
-    window: typing.List[WindowCodeSnippet]
+    wall: typing.List[str]
+    window: typing.List[str]
 
 
 class Codes(_Codes):
 
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
+    def to_dict(self) -> typing.Dict[str, typing.Dict[str, typing.List[str]]]:
         return {
             'codes': {
-                'wall': [wall.to_dict() for wall in self.wall],
-                'window': [window.to_dict() for window in self.window],
+                'wall': self.wall,
+                'window': self.window,
             }
         }
 
@@ -136,35 +76,6 @@ def snip_house(house: etree._Element) -> HouseSnippet:
     )
 
 
-def _wall_code_snippet(wall_code: etree._Element) -> WallCodeSnippet:
-    return WallCodeSnippet(**_extract_values(wall_code, {
-        'identifier': '@id',
-        'label': 'Label/text()',
-        'structure_type_english': 'Layers/StructureType/English/text()',
-        'structure_type_french': 'Layers/StructureType/French/text()',
-        'component_type_size_english': 'Layers/ComponentTypeSize/English/text()',
-        'component_type_size_french': 'Layers/ComponentTypeSize/French/text()',
-    }))
-
-
-def _window_code_snippet(window_code: etree._Element) -> WindowCodeSnippet:
-    return WindowCodeSnippet(**_extract_values(window_code, {
-        'identifier': '@id',
-        'label': 'Label/text()',
-        'glazing_types_english': 'Layers/GlazingTypes/English/text()',
-        'glazing_types_french': 'Layers/GlazingTypes/French/text()',
-        'coatings_tints_english': 'Layers/CoatingsTints/English/text()',
-        'coatings_tints_french': 'Layers/CoatingsTints/French/text()',
-        'fill_type_english': 'Layers/FillType/English/text()',
-        'fill_type_french': 'Layers/FillType/French/text()',
-        'spacer_type_english': 'Layers/SpacerType/English/text()',
-        'spacer_type_french': 'Layers/SpacerType/French/text()',
-        'type_english': 'Layers/Type/English/text()',
-        'type_french': 'Layers/Type/French/text()',
-        'frame_material_english': 'Layers/FrameMaterial/English/text()',
-        'frame_material_french': 'Layers/FrameMaterial/French/text()',
-    }))
-
 
 def snip_codes(codes: etree._Element
               ) -> Codes:
@@ -172,6 +83,6 @@ def snip_codes(codes: etree._Element
     window_codes = codes.xpath('Window/*/Code')
 
     return Codes(
-        wall=[_wall_code_snippet(node) for node in wall_codes],
-        window=[_window_code_snippet(node) for node in window_codes],
+        wall=[etree.tostring(node, encoding='unicode') for node in wall_codes],
+        window=[etree.tostring(node, encoding='unicode') for node in window_codes],
     )

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -220,58 +220,105 @@ def ventilation_input() -> typing.List[str]:
     """
     return [doc]
 
+
 @pytest.fixture
-def raw_codes() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
+def raw_codes() -> typing.Dict[str, typing.List[str]]:
     return {
         'wall': [
-            {
-                'id': 'Code 1',
-                'label': '1201101121',
-                'structureTypeEnglish': 'Wood frame',
-                'structureTypeFrench': 'Ossature de bois',
-                'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-                'componentTypeSizeFrench': '38x89 (2x4)',
-            }, {
-                'id': 'Code 2',
-                'label': '1201101122',
-                'structureTypeEnglish': 'Metal frame',
-                'structureTypeFrench': 'Ossature de métal',
-                'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-                'componentTypeSizeFrench': '38x89 (2x4)',
-            }
+            """
+            <Code id='Code 1'>
+                <Label>1201101121</Label>
+                <Layers>
+                    <StructureType>
+                        <English>Wood frame</English>
+                        <French>Ossature de bois</French>
+                    </StructureType>
+                    <ComponentTypeSize>
+                        <English>38x89 mm (2x4 in)</English>
+                        <French>38x89 (2x4)</French>
+                    </ComponentTypeSize>
+                </Layers>
+            </Code>
+            """,
+            """
+            <Code id='Code 2'>
+                <Label>1201101121</Label>
+                <Layers>
+                    <StructureType>
+                        <English>Metal frame</English>
+                        <French>Ossature de métal</French>
+                    </StructureType>
+                    <ComponentTypeSize>
+                        <English>38x89 mm (2x4 in)</English>
+                        <French>38x89 (2x4)</French>
+                    </ComponentTypeSize>
+                </Layers>
+            </Code>
+            """,
         ],
         'window': [
-            {
-                'id': 'Code 11',
-                'label': '202002',
-                'glazingTypesEnglish': 'Double/double with 1 coat',
-                'glazingTypesFrench': 'Double/double, 1 couche',
-                'coatingsTintsEnglish': 'Clear',
-                'coatingsTintsFrench': 'Transparent',
-                'fillTypeEnglish': '6 mm Air',
-                'fillTypeFrench': "6 mm d'air",
-                'spacerTypeEnglish': 'Metal',
-                'spacerTypeFrench': 'Métal',
-                'typeEnglish': 'Picture',
-                'typeFrench': 'Fixe',
-                'frameMaterialEnglish': 'Wood',
-                'frameMaterialFrench': 'Bois',
-            }, {
-                'id': 'Code 12',
-                'label': '234002',
-                'glazingTypesEnglish': 'Double/double with 1 coat',
-                'glazingTypesFrench': 'Double/double, 1 couche',
-                'coatingsTintsEnglish': 'Low-E .20 (hard1)',
-                'coatingsTintsFrench': 'Faible E .20 (Dur 1)',
-                'fillTypeEnglish': '9 mm Argon',
-                'fillTypeFrench': "9 mm d'argon",
-                'spacerTypeEnglish': 'Metal',
-                'spacerTypeFrench': 'Métal',
-                'typeEnglish': 'Picture',
-                'typeFrench': 'Fixe',
-                'frameMaterialEnglish': 'Wood',
-                'frameMaterialFrench': 'Bois',
-            }
+            """
+            <Code id='Code 11'>
+                <Label>202002</Label>
+                <Layers>
+                    <GlazingTypes>
+                        <English>Double/double with 1 coat</English>
+                        <French>Double/double, 1 couche</French>
+                    </GlazingTypes>
+                    <CoatingsTints>
+                        <English>Clear</English>
+                        <French>Transparent</French>
+                    </CoatingsTints>
+                    <FillType>
+                        <English>6 mm Air</English>
+                        <French>6 mm d'air</French>
+                    </FillType>
+                    <SpacerType>
+                        <English>Metal</English>
+                        <French>Métal</French>
+                    </SpacerType>
+                    <Type>
+                        <English>Picture</English>
+                        <French>Fixe</French>
+                    </Type>
+                    <FrameMaterial>
+                        <English>Wood</English>
+                        <French>Bois</French>
+                    </FrameMaterial>
+                </Layers>
+            </Code>
+            """,
+            """
+            <Code id='Code 12'>
+                <Label>234002</Label>
+                <Layers>
+                    <GlazingTypes>
+                        <English>Double/double with 1 coat</English>
+                        <French>Double/double, 1 couche</French>
+                    </GlazingTypes>
+                    <CoatingsTints>
+                        <English>Low-E .20 (hard1)</English>
+                        <French>Faible E .20 (Dur 1)</French>
+                    </CoatingsTints>
+                    <FillType>
+                        <English>9 mm Argon</English>
+                        <French>9 mm d'argon</French>
+                    </FillType>
+                    <SpacerType>
+                        <English>Metal</English>
+                        <French>Métal</French>
+                    </SpacerType>
+                    <Type>
+                        <English>Picture</English>
+                        <French>Fixe</French>
+                    </Type>
+                    <FrameMaterial>
+                        <English>Wood</English>
+                        <French>Bois</French>
+                    </FrameMaterial>
+                </Layers>
+            </Code>
+            """,
         ]
     }
 
@@ -285,7 +332,7 @@ def sample_input_d(ceiling_input: typing.List[str],
                    heated_floor_area_input: str,
                    heating_cooling_input: str,
                    ventilation_input: typing.List[str],
-                   raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> reader.InputData:
+                   raw_codes: typing.Dict[str, typing.List[str]]) -> reader.InputData:
     return {
         'EVAL_ID': '123',
         'EVAL_TYPE': 'D',
@@ -304,7 +351,6 @@ def sample_input_d(ceiling_input: typing.List[str],
         'heating_cooling': heating_cooling_input,
         'heatedFloorArea': heated_floor_area_input,
         'ventilations': ventilation_input,
-
         'codes': raw_codes,
     }
 

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -7,93 +7,144 @@ from energuide import extracted_datatypes
 
 
 @pytest.fixture
-def raw_codes() -> typing.Dict[str, typing.List[typing.Dict[str, str]]]:
+def raw_wall_codes() -> typing.List[element.Element]:
+    data = [
+        """
+        <Code id='Code 1'>
+            <Label>1201101121</Label>
+            <Layers>
+                <StructureType>
+                    <English>Wood frame</English>
+                    <French>Ossature de bois</French>
+                </StructureType>
+                <ComponentType>
+                    <English>38x89 mm (2x4 in)</English>
+                    <French>38x89 (2x4)</French>
+                </ComponentType>
+            </Layers>
+        </Code>
+        """,
+        """
+        <Code id='Code 2'>
+            <Label>1201101121</Label>
+            <Layers>
+                <StructureType>
+                    <English>Metal frame</English>
+                    <French>Ossature de métal</French>
+                </StructureType>
+                <ComponentType>
+                    <English>38x89 mm (2x4 in)</English>
+                    <French>38x89 (2x4)</French>
+                </ComponentType>
+            </Layers>
+        </Code>
+        """,
+    ]
+    return [element.Element.from_string(code) for code in data]
+
+
+@pytest.fixture
+def raw_window_codes() -> typing.List[element.Element]:
+    data = [
+        """
+        <Code id='Code 11'>
+            <Label>202002</Label>
+            <Layers>
+                <GlazingTypes>
+                    <English>Double/double with 1 coat</English>
+                    <French>Double/double, 1 couche</French>
+                </GlazingTypes>
+                <CoatingsTints>
+                    <English>Clear</English>
+                    <French>Transparent</French>
+                </CoatingsTints>
+                <FillType>
+                    <English>6 mm Air</English>
+                    <French>6 mm d'air</French>
+                </FillType>
+                <SpacerType>
+                    <English>Metal</English>
+                    <French>Métal</French>
+                </SpacerType>
+                <Type>
+                    <English>Picture</English>
+                    <French>Fixe</French>
+                </Type>
+                <FrameMaterial>
+                    <English>Wood</English>
+                    <French>Bois</French>
+                </FrameMaterial>
+            </Layers>
+        </Code>
+        """,
+        """
+        <Code id='Code 12'>
+            <Label>234002</Label>
+            <Layers>
+                <GlazingTypes>
+                    <English>Double/double with 1 coat</English>
+                    <French>Double/double, 1 couche</French>
+                </GlazingTypes>
+                <CoatingsTints>
+                    <English>Low-E .20 (hard1)</English>
+                    <French>Faible E .20 (Dur 1)</French>
+                </CoatingsTints>
+                <FillType>
+                    <English>9 mm Argon</English>
+                    <French>9 mm d'argon</French>
+                </FillType>
+                <SpacerType>
+                    <English>Metal</English>
+                    <French>Métal</French>
+                </SpacerType>
+                <Type>
+                    <English>Picture</English>
+                    <French>Fixe</French>
+                </Type>
+                <FrameMaterial>
+                    <English>Wood</English>
+                    <French>Bois</French>
+                </FrameMaterial>
+            </Layers>
+        </Code>
+        """,
+    ]
+    return [element.Element.from_string(code) for code in data]
+
+
+@pytest.fixture
+def raw_codes(raw_wall_codes: typing.List[element.Element],
+              raw_window_codes: typing.List[element.Element]) -> typing.Dict[str, typing.List[element.Element]]:
     return {
-        'wall': [
-            {
-                'id': 'Code 1',
-                'label': '1201101121',
-                'structureTypeEnglish': 'Wood frame',
-                'structureTypeFrench': 'Ossature de bois',
-                'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-                'componentTypeSizeFrench': '38x89 (2x4)',
-            }, {
-                'id': 'Code 2',
-                'label': '1201101122',
-                'structureTypeEnglish': 'Metal frame',
-                'structureTypeFrench': 'Ossature de métal',
-                'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-                'componentTypeSizeFrench': '38x89 (2x4)',
-            }
-        ],
-        'window': [
-            {
-                'id': 'Code 11',
-                'label': '202002',
-                'glazingTypesEnglish': 'Double/double with 1 coat',
-                'glazingTypesFrench': 'Double/double, 1 couche',
-                'coatingsTintsEnglish': 'Clear',
-                'coatingsTintsFrench': 'Transparent',
-                'fillTypeEnglish': '6 mm Air',
-                'fillTypeFrench': "6 mm d'air",
-                'spacerTypeEnglish': 'Metal',
-                'spacerTypeFrench': 'Métal',
-                'typeEnglish': 'Picture',
-                'typeFrench': 'Fixe',
-                'frameMaterialEnglish': 'Wood',
-                'frameMaterialFrench': 'Bois',
-            }, {
-                'id': 'Code 12',
-                'label': '234002',
-                'glazingTypesEnglish': 'Double/double with 1 coat',
-                'glazingTypesFrench': 'Double/double, 1 couche',
-                'coatingsTintsEnglish': 'Low-E .20 (hard1)',
-                'coatingsTintsFrench': 'Faible E .20 (Dur 1)',
-                'fillTypeEnglish': '9 mm Argon',
-                'fillTypeFrench': "9 mm d'argon",
-                'spacerTypeEnglish': 'Metal',
-                'spacerTypeFrench': 'Métal',
-                'typeEnglish': 'Picture',
-                'typeFrench': 'Fixe',
-                'frameMaterialEnglish': 'Wood',
-                'frameMaterialFrench': 'Bois',
-            }
-        ]
+        'wall': raw_wall_codes,
+        'window': raw_window_codes,
     }
 
 
 @pytest.fixture
-def codes(raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> extracted_datatypes.Codes:
+def codes(raw_codes: typing.Dict[str, typing.List[element.Element]]) -> extracted_datatypes.Codes:
     return extracted_datatypes.Codes.from_data(raw_codes)
 
 
 class TestWallCode:
 
-    @pytest.fixture
-    def sample(self, raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> typing.Dict[str, str]:
-        return raw_codes['wall'][0]
-
-    def test_from_data(self, sample: typing.Dict[str, str]) -> None:
-        output = extracted_datatypes.WallCode.from_data(sample)
-        assert output.identifier == 'Code 1'
-        assert output.label == '1201101121'
+    def test_from_data(self, raw_wall_codes: typing.List[element.Element]) -> None:
+        output = [extracted_datatypes.WallCode.from_data(raw_code) for raw_code in raw_wall_codes]
+        assert output[0].identifier == 'Code 1'
+        assert output[0].label == '1201101121'
 
 
 class TestWindowCode:
 
-    @pytest.fixture
-    def sample(self, raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> typing.Dict[str, str]:
-        return raw_codes['window'][0]
-
-    def test_from_data(self, sample: typing.Dict[str, str]) -> None:
-        output = extracted_datatypes.WindowCode.from_data(sample)
-        assert output.identifier == 'Code 11'
-        assert output.label == '202002'
+    def test_from_data(self, raw_window_codes: typing.List[element.Element]) -> None:
+        output = [extracted_datatypes.WindowCode.from_data(raw_code) for raw_code in raw_window_codes]
+        assert output[0].identifier == 'Code 11'
+        assert output[0].label == '202002'
 
 
 class TestCodes:
 
-    def test_from_data(self, raw_codes: typing.Dict[str, typing.List[typing.Dict[str, str]]]) -> None:
+    def test_from_data(self, raw_codes: typing.Dict[str, typing.List[element.Element]]) -> None:
         output = extracted_datatypes.Codes.from_data(raw_codes)
         assert len(output.wall) == 2
         assert len(output.window) == 2

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -149,69 +149,24 @@ def test_deeply_embedded_components() -> None:
     assert len(output.doors) == 2
 
 
-def test_wall_code_snippet_to_dict(code: etree._Element) -> None:
-    output = snippets.snip_codes(code)
-    assert sorted(output.wall, key=lambda row: row.label)[0].to_dict() == {
-        'id': 'Code 1',
-        'label': '1201101121',
-        'structureTypeEnglish': 'Wood frame',
-        'structureTypeFrench': 'Ossature de bois',
-        'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
-        'componentTypeSizeFrench': '38x89 (2x4)',
-    }
-
-
 def test_wall_code_snippet(code: etree._Element) -> None:
     output = snippets.snip_codes(code)
     assert len(output.wall) == 2
-    assert sorted(output.wall, key=lambda row: row.label)[0] == snippets.WallCodeSnippet(
-        identifier='Code 1',
-        label='1201101121',
-        structure_type_english='Wood frame',
-        structure_type_french='Ossature de bois',
-        component_type_size_english='38x89 mm (2x4 in)',
-        component_type_size_french='38x89 (2x4)',
-    )
-
-
-def test_window_code_snippet_to_dict(code: etree._Element) -> None:
-    output = snippets.snip_codes(code)
-    assert sorted(output.window, key=lambda row: row.label)[0].to_dict() == {
-        'id': 'Code 11',
-        'label': '202002',
-        'glazingTypesEnglish': 'Double/double with 1 coat',
-        'glazingTypesFrench': 'Double/double, 1 couche',
-        'coatingsTintsEnglish': 'Clear',
-        'coatingsTintsFrench': 'Transparent',
-        'fillTypeEnglish': '6 mm Air',
-        'fillTypeFrench': "6 mm d'air",
-        'spacerTypeEnglish': 'Metal',
-        'spacerTypeFrench': 'Métal',
-        'typeEnglish': 'Picture',
-        'typeFrench': 'Fixe',
-        'frameMaterialEnglish': 'Wood',
-        'frameMaterialFrench': 'Bois',
-    }
+    checker = validator.DwellingValidator({
+        'codes': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
+    }, allow_unknown=True)
+    doc = {'codes': output.wall}
+    assert checker.validate(doc)
 
 
 def test_window_code_snippet(code: etree._Element) -> None:
     output = snippets.snip_codes(code)
-    assert sorted(output.window, key=lambda row: row.label)[0] == snippets.WindowCodeSnippet(
-        identifier='Code 11',
-        label='202002',
-        glazing_types_english='Double/double with 1 coat',
-        glazing_types_french='Double/double, 1 couche',
-        coatings_tints_english='Clear',
-        coatings_tints_french='Transparent',
-        fill_type_english='6 mm Air',
-        fill_type_french="6 mm d'air",
-        spacer_type_english='Metal',
-        spacer_type_french='Métal',
-        type_english='Picture',
-        type_french='Fixe',
-        frame_material_english='Wood',
-        frame_material_french='Bois',
-    )
+    assert len(output.wall) == 2
+    checker = validator.DwellingValidator({
+        'codes': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
+    }, allow_unknown=True)
+    doc = {'codes': output.window}
+    assert checker.validate(doc)
 
 
 def test_door_snippet(house: etree._Element) -> None:


### PR DESCRIPTION
This PR was hard to break up, but it's just taking the same approach as all the other similar PRs (e.g. #125). It moves a bunch of logic out of the extractor and into the transfomer.