### PR TITLE
Load water heating

### DIFF
--- a/python/pylintrc
+++ b/python/pylintrc
@@ -60,6 +60,7 @@ disable=
     c-extension-no-member,
     too-few-public-methods,
     redefined-outer-name,
+    too-many-instance-attributes,
 
 
 [REPORTS]
@@ -213,10 +214,10 @@ argument-rgx=[a-z_][a-z0-9_]{2,30}$
 argument-name-hint=[a-z_][a-z0-9_]{2,30}$
 
 # Regular expression matching correct class attribute names
-class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,120}|(__.*__))$
 
 # Naming hint for class attribute names
-class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,120}|(__.*__))$
 
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -127,6 +127,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
     def from_row(cls, row: reader.InputData) -> 'ParsedDwellingDataRow':
         checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True, ignore_none_values=True)
         if not checker.validate(row):
+            # import pdb; pdb.set_trace()
             error_keys = ', '.join(checker.errors.keys())
             raise reader.InvalidInputDataException(f'Validator failed on keys: {error_keys}')
 
@@ -150,7 +151,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             windows=[Window.from_data(window, codes.window) for window in parsed['windows']],
             heated_floor_area=HeatedFloorArea.from_data(parsed['heatedFloorArea']),
             ventilations=[Ventilation.from_data(ventilation) for ventilation in parsed['ventilations']],
-            water_heatings=[WaterHeating.from_data(water_heating) for water_heating in parsed['waterHeatings']],
+            water_heatings=WaterHeating.from_data(parsed['waterHeatings']),
         )
 
 

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -127,7 +127,6 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
     def from_row(cls, row: reader.InputData) -> 'ParsedDwellingDataRow':
         checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True, ignore_none_values=True)
         if not checker.validate(row):
-            # import pdb; pdb.set_trace()
             error_keys = ', '.join(checker.errors.keys())
             raise reader.InvalidInputDataException(f'Validator failed on keys: {error_keys}')
 

--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -11,6 +11,7 @@ from energuide.extracted_datatypes import Wall
 from energuide.extracted_datatypes import Window
 from energuide.extracted_datatypes import HeatedFloorArea
 from energuide.extracted_datatypes import Ventilation
+from energuide.extracted_datatypes import WaterHeating
 from energuide.extracted_datatypes import Codes
 
 
@@ -90,6 +91,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     windows: typing.List[Window]
     heated_floor_area: HeatedFloorArea
     ventilations: typing.List[Ventilation]
+    water_heatings: typing.List[WaterHeating]
 
 
 class ParsedDwellingDataRow(_ParsedDwellingDataRow):
@@ -116,6 +118,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'heatedFloorArea': _XML_SCHEMA,
         'heating_cooling': {'type': 'xml', 'required': True, 'coerce': 'parse_xml'},
         'ventilations': _XML_LIST_SCHEMA,
+        'waterHeatings': _XML_SCHEMA,
 
         'codes': {'type': 'dict', 'required': True, 'schema': {'wall': _XML_LIST_SCHEMA, 'window': _XML_LIST_SCHEMA}},
     }
@@ -147,6 +150,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             windows=[Window.from_data(window, codes.window) for window in parsed['windows']],
             heated_floor_area=HeatedFloorArea.from_data(parsed['heatedFloorArea']),
             ventilations=[Ventilation.from_data(ventilation) for ventilation in parsed['ventilations']],
+            water_heatings=[WaterHeating.from_data(water_heating) for water_heating in parsed['waterHeatings']],
         )
 
 
@@ -164,6 +168,7 @@ class Evaluation:
                  windows: typing.List[Window],
                  heated_floor_area: HeatedFloorArea,
                  ventilations: typing.List[Ventilation],
+                 water_heatings: typing.List[WaterHeating],
                 ) -> None:
         self._evaluation_type = evaluation_type
         self._entry_date = entry_date
@@ -176,6 +181,7 @@ class Evaluation:
         self._windows = windows
         self._heated_floor_area = heated_floor_area
         self._ventilations = ventilations
+        self._water_heatings = water_heatings
 
     @classmethod
     def from_data(cls, data: ParsedDwellingDataRow) -> 'Evaluation':
@@ -190,7 +196,8 @@ class Evaluation:
             doors=data.doors,
             windows=data.windows,
             heated_floor_area=data.heated_floor_area,
-            ventilations=data.ventilations
+            ventilations=data.ventilations,
+            water_heatings=data.water_heatings
         )
 
     @property
@@ -237,6 +244,10 @@ class Evaluation:
     def ventilations(self) -> typing.List[Ventilation]:
         return self._ventilations
 
+    @property
+    def water_heatings(self) -> typing.List[WaterHeating]:
+        return self._water_heatings
+
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'evaluationType': self.evaluation_type.value,
@@ -250,6 +261,7 @@ class Evaluation:
             'windows': [window.to_dict() for window in self.windows],
             'heatedFloorArea': self.heated_floor_area.to_dict(),
             'ventilations': [ventilation.to_dict() for ventilation in self.ventilations],
+            'waterHeatings': [water_heating.to_dict() for water_heating in self.water_heatings]
         }
 
 

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -759,7 +759,7 @@ class WaterHeating(_WaterHeating):
     }
 
     @classmethod
-    def from_data(cls, water_heating: element.Element) -> 'WaterHeating':
+    def _from_data(cls, water_heating: element.Element) -> 'WaterHeating':
         assert water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
 
         energy_type = water_heating.xpath('EnergySource/English/text()')[0]
@@ -775,6 +775,12 @@ class WaterHeating(_WaterHeating):
             tank_volume=volume,
             efficiency=efficiency,
         )
