### PR TITLE
add Element tests, turn on strict optionals

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
-strict_optional = False
+strict_optional = True
 ignore_missing_imports = True
 warn_unused_ignores = True

--- a/python/src/energuide/element.py
+++ b/python/src/energuide/element.py
@@ -15,6 +15,11 @@ class Element:
     def findtext(self, *args, **kwargs) -> typing.Optional[str]:
         return self.__node.findtext(*args, **kwargs)
 
+    def get_text(self, *args, **kwargs) -> str:
+        result: typing.Optional[str] = self.__node.findtext(*args, **kwargs)
+        assert result is not None
+        return result
+
     @property
     def attrib(self) -> typing.Dict[str, typing.Any]:
         return self.__node.attrib

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -111,11 +111,11 @@ class WallCode(_WallCode):
     def from_data(cls, wall_code: element.Element) -> 'WallCode':
         return WallCode(
             identifier=wall_code.attrib['id'],
-            label=wall_code.findtext('Label'),
-            structure_type_english=wall_code.findtext('Layers/StructureType/English'),
-            structure_type_french=wall_code.findtext('Layers/StructureType/French'),
-            component_type_size_english=wall_code.findtext('Layers/ComponentTypeSize/English'),
-            component_type_size_french=wall_code.findtext('Layers/ComponentTypeSize/French'),
+            label=wall_code.get_text('Label'),
+            structure_type_english=wall_code.get_text('Layers/StructureType/English'),
+            structure_type_french=wall_code.get_text('Layers/StructureType/French'),
+            component_type_size_english=wall_code.get_text('Layers/ComponentTypeSize/English'),
+            component_type_size_french=wall_code.get_text('Layers/ComponentTypeSize/French'),
         )
 
 