+
+    @classmethod
+    def from_data(cls, water_heating: element.Element) -> typing.List['WaterHeating']:
+        water_heatings = water_heating.xpath("*[self::Primary or self::Secondary]")
+        return [cls._from_data(water_heating) for water_heating in water_heatings]
+
 
     @property
     def tank_volume_usg(self):

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -1,5 +1,84 @@
+import enum
 import typing
 from energuide import element
+
+
+class WaterHeaterType(enum.Enum):
+    NOT_APPLICABLE = ""
+    ELECTRICITY_CONVENTIONAL_TANK_ENGLISH = "Electric storage tank"
+    ELECTRICITY_CONVENTIONAL_TANK_FRENCH = "Réservoir électrique"
+    ELECTRICITY_CONSERVER_TANK_ENGLISH = "Electric storage tank"
+    ELECTRICITY_CONSERVER_TANK_FRENCH = "Réservoir électrique"
+    ELECTRICITY_INSTANTANEOUS_ENGLISH = "Electric tankless water heater"
+    ELECTRICITY_INSTANTANEOUS_FRENCH = "Chauffe-eau électrique sans réservoir"
+    ELECTRICITY_TANKLESS_HEAT_PUMP_ENGLISH = "Electric tankless heat pump"
+    ELECTRICITY_TANKLESS_HEAT_PUMP_FRENCH = "Thermopompe électrique sans réservoir"
+    ELECTRICITY_HEAT_PUMP_ENGLISH = "Electric heat pump"
+    ELECTRICITY_HEAT_PUMP_FRENCH = "Thermopompe électrique"
+    ELECTRICITY_ADDON_HEAT_PUMP_ENGLISH = "Integrated heat pump"
+    ELECTRICITY_ADDON_HEAT_PUMP_FRENCH = "Thermopompe intégrée"
+    NATURAL_GAS_CONVENTIONAL_TANK_ENGLISH = "Natural gas storage tank"
+    NATURAL_GAS_CONVENTIONAL_TANK_FRENCH = "Réservoir au gaz naturel"
+    NATURAL_GAS_CONVENTIONAL_TANK_PILOT_ENGLISH = "Natural gas storage tank with pilot"
+    NATURAL_GAS_CONVENTIONAL_TANK_PILOT_FRENCH = "Réservoir au gaz naturel avec veilleuse"
+    NATURAL_GAS_TANKLESS_COIL_ENGLISH = "Natural gas tankless coil"
+    NATURAL_GAS_TANKLESS_COIL_FRENCH = "Serpentin sans réservoir au gaz naturel"
+    NATURAL_GAS_INSTANTANEOUS_ENGLISH = "Natural gas tankless"
+    NATURAL_GAS_INSTANTANEOUS_FRENCH = "Chauffe-eau instantané au gaz naturel"
+    NATURAL_GAS_INSTANTANEOUS_CONDENSING_ENGLISH = "Natural gas tankless"
+    NATURAL_GAS_INSTANTANEOUS_CONDENSING_FRENCH = "Chauffe-eau instantané au gaz naturel"
+    NATURAL_GAS_INSTANTANEOUS_PILOT_ENGLISH = "Natural gas tankless with pilot"
+    NATURAL_GAS_INSTANTANEOUS_PILOT_FRENCH = "Chauffe-eau instantané au gaz naturel avec veilleuse"
+    NATURAL_GAS_INDUCED_DRAFT_FAN_ENGLISH = "Natural gas power vented storage tank"
+    NATURAL_GAS_INDUCED_DRAFT_FAN_FRENCH = "Réservoir au gaz naturel à évacuation forcée"
+    NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_ENGLISH = "Natural gas power vented storage tank with pilot"
+    NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_FRENCH = "Réservoir au gaz naturel à évacuation forcée avec veilleuse"
+    NATURAL_GAS_DIRECT_VENT_SEALED_ENGLISH = "Natural gas direct vented storage tank"
+    NATURAL_GAS_DIRECT_VENT_SEALED_FRENCH = "Réservoir au gaz naturel à évacuation directe"
+    NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_ENGLISH = "Natural gas direct vented storage tank with pilot"
+    NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_FRENCH = "Réservoir au gaz naturel à évacuation directe avec veilleuse"
+    NATURAL_GAS_CONDENSING_ENGLISH = "Natural gas condensing storage tank"
+    NATURAL_GAS_CONDENSING_FRENCH = "Réservoir au gaz naturel à condensation"
+    OIL_CONVENTIONAL_TANK_ENGLISH = "Oil-fired storage tank"
+    OIL_CONVENTIONAL_TANK_FRENCH = "Réservoir au mazout"
+    OIL_TANKLESS_COIL_ENGLISH = "Oil-type tankless coil"
+    OIL_TANKLESS_COIL_FRENCH = "Serpentin sans réservoir au mazout"
+    PROPANE_CONVENTIONAL_TANK_ENGLISH = "Propane storage tank"
+    PROPANE_CONVENTIONAL_TANK_FRENCH = "Réservoir au propane"
+    PROPANE_CONVENTIONAL_TANK_PILOT_ENGLISH = "Propane storage tank with pilot"
+    PROPANE_CONVENTIONAL_TANK_PILOT_FRENCH = "Réservoir au propane avec veilleuse"
+    PROPANE_TANKLESS_COIL_ENGLISH = "Propane tankless coil"
+    PROPANE_TANKLESS_COIL_FRENCH = "Serpentin sans réservoir au propane"
+    PROPANE_INSTANTANEOUS_ENGLISH = "Propane tankless"
+    PROPANE_INSTANTANEOUS_FRENCH = "Chauffe-eau instantané au propane"
+    PROPANE_INSTANTANEOUS_CONDENSING_ENGLISH = "Propane condensing tankless"
+    PROPANE_INSTANTANEOUS_CONDENSING_FRENCH = "Chauffe-eau instantané au propane à condensation"
+    PROPANE_INSTANTANEOUS_PILOT_ENGLISH = "Propane tankless with pilot"
+    PROPANE_INSTANTANEOUS_PILOT_FRENCH = "Chauffe-eau instantané au propane avec veilleuse"
+    PROPANE_INDUCED_DRAFT_FAN_ENGLISH = "Propane power vented storage tank"
+    PROPANE_INDUCED_DRAFT_FAN_FRENCH = "Réservoir au propane à évacuation forcée"
+    PROPANE_INDUCED_DRAFT_FAN_PILOT_ENGLISH = "Propane power vented storage tank with pilot"
+    PROPANE_INDUCED_DRAFT_FAN_PILOT_FRENCH = "Réservoir au propane à évacuation forcée avec veilleuse"
+    PROPANE_DIRECT_VENT_SEALED_ENGLISH = "Propane power vented storage tank"
+    PROPANE_DIRECT_VENT_SEALED_FRENCH = "Réservoir au propane à évacuation directe"
+    PROPANE_DIRECT_VENT_SEALED_PILOT_ENGLISH = "Propane power vented storage tank with pilot"
+    PROPANE_DIRECT_VENT_SEALED_PILOT_FRENCH = "Réservoir au propane à évacuation directe avec veilleuse"
+    PROPANE_CONDENSING_ENGLISH = "Propane condensing storage tank"
+    PROPANE_CONDENSING_FRENCH = "Réservoir au propane à condensation"
+    WOOD_SPACE_HEATING_FIREPLACE_ENGLISH = "Fireplace"
+    WOOD_SPACE_HEATING_FIREPLACE_FRENCH = "Foyer"
+    WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_ENGLISH = "Wood stove water coil"
+    WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_FRENCH = "Poêle à bois avec serpentin à l'eau"
+    WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_ENGLISH = "Indoor wood boiler"
+    WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_FRENCH = "Chaudière intérieure au bois"
+    WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_ENGLISH = "Outdoor wood boiler"
+    WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_FRENCH = "Chaudière extérieure au bois"
+    WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_ENGLISH = "Wood-fired water storage tank"
+    WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_FRENCH = "Réservoir à eau chaude au bois"
+    SOLAR_COLLECTOR_SYSTEM_ENGLISH = "Solar domestic water heater"
+    SOLAR_COLLECTOR_SYSTEM_FRENCH = "Chauffe-eau solaire domestique"
+    CSA_DHW_ENGLISH = "Certified combo system, space and domestic water heating"
+    CSA_DHW_FRENCH = "Système combiné certifié pour le chauffage des locaux et de l’eau"
 
 
 class _Ceiling(typing.NamedTuple):
@@ -98,11 +177,19 @@ class _WindowCode(typing.NamedTuple):
     frame_material_french: typing.Optional[str]
 
 
+class _WaterHeating(typing.NamedTuple):
+    type_english: str
+    type_french: str
+    tank_volume: float
+    efficiency: float
+
+
 _RSI_MULTIPLIER = 5.678263337
 _CFM_MULTIPLIER = 2.11888
 _FEET_MULTIPLIER = 3.28084
 _FEET_SQUARED_MULTIPLIER = _FEET_MULTIPLIER**2
 _MILLIMETRES_TO_METRES = 1000
+_LITRE_TO_USG = 0.264172
 
 
 class WallCode(_WallCode):
@@ -494,5 +581,211 @@ class Ventilation(_Ventilation):
             'typeFrench': self.type_french,
             'airFlowRateLps': self.air_flow_rate,
             'airFlowRateCfm': self.air_flow_rate_cmf,
+            'efficiency': self.efficiency,
+        }
+
+
+class WaterHeating(_WaterHeating):
+
+    _TYPE_MAP = {
+        ("Electricity", "Not applicable"): (
+            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE.value,
+        ),
+        ("Electricity", "Conventional tank"): (
+            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_FRENCH.value,
+        ),
+        ("Electricity", "Conserver tank"): (
+            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_FRENCH.value,
+        ),
+        ("Electricity", "Instantaneous"): (
+            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_FRENCH.value,
+        ),
+        ("Electricity", "Tankless heat pump"): (
+            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_FRENCH.value,
+        ),
+        ("Electricity", "Heat pump"): (
+            WaterHeaterType.ELECTRICITY_HEAT_PUMP_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_HEAT_PUMP_FRENCH.value,
+        ),
+        ("Electricity", "Add-on heat pump"): (
+            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_ENGLISH.value,
+            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_FRENCH.value,
+        ),
+        ("Natural gas", "Not applicable"): (
+            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE.value,
+        ),
+        ("Natural gas", "Conventional tank"): (
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_FRENCH.value,
+        ),
+        ("Natural gas", "Conventional tank (pilot)"): (
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_FRENCH.value,
+        ),
+        ("Natural gas", "Tankless coil"): (
+            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_FRENCH.value,
+        ),
+        ("Natural gas", "Instantaneous"): (
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_FRENCH.value,
+        ),
+        ("Natural gas", "Instantaneous (condensing)"): (
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_FRENCH.value,
+        ),
+        ("Natural gas", "Instantaneous (pilot)"): (
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_FRENCH.value,
+        ),
+        ("Natural gas", "Induced draft fan"): (
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_FRENCH.value,
+        ),
+        ("Natural gas", "Induced draft fan (pilot)"): (
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_FRENCH.value,
+        ),
+        ("Natural gas", "Direct vent (sealed)"): (
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_FRENCH.value,
+        ),
+        ("Natural gas", "Direct vent (sealed, pilot)"): (
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_FRENCH.value,
+        ),
+        ("Natural gas", "Condensing"): (
+            WaterHeaterType.NATURAL_GAS_CONDENSING_ENGLISH.value,
+            WaterHeaterType.NATURAL_GAS_CONDENSING_FRENCH.value,
+        ),
+        ("Oil", "Not applicable"): (
+            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE.value,
+        ),
+        ("Oil", "Conventional tank"): (
+            WaterHeaterType.OIL_CONVENTIONAL_TANK_ENGLISH.value,
+            WaterHeaterType.OIL_CONVENTIONAL_TANK_FRENCH.value,
+        ),
+        ("Oil", "Tankless coil"): (
+            WaterHeaterType.OIL_TANKLESS_COIL_ENGLISH.value,
+            WaterHeaterType.OIL_TANKLESS_COIL_FRENCH.value,
+        ),
+        ("Propane", "Not applicable"): (
+            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE.value,
+        ),
+        ("Propane", "Conventional tank"): (
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_ENGLISH.value,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_FRENCH.value,
+        ),
+        ("Propane", "Conventional tank (pilot)"): (
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_ENGLISH.value,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_FRENCH.value,
+        ),
+        ("Propane", "Tankless coil"): (
+            WaterHeaterType.PROPANE_TANKLESS_COIL_ENGLISH.value,
+            WaterHeaterType.PROPANE_TANKLESS_COIL_FRENCH.value,
+        ),
+        ("Propane", "Instantaneous"): (
+            WaterHeaterType.PROPANE_INSTANTANEOUS_ENGLISH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_FRENCH.value,
+        ),
+        ("Propane", "Instantaneous (condensing)"): (
+            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_ENGLISH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_FRENCH.value,
+        ),
+        ("Propane", "Instantaneous (pilot)"): (
+            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_ENGLISH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_FRENCH.value,
+        ),
+        ("Propane", "Induced draft fan"): (
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_ENGLISH.value,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_FRENCH.value,
+        ),
+        ("Propane", "Induced draft fan (pilot)"): (
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_ENGLISH.value,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_FRENCH.value,
+        ),
+        ("Propane", "Direct vent (sealed)"): (
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_ENGLISH.value,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_FRENCH.value,
+        ),
+        ("Propane", "Direct vent (sealed, pilot)"): (
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_ENGLISH.value,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_FRENCH.value,
+        ),
+        ("Propane", "Condensing"): (
+            WaterHeaterType.PROPANE_CONDENSING_ENGLISH.value,
+            WaterHeaterType.PROPANE_CONDENSING_FRENCH.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Not applicable"): (
+            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Fireplace"): (
+            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_ENGLISH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_FRENCH.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Wood stove water coil"): (
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_ENGLISH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_FRENCH.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Indoor wood boiler"): (
+            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_ENGLISH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_FRENCH.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Outdoor wood boiler"): (
+            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_ENGLISH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_FRENCH.value,
+        ),
+        ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Wood hot water tank"): (
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_ENGLISH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_FRENCH.value,
+        ),
+        ("Solar", "Solar Collector System"): (
+            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_ENGLISH.value,
+            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_FRENCH.value,
+        ),
+        ("CSA P9-11 tested Combo Heat/DHW", "CSA P9-11 tested Combo Heat/DHW"): (
+            WaterHeaterType.CSA_DHW_ENGLISH.value,
+            WaterHeaterType.CSA_DHW_FRENCH.value,
+        ),
+    }
+
+    @classmethod
+    def from_data(cls, water_heating: element.Element) -> 'WaterHeating':
+        assert water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
+
+        energy_type = water_heating.xpath('EnergySource/English/text()')[0]
+        tank_type = water_heating.xpath('TankType/English/text()')[0]
+
+        type_english, type_french = cls._TYPE_MAP[(energy_type, tank_type)]
+        volume = float(water_heating.xpath('TankVolume/@value')[0])
+        efficiency = float(water_heating.xpath('EnergyFactor/@value')[0])
+
+        return WaterHeating(
+            type_english=type_english,
+            type_french=type_french,
+            tank_volume=volume,
+            efficiency=efficiency,
+        )
+
+    @property
+    def tank_volume_usg(self):
+        return self.tank_volume * _LITRE_TO_USG
+
+
+    def to_dict(self) -> typing.Dict[str, typing.Union[str, float]]:
+        return {
+            'typeEnglish': self.type_english,
+            'typeFrench': self.type_french,
+            'tankVolumeLitres': self.tank_volume,
+            'TankVolumeUsg': self.tank_volume_usg,
             'efficiency': self.efficiency,
         }

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -178,8 +178,8 @@ class _WindowCode(typing.NamedTuple):
 
 
 class _WaterHeating(typing.NamedTuple):