@@ -270,7 +270,7 @@ class Wall(_Wall):
             code = wall_codes[code_id[0]]
 
         return Wall(
-            label=wall.findtext('Label'),
+            label=wall.get_text('Label'),
             structure_type_english=code.structure_type_english if code else None,
             structure_type_french=code.structure_type_french if code else None,
             component_type_size_english=code.component_type_size_english if code else None,
@@ -320,9 +320,9 @@ class Ceiling(_Ceiling):
     @classmethod
     def from_data(cls, ceiling: element.Element) -> 'Ceiling':
         return Ceiling(
-            label=ceiling.findtext('Label'),
-            type_english=ceiling.findtext('Construction/Type/English'),
-            type_french=ceiling.findtext('Construction/Type/French'),
+            label=ceiling.get_text('Label'),
+            type_english=ceiling.get_text('Construction/Type/English'),
+            type_french=ceiling.get_text('Construction/Type/French'),
             nominal_rsi=float(ceiling.xpath('Construction/CeilingType/@nominalInsulation')[0]),
             effective_rsi=float(ceiling.xpath('Construction/CeilingType/@rValue')[0]),
             area_metres=float(ceiling.xpath('Measurements/@area')[0]),
@@ -366,7 +366,7 @@ class Floor(_Floor):
     @classmethod
     def from_data(cls, floor: element.Element) -> 'Floor':
         return Floor(
-            label=floor.findtext('Label'),
+            label=floor.get_text('Label'),
             nominal_rsi=float(floor.xpath('Construction/Type/@nominalInsulation')[0]),
             effective_rsi=float(floor.xpath('Construction/Type/@rValue')[0]),
             area_metres=float(floor.xpath('Measurements/@area')[0]),
@@ -408,9 +408,9 @@ class Door(_Door):
     @classmethod
     def from_data(cls, door: element.Element) -> 'Door':
         return Door(
-            label=door.findtext('Label'),
-            type_english=door.findtext('Construction/Type/English'),
-            type_french=door.findtext('Construction/Type/French'),
+            label=door.get_text('Label'),
+            type_english=door.get_text('Construction/Type/English'),
+            type_french=door.get_text('Construction/Type/French'),
             rsi=float(door.xpath('Construction/Type/@value')[0]),
             height=float(door.xpath('Measurements/@height')[0]),
             width=float(door.xpath('Measurements/@width')[0]),

--- a/python/src/energuide/validator.py
+++ b/python/src/energuide/validator.py
@@ -1,17 +1,13 @@
 import typing
 import cerberus
-from lxml import etree
+from energuide import element
 
 
 class DwellingValidator(cerberus.Validator):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
-
     def _validate_type_xml(self, value: typing.Any) -> bool:  # pylint: disable=no-self-use
-        return isinstance(value, etree._Element)
+        return isinstance(value, element.Element)
 
-    def _normalize_coerce_parse_xml(self, value: typing.Any) -> typing.Optional[etree._Element]:
+    def _normalize_coerce_parse_xml(self, value: typing.Any) -> element.Element:  # pylint: disable=no-self-use
         assert isinstance(value, str), "Can't coerce non-strings to XML"
-        return etree.fromstring(value.encode('utf-8'), self._parser)
+        return element.Element.from_string(value)

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 from energuide import cli
 
 
-def data1() -> typing.Dict[str, str]:
+def data1() -> typing.Dict[str, typing.Optional[str]]:
     return {
         'EVAL_ID': '123',
         'EVAL_TYPE': 'D',
@@ -36,7 +36,7 @@ def data1() -> typing.Dict[str, str]:
     }
 
 
-def data2() -> typing.Dict[str, str]:
+def data2() -> typing.Dict[str, typing.Optional[str]]:
     data = data1()
     data['other_1'] = 'foo'
     data['other_2'] = 'bar'

--- a/python/tests/test_element.py
+++ b/python/tests/test_element.py
@@ -1,0 +1,21 @@
+import pytest
+from energuide import element
+
+
+def test_get_text() -> None:
+    node = element.Element.from_string('<Foo><Bar>baz</Bar></Foo>')
+    assert node.get_text('Bar') == 'baz'
+
+
+def test_get_text_raises_when_not_found() -> None:
+    node = element.Element.from_string('<Foo><Bar>baz</Bar></Foo>')
+    with pytest.raises(AssertionError):
+        node.get_text('Baz')
+
+
+def test_xpath_returns_elements() -> None:
+    node = element.Element.from_string("<Foo><Bar baz='1' /><Bar baz='2' /></Foo>")
+    output = node.xpath('Bar')
+    assert len(output) == 2
+    assert all([isinstance(bar_node, element.Element) for bar_node in output])
+    assert output[0].attrib['baz'] == '1'

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -17,10 +17,10 @@ def raw_wall_codes() -> typing.List[element.Element]:
                     <English>Wood frame</English>
                     <French>Ossature de bois</French>
                 </StructureType>
-                <ComponentType>
+                <ComponentTypeSize>
                     <English>38x89 mm (2x4 in)</English>
                     <French>38x89 (2x4)</French>
-                </ComponentType>
+                </ComponentTypeSize>
             </Layers>
         </Code>
         """,
@@ -32,10 +32,10 @@ def raw_wall_codes() -> typing.List[element.Element]:
                     <English>Metal frame</English>
                     <French>Ossature de métal</French>
                 </StructureType>
-                <ComponentType>
+                <ComponentTypeSize>
                     <English>38x89 mm (2x4 in)</English>
                     <French>38x89 (2x4)</French>
-                </ComponentType>
+                </ComponentTypeSize>
             </Layers>
         </Code>
         """,

--- a/python/tests/test_extractor.py
+++ b/python/tests/test_extractor.py
@@ -8,7 +8,7 @@ import pytest
 from energuide import extractor, reader
 
 
-def data1() -> typing.Dict[str, str]:
+def data1() -> typing.Dict[str, typing.Optional[str]]:
     return {
         'EVAL_ID': '123',
         'EVAL_TYPE': 'D',
@@ -35,7 +35,7 @@ def data1() -> typing.Dict[str, str]:
     }
 
 
-def data2() -> typing.Dict[str, str]:
+def data2() -> typing.Dict[str, typing.Optional[str]]:
     data = data1()
     data['other_1'] = 'foo'
     data['other_2'] = 'bar'

--- a/python/tests/test_validator.py
+++ b/python/tests/test_validator.py
@@ -1,10 +1,10 @@
-from lxml import etree
+from energuide import element
 from energuide import validator
 
 
 def test_validates_xml() -> None:
     raw_xml = '<Foo />'
-    doc = etree.fromstring(raw_xml)
+    doc = element.Element.from_string(raw_xml)
     data = {'raw_xml': doc}
     checker = validator.DwellingValidator({'raw_xml': {'type': 'xml', 'required': True}})
     assert checker.validate(data)
@@ -22,7 +22,7 @@ def test_coerce_to_xml() -> None:
     data = {'raw_xml': raw_xml}
     checker = validator.DwellingValidator({'raw_xml': {'type': 'xml', 'required': True, 'coerce': 'parse_xml'}})
     assert checker.validate(data)
-    assert isinstance(checker.document['raw_xml'], etree._Element)
+    assert isinstance(checker.document['raw_xml'], element.Element)
 
 
 def test_embedded_xml() -> None:
@@ -33,4 +33,4 @@ def test_embedded_xml() -> None:
     assert checker.validate(data)
     assert isinstance(checker.document['raw_xml'], list)
     assert len(checker.document['raw_xml']) == 2
-    assert isinstance(checker.document['raw_xml'][0], etree._Element)
+    assert isinstance(checker.document['raw_xml'][0], element.Element)


### PR DESCRIPTION
This PR turns on the `strict_optionals` flag for mypy, which differentiates between things like `Optional[str]` and `str`.

Also added a couple of tests for `element.Element` because I added a custom function.