-    type_english: str
-    type_french: str
+    type_english: WaterHeaterType
+    type_french: WaterHeaterType
     tank_volume: float
     efficiency: float
 
@@ -189,7 +189,7 @@ _CFM_MULTIPLIER = 2.11888
 _FEET_MULTIPLIER = 3.28084
 _FEET_SQUARED_MULTIPLIER = _FEET_MULTIPLIER**2
 _MILLIMETRES_TO_METRES = 1000
-_LITRE_TO_USG = 0.264172
+_LITRE_TO_GALLON = 0.264172
 
 
 class WallCode(_WallCode):
@@ -589,172 +589,172 @@ class WaterHeating(_WaterHeating):
 
     _TYPE_MAP = {
         ("Electricity", "Not applicable"): (
-            WaterHeaterType.NOT_APPLICABLE.value,
-            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE,
+            WaterHeaterType.NOT_APPLICABLE,
         ),
         ("Electricity", "Conventional tank"): (
-            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_ENGLISH,
+            WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_FRENCH,
         ),
         ("Electricity", "Conserver tank"): (
-            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_ENGLISH,
+            WaterHeaterType.ELECTRICITY_CONSERVER_TANK_FRENCH,
         ),
         ("Electricity", "Instantaneous"): (
-            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_ENGLISH,
+            WaterHeaterType.ELECTRICITY_INSTANTANEOUS_FRENCH,
         ),
         ("Electricity", "Tankless heat pump"): (
-            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_ENGLISH,
+            WaterHeaterType.ELECTRICITY_TANKLESS_HEAT_PUMP_FRENCH,
         ),
         ("Electricity", "Heat pump"): (
-            WaterHeaterType.ELECTRICITY_HEAT_PUMP_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_HEAT_PUMP_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_HEAT_PUMP_ENGLISH,
+            WaterHeaterType.ELECTRICITY_HEAT_PUMP_FRENCH,
         ),
         ("Electricity", "Add-on heat pump"): (
-            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_ENGLISH.value,
-            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_FRENCH.value,
+            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_ENGLISH,
+            WaterHeaterType.ELECTRICITY_ADDON_HEAT_PUMP_FRENCH,
         ),
         ("Natural gas", "Not applicable"): (
-            WaterHeaterType.NOT_APPLICABLE.value,
-            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE,
+            WaterHeaterType.NOT_APPLICABLE,
         ),
         ("Natural gas", "Conventional tank"): (
-            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_FRENCH,
         ),
         ("Natural gas", "Conventional tank (pilot)"): (
-            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_CONVENTIONAL_TANK_PILOT_FRENCH,
         ),
         ("Natural gas", "Tankless coil"): (
-            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_TANKLESS_COIL_FRENCH,
         ),
         ("Natural gas", "Instantaneous"): (
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_FRENCH,
         ),
         ("Natural gas", "Instantaneous (condensing)"): (
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_CONDENSING_FRENCH,
         ),
         ("Natural gas", "Instantaneous (pilot)"): (
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_INSTANTANEOUS_PILOT_FRENCH,
         ),
         ("Natural gas", "Induced draft fan"): (
-            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_FRENCH,
         ),
         ("Natural gas", "Induced draft fan (pilot)"): (
-            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_INDUCED_DRAFT_FAN_PILOT_FRENCH,
         ),
         ("Natural gas", "Direct vent (sealed)"): (
-            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_FRENCH,
         ),
         ("Natural gas", "Direct vent (sealed, pilot)"): (
-            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_DIRECT_VENT_SEALED_PILOT_FRENCH,
         ),
         ("Natural gas", "Condensing"): (
-            WaterHeaterType.NATURAL_GAS_CONDENSING_ENGLISH.value,
-            WaterHeaterType.NATURAL_GAS_CONDENSING_FRENCH.value,
+            WaterHeaterType.NATURAL_GAS_CONDENSING_ENGLISH,
+            WaterHeaterType.NATURAL_GAS_CONDENSING_FRENCH,
         ),
         ("Oil", "Not applicable"): (
-            WaterHeaterType.NOT_APPLICABLE.value,
-            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE,
+            WaterHeaterType.NOT_APPLICABLE,
         ),
         ("Oil", "Conventional tank"): (
-            WaterHeaterType.OIL_CONVENTIONAL_TANK_ENGLISH.value,
-            WaterHeaterType.OIL_CONVENTIONAL_TANK_FRENCH.value,
+            WaterHeaterType.OIL_CONVENTIONAL_TANK_ENGLISH,
+            WaterHeaterType.OIL_CONVENTIONAL_TANK_FRENCH,
         ),
         ("Oil", "Tankless coil"): (
-            WaterHeaterType.OIL_TANKLESS_COIL_ENGLISH.value,
-            WaterHeaterType.OIL_TANKLESS_COIL_FRENCH.value,
+            WaterHeaterType.OIL_TANKLESS_COIL_ENGLISH,
+            WaterHeaterType.OIL_TANKLESS_COIL_FRENCH,
         ),
         ("Propane", "Not applicable"): (
-            WaterHeaterType.NOT_APPLICABLE.value,
-            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE,
+            WaterHeaterType.NOT_APPLICABLE,
         ),
         ("Propane", "Conventional tank"): (
-            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_ENGLISH.value,
-            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_FRENCH.value,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_ENGLISH,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_FRENCH,
         ),
         ("Propane", "Conventional tank (pilot)"): (
-            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_ENGLISH.value,
-            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_FRENCH.value,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_ENGLISH,
+            WaterHeaterType.PROPANE_CONVENTIONAL_TANK_PILOT_FRENCH,
         ),
         ("Propane", "Tankless coil"): (
-            WaterHeaterType.PROPANE_TANKLESS_COIL_ENGLISH.value,
-            WaterHeaterType.PROPANE_TANKLESS_COIL_FRENCH.value,
+            WaterHeaterType.PROPANE_TANKLESS_COIL_ENGLISH,
+            WaterHeaterType.PROPANE_TANKLESS_COIL_FRENCH,
         ),
         ("Propane", "Instantaneous"): (
-            WaterHeaterType.PROPANE_INSTANTANEOUS_ENGLISH.value,
-            WaterHeaterType.PROPANE_INSTANTANEOUS_FRENCH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_ENGLISH,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_FRENCH,
         ),
         ("Propane", "Instantaneous (condensing)"): (
-            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_ENGLISH.value,
-            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_FRENCH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_ENGLISH,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_CONDENSING_FRENCH,
         ),
         ("Propane", "Instantaneous (pilot)"): (
-            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_ENGLISH.value,
-            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_FRENCH.value,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_ENGLISH,
+            WaterHeaterType.PROPANE_INSTANTANEOUS_PILOT_FRENCH,
         ),
         ("Propane", "Induced draft fan"): (
-            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_ENGLISH.value,
-            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_FRENCH.value,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_ENGLISH,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_FRENCH,
         ),
         ("Propane", "Induced draft fan (pilot)"): (
-            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_ENGLISH.value,
-            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_FRENCH.value,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_ENGLISH,
+            WaterHeaterType.PROPANE_INDUCED_DRAFT_FAN_PILOT_FRENCH,
         ),
         ("Propane", "Direct vent (sealed)"): (
-            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_ENGLISH.value,
-            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_FRENCH.value,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_ENGLISH,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_FRENCH,
         ),
         ("Propane", "Direct vent (sealed, pilot)"): (
-            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_ENGLISH.value,
-            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_FRENCH.value,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_ENGLISH,
+            WaterHeaterType.PROPANE_DIRECT_VENT_SEALED_PILOT_FRENCH,
         ),
         ("Propane", "Condensing"): (
-            WaterHeaterType.PROPANE_CONDENSING_ENGLISH.value,
-            WaterHeaterType.PROPANE_CONDENSING_FRENCH.value,
+            WaterHeaterType.PROPANE_CONDENSING_ENGLISH,
+            WaterHeaterType.PROPANE_CONDENSING_FRENCH,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Not applicable"): (
-            WaterHeaterType.NOT_APPLICABLE.value,
-            WaterHeaterType.NOT_APPLICABLE.value,
+            WaterHeaterType.NOT_APPLICABLE,
+            WaterHeaterType.NOT_APPLICABLE,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Fireplace"): (
-            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_ENGLISH.value,
-            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_FRENCH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_ENGLISH,
+            WaterHeaterType.WOOD_SPACE_HEATING_FIREPLACE_FRENCH,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Wood stove water coil"): (
-            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_ENGLISH.value,
-            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_FRENCH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_ENGLISH,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_STOVE_WATER_COIL_FRENCH,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Indoor wood boiler"): (
-            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_ENGLISH.value,
-            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_FRENCH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_ENGLISH,
+            WaterHeaterType.WOOD_SPACE_HEATING_INDOOR_WOOD_BOILER_FRENCH,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Outdoor wood boiler"): (
-            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_ENGLISH.value,
-            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_FRENCH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_ENGLISH,
+            WaterHeaterType.WOOD_SPACE_HEATING_OUTDOOR_WOOD_BOILER_FRENCH,
         ),
         ("Wood Space Heating (Mixed Wood, Hardwood, Soft Wood or Wood Pellets)", "Wood hot water tank"): (
-            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_ENGLISH.value,
-            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_FRENCH.value,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_ENGLISH,
+            WaterHeaterType.WOOD_SPACE_HEATING_WOOD_HOT_WATER_TANK_FRENCH,
         ),
         ("Solar", "Solar Collector System"): (
-            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_ENGLISH.value,
-            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_FRENCH.value,
+            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_ENGLISH,
+            WaterHeaterType.SOLAR_COLLECTOR_SYSTEM_FRENCH,
         ),
         ("CSA P9-11 tested Combo Heat/DHW", "CSA P9-11 tested Combo Heat/DHW"): (
-            WaterHeaterType.CSA_DHW_ENGLISH.value,
-            WaterHeaterType.CSA_DHW_FRENCH.value,
+            WaterHeaterType.CSA_DHW_ENGLISH,
+            WaterHeaterType.CSA_DHW_FRENCH,
         ),
     }
 
@@ -762,8 +762,8 @@ class WaterHeating(_WaterHeating):
     def _from_data(cls, water_heating: element.Element) -> 'WaterHeating':
         assert water_heating.attrib['hasDrainWaterHeatRecovery'] == 'false'
 
-        energy_type = water_heating.xpath('EnergySource/English/text()')[0]
-        tank_type = water_heating.xpath('TankType/English/text()')[0]
+        energy_type = water_heating.get_text('EnergySource/English')
+        tank_type = water_heating.get_text('TankType/English')
 
         type_english, type_french = cls._TYPE_MAP[(energy_type, tank_type)]
         volume = float(water_heating.xpath('TankVolume/@value')[0])
@@ -783,15 +783,15 @@ class WaterHeating(_WaterHeating):
 
 
     @property
-    def tank_volume_usg(self):
-        return self.tank_volume * _LITRE_TO_USG
+    def tank_volume_gallon(self):
+        return self.tank_volume * _LITRE_TO_GALLON
 
 
     def to_dict(self) -> typing.Dict[str, typing.Union[str, float]]:
         return {
-            'typeEnglish': self.type_english,
-            'typeFrench': self.type_french,
+            'typeEnglish': self.type_english.value,
+            'typeFrench': self.type_french.value,
             'tankVolumeLitres': self.tank_volume,
-            'TankVolumeUsg': self.tank_volume_usg,
+            'TankVolumeGallon': self.tank_volume_gallon,
             'efficiency': self.efficiency,
         }

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -42,7 +42,7 @@ class HouseSnippet(_HouseSnippet):
             'heatedFloorArea': self.heated_floor_area,
             'heating_cooling': self.heating_cooling,
             'ventilations': self.ventilation,
-            'waterHeating': self.water_heating,
+            'waterHeatings': self.water_heating,
         }
 
 

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -545,8 +545,8 @@ class TestParsedDwellingDataRow:
             ],
             water_heatings=[
                 extracted_datatypes.WaterHeating(
-                    type_english='Electric storage tank',
-                    type_french='Réservoir électrique',
+                    type_english=extracted_datatypes.WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_ENGLISH,
+                    type_french=extracted_datatypes.WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_FRENCH,
                     tank_volume=189.3001,
                     efficiency=0.8217,
                 )

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -222,7 +222,7 @@ def ventilation_input() -> typing.List[str]:
 
 
 @pytest.fixture
-def water_heating_input() -> typing.List[str]:
+def water_heating_input() -> str:
     doc = """
 <HotWater>
     <Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -224,34 +224,36 @@ def ventilation_input() -> typing.List[str]:
 @pytest.fixture
 def water_heating_input() -> typing.List[str]:
     doc = """
-<Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
-    <EquipmentInformation>
-        <Manufacturer>Wizard DHW man</Manufacturer>
-        <Model>Wizard DHW mod</Model>
-    </EquipmentInformation>
-    <EnergySource code="1">
-        <English>Electricity</English>
-        <French>Électricité</French>
-    </EnergySource>
-    <TankType code="2">
-        <English>Conventional tank</English>
-        <French>Réservoir classique</French>
-    </TankType>
-    <TankVolume code="4" value="189.3001">
-        <English>189.3 L, 41.6 Imp, 50 US gal</English>
-        <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
-    </TankVolume>
-    <EnergyFactor code="1" value="0.8217" inputCapacity="0">
-        <English>Use defaults</English>
-        <French>Valeurs par défaut</French>
-    </EnergyFactor>
-    <TankLocation code="2">
-        <English>Basement</English>
-        <French>Sous-sol</French>
-    </TankLocation>
-</Primary>
+<HotWater>
+    <Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
+        <EquipmentInformation>
+            <Manufacturer>Wizard DHW man</Manufacturer>
+            <Model>Wizard DHW mod</Model>
+        </EquipmentInformation>
+        <EnergySource code="1">
+            <English>Electricity</English>
+            <French>Électricité</French>
+        </EnergySource>
+        <TankType code="2">
+            <English>Conventional tank</English>
+            <French>Réservoir classique</French>
+        </TankType>
+        <TankVolume code="4" value="189.3001">
+            <English>189.3 L, 41.6 Imp, 50 US gal</English>
+            <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
+        </TankVolume>
+        <EnergyFactor code="1" value="0.8217" inputCapacity="0">
+            <English>Use defaults</English>
+            <French>Valeurs par défaut</French>
+        </EnergyFactor>
+        <TankLocation code="2">
+            <English>Basement</English>
+            <French>Sous-sol</French>
+        </TankLocation>
+    </Primary>
+</HotWater>
     """
-    return [doc]
+    return doc
 
 
 @pytest.fixture
@@ -365,7 +367,7 @@ def sample_input_d(ceiling_input: typing.List[str],
                    heated_floor_area_input: str,
                    heating_cooling_input: str,
                    ventilation_input: typing.List[str],
-                   water_heating_input: typing.List[str],
+                   water_heating_input: str,
                    raw_codes: typing.Dict[str, typing.List[str]]) -> reader.InputData:
 
     return {

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -222,6 +222,39 @@ def ventilation_input() -> typing.List[str]:
 
 
 @pytest.fixture
+def water_heating_input() -> typing.List[str]:
+    doc = """
+<Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
+    <EquipmentInformation>
+        <Manufacturer>Wizard DHW man</Manufacturer>
+        <Model>Wizard DHW mod</Model>
+    </EquipmentInformation>
+    <EnergySource code="1">
+        <English>Electricity</English>
+        <French>Électricité</French>
+    </EnergySource>
+    <TankType code="2">
+        <English>Conventional tank</English>
+        <French>Réservoir classique</French>
+    </TankType>
+    <TankVolume code="4" value="189.3001">
+        <English>189.3 L, 41.6 Imp, 50 US gal</English>
+        <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
+    </TankVolume>
+    <EnergyFactor code="1" value="0.8217" inputCapacity="0">
+        <English>Use defaults</English>
+        <French>Valeurs par défaut</French>
+    </EnergyFactor>
+    <TankLocation code="2">
+        <English>Basement</English>
+        <French>Sous-sol</French>
+    </TankLocation>
+</Primary>
+    """
+    return [doc]
+
+
+@pytest.fixture
 def raw_codes() -> typing.Dict[str, typing.List[str]]:
     return {
         'wall': [
@@ -332,7 +365,9 @@ def sample_input_d(ceiling_input: typing.List[str],
                    heated_floor_area_input: str,
                    heating_cooling_input: str,
                    ventilation_input: typing.List[str],
+                   water_heating_input: typing.List[str],
                    raw_codes: typing.Dict[str, typing.List[str]]) -> reader.InputData:
+
     return {
         'EVAL_ID': '123',
         'EVAL_TYPE': 'D',
@@ -351,6 +386,7 @@ def sample_input_d(ceiling_input: typing.List[str],
         'heating_cooling': heating_cooling_input,
         'heatedFloorArea': heated_floor_area_input,
         'ventilations': ventilation_input,
+        'waterHeatings': water_heating_input,
         'codes': raw_codes,
     }
 
@@ -503,6 +539,14 @@ class TestParsedDwellingDataRow:
                     type_french='Ventilateur-récupérateur de chaleur',
                     air_flow_rate=220,
                     efficiency=55,
+                )
+            ],
+            water_heatings=[
+                extracted_datatypes.WaterHeating(
+                    type_english='Electric storage tank',
+                    type_french='Réservoir électrique',
+                    tank_volume=189.3001,
+                    efficiency=0.8217,
                 )
             ]
         )

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -421,42 +421,44 @@ class TestWaterHeating:
     @pytest.fixture
     def sample(self) -> element.Element:
         data = """
-<Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
-    <EquipmentInformation>
-        <Manufacturer>Wizard DHW man</Manufacturer>
-        <Model>Wizard DHW mod</Model>
-    </EquipmentInformation>
-    <EnergySource code="1">
-        <English>Electricity</English>
-        <French>Électricité</French>
-    </EnergySource>
-    <TankType code="2">
-        <English>Conventional tank</English>
-        <French>Réservoir classique</French>
-    </TankType>
-    <TankVolume code="4" value="189.3001">
-        <English>189.3 L, 41.6 Imp, 50 US gal</English>
-        <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
-    </TankVolume>
-    <EnergyFactor code="1" value="0.8217" inputCapacity="0">
-        <English>Use defaults</English>
-        <French>Valeurs par défaut</French>
-    </EnergyFactor>
-    <TankLocation code="2">
-        <English>Basement</English>
-        <French>Sous-sol</French>
-    </TankLocation>
-</Primary>
+<HotWater>
+    <Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
+        <EquipmentInformation>
+            <Manufacturer>Wizard DHW man</Manufacturer>
+            <Model>Wizard DHW mod</Model>
+        </EquipmentInformation>
+        <EnergySource code="1">
+            <English>Electricity</English>
+            <French>Électricité</French>
+        </EnergySource>
+        <TankType code="2">
+            <English>Conventional tank</English>
+            <French>Réservoir classique</French>
+        </TankType>
+        <TankVolume code="4" value="189.3001">
+            <English>189.3 L, 41.6 Imp, 50 US gal</English>
+            <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
+        </TankVolume>
+        <EnergyFactor code="1" value="0.8217" inputCapacity="0">
+            <English>Use defaults</English>
+            <French>Valeurs par défaut</French>
+        </EnergyFactor>
+        <TankLocation code="2">
+            <English>Basement</English>
+            <French>Sous-sol</French>
+        </TankLocation>
+    </Primary>
+</HotWater>
         """
         return element.Element.from_string(data)
 
     def test_from_data(self, sample: element.Element) -> None:
-        output = extracted_datatypes.WaterHeating.from_data(sample)
+        output = extracted_datatypes.WaterHeating.from_data(sample)[0]
         assert output.type_english == 'Electric storage tank'
         assert output.efficiency == 0.8217
 
     def test_to_dict(self, sample: element.Element) -> None:
-        output = extracted_datatypes.WaterHeating.from_data(sample).to_dict()
+        output = extracted_datatypes.WaterHeating.from_data(sample)[0].to_dict()
         assert output == {
             'typeEnglish': 'Electric storage tank',
             'typeFrench': 'Réservoir électrique',
@@ -466,5 +468,5 @@ class TestWaterHeating:
         }
 
     def test_properties(self, sample: element.Element) -> None:
-        output = extracted_datatypes.WaterHeating.from_data(sample)
+        output = extracted_datatypes.WaterHeating.from_data(sample)[0]
         assert output.tank_volume_usg == 50.0077860172

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -414,3 +414,57 @@ class TestVentilation:
     def test_properties(self, sample: element.Element) -> None:
         output = extracted_datatypes.Ventilation.from_data(sample)
         assert output.air_flow_rate_cmf == 466.1536
+
+
+class TestWaterHeating:
+
+    @pytest.fixture
+    def sample(self) -> element.Element:
+        data = """
+<Primary hasDrainWaterHeatRecovery="false" insulatingBlanket="0" combinedFlue="false" flueDiameter="0" energyStar="false" ecoEnergy="false" userDefinedPilot="false" connectedUnitsDwhr="0">
+    <EquipmentInformation>
+        <Manufacturer>Wizard DHW man</Manufacturer>
+        <Model>Wizard DHW mod</Model>
+    </EquipmentInformation>
+    <EnergySource code="1">
+        <English>Electricity</English>
+        <French>Électricité</French>
+    </EnergySource>
+    <TankType code="2">
+        <English>Conventional tank</English>
+        <French>Réservoir classique</French>
+    </TankType>
+    <TankVolume code="4" value="189.3001">
+        <English>189.3 L, 41.6 Imp, 50 US gal</English>
+        <French>189.3 L, 41.6 imp, 50 gal ÉU</French>
+    </TankVolume>
+    <EnergyFactor code="1" value="0.8217" inputCapacity="0">
+        <English>Use defaults</English>
+        <French>Valeurs par défaut</French>
+    </EnergyFactor>
+    <TankLocation code="2">
+        <English>Basement</English>
+        <French>Sous-sol</French>
+    </TankLocation>
+</Primary>
+        """
+        return element.Element.from_string(data)
+
+    def test_from_data(self, sample: element.Element) -> None:
+        output = extracted_datatypes.WaterHeating.from_data(sample)
+        assert output.type_english == 'Electric storage tank'
+        assert output.efficiency == 0.8217
+
+    def test_to_dict(self, sample: element.Element) -> None:
+        output = extracted_datatypes.WaterHeating.from_data(sample).to_dict()
+        assert output == {
+            'typeEnglish': 'Electric storage tank',
+            'typeFrench': 'Réservoir électrique',
+            'tankVolumeLitres': 189.3001,
+            'TankVolumeUsg': 50.0077860172,
+            'efficiency': 0.8217,
+        }
+
+    def test_properties(self, sample: element.Element) -> None:
+        output = extracted_datatypes.WaterHeating.from_data(sample)
+        assert output.tank_volume_usg == 50.0077860172

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -454,7 +454,7 @@ class TestWaterHeating:
 
     def test_from_data(self, sample: element.Element) -> None:
         output = extracted_datatypes.WaterHeating.from_data(sample)[0]
-        assert output.type_english == 'Electric storage tank'
+        assert output.type_english == extracted_datatypes.WaterHeaterType.ELECTRICITY_CONVENTIONAL_TANK_ENGLISH
         assert output.efficiency == 0.8217
 
     def test_to_dict(self, sample: element.Element) -> None:
@@ -463,10 +463,10 @@ class TestWaterHeating:
             'typeEnglish': 'Electric storage tank',
             'typeFrench': 'Réservoir électrique',
             'tankVolumeLitres': 189.3001,
-            'TankVolumeUsg': 50.0077860172,
+            'TankVolumeGallon': 50.0077860172,
             'efficiency': 0.8217,
         }
 
     def test_properties(self, sample: element.Element) -> None:
         output = extracted_datatypes.WaterHeating.from_data(sample)[0]
-        assert output.tank_volume_usg == 50.0077860172
+        assert output.tank_volume_gallon == 50.0077860172


### PR DESCRIPTION
This PR adds functionality to transform and load water heating data.

While the line count is much larger than I would like, it is artificially inflated by a very large enum created to store all 79 possible type values for water heating, that are derived from the energy type and the tank type.