### PR TITLE
replace more uses of _Element

### DIFF
--- a/python/src/energuide/element.py
+++ b/python/src/energuide/element.py
@@ -4,12 +4,19 @@ from lxml import etree
 
 class Element:
 
+    _PARSER = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
+
     def __init__(self, node: etree._Element) -> None:
         self.__node = node
 
     @classmethod
     def from_string(cls, data: str) -> 'Element':
-        output = etree.fromstring(data)
+        output = etree.fromstring(data.encode('utf-8'), parser=cls._PARSER)
+        return cls(output)
+
+    @classmethod
+    def parse(cls, *args, **kwargs):
+        output = etree.parse(*args, **kwargs)
         return cls(output)
 
     def findtext(self, *args, **kwargs) -> typing.Optional[str]:
@@ -27,3 +34,18 @@ class Element:
     def xpath(self, *args, **kwargs) -> typing.List[typing.Any]:
         output = self.__node.xpath(*args, **kwargs)
         return [Element(node) if isinstance(node, etree._Element) else node for node in output]
+
+    def find(self, *args, **kwargs) -> typing.Optional['Element']:
+        output = self.__node.find(*args, **kwargs)
+        return Element(output) if output is not None else None
+
+    def to_string(self) -> str:
+        return etree.tostring(self.__node, encoding='unicode')
+
+    def __iter__(self) -> typing.Iterator[typing.Any]:
+        for child in self.__node.__iter__():
+            yield Element(child)
+
+    @property
+    def tag(self):
+        return self.__node.tag

--- a/python/src/energuide/element.py
+++ b/python/src/energuide/element.py
@@ -17,7 +17,7 @@ class Element:
     @classmethod
     def parse(cls, *args, **kwargs):
         output = etree.parse(*args, **kwargs)
-        return cls(output)
+        return cls(output.find('.'))
 
     def findtext(self, *args, **kwargs) -> typing.Optional[str]:
         return self.__node.findtext(*args, **kwargs)

--- a/python/src/energuide/extractor.py
+++ b/python/src/energuide/extractor.py
@@ -3,8 +3,8 @@ import json
 import typing
 import sys
 import zipfile
-from lxml import etree
 import cerberus
+from energuide import element
 from energuide import reader
 from energuide import snippets
 
@@ -63,12 +63,10 @@ def _safe_merge(data: reader.InputData, extra: reader.InputData) -> reader.Input
 
 
 def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterator[reader.InputData]:
-    parser = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
-
     for row in data:
         row['forwardSortationArea'] = row['CLIENTPCODE'][:3]
 
-        doc = etree.fromstring(row['RAW_XML'].encode('utf-8'), parser=parser)
+        doc = element.Element.from_string(row['RAW_XML'])
         house_node = doc.xpath('House')
         if house_node:
             house_snippets = snippets.snip_house(house_node[0])

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -1,5 +1,5 @@
 import typing
-from lxml import etree
+from energuide import element
 
 
 class _Codes(typing.NamedTuple):
@@ -46,13 +46,7 @@ class HouseSnippet(_HouseSnippet):
         }
 
 
-def _extract_values(node: etree._Element,
-                    xpath_mapping: typing.Dict[str, str]) -> typing.Dict[str, typing.Optional[str]]:
-    output = {key: node.xpath(value) for key, value in xpath_mapping.items()}
-    return {key: value[0] if value else None for key, value in output.items()}
-
-
-def snip_house(house: etree._Element) -> HouseSnippet:
+def snip_house(house: element.Element) -> HouseSnippet:
     ceilings = house.xpath('Components/Ceiling')
     floors = house.xpath('Components/Floor')
     walls = house.xpath('Components/Wall')
@@ -60,11 +54,9 @@ def snip_house(house: etree._Element) -> HouseSnippet:
     windows = house.xpath('Components//Components/Window')
     heated_floor_area = house.xpath('Specifications/HeatedFloorArea')
     heating_cooling = house.xpath('HeatingCooling')
-    heating_cooling_string = (
-        etree.tostring(heating_cooling[0], encoding='unicode') if heating_cooling else None
-    )
+    heating_cooling_string = heating_cooling[0].to_string() if heating_cooling else None
     ventilation = house.xpath('Ventilation/WholeHouseVentilatorList/Hrv')
-    ventilation_strings = [etree.tostring(hrv, encoding='unicode') for hrv in ventilation]
+    ventilation_strings = [hrv.to_string() for hrv in ventilation]
 
     water_heating = house.xpath('Components/HotWater')
     water_heating_string = (
@@ -73,25 +65,23 @@ def snip_house(house: etree._Element) -> HouseSnippet:
 
 
     return HouseSnippet(
-        ceilings=[etree.tostring(node, encoding='unicode') for node in ceilings],
-        floors=[etree.tostring(node, encoding='unicode') for node in floors],
-        walls=[etree.tostring(node, encoding='unicode') for node in walls],
-        doors=[etree.tostring(node, encoding='unicode') for node in doors],
-        windows=[etree.tostring(node, encoding='unicode') for node in windows],
-        heated_floor_area=etree.tostring(heated_floor_area[0], encoding='unicode') if heated_floor_area else None,
+        ceilings=[node.to_string() for node in ceilings],
+        floors=[node.to_string() for node in floors],
+        walls=[node.to_string() for node in walls],
+        doors=[node.to_string() for node in doors],
+        windows=[node.to_string() for node in windows],
+        heated_floor_area=heated_floor_area[0].to_string() if heated_floor_area else None,
         heating_cooling=heating_cooling_string,
         ventilation=ventilation_strings,
         water_heating=water_heating_string,
     )
 
 
-
-def snip_codes(codes: etree._Element
-              ) -> Codes:
+def snip_codes(codes: element.Element) -> Codes:
     wall_codes = codes.xpath('Wall/*/Code')
     window_codes = codes.xpath('Window/*/Code')
 
     return Codes(
-        wall=[etree.tostring(node, encoding='unicode') for node in wall_codes],
-        window=[etree.tostring(node, encoding='unicode') for node in window_codes],
+        wall=[node.to_string() for node in wall_codes],
+        window=[node.to_string() for node in window_codes],
     )

--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -27,7 +27,7 @@ class _HouseSnippet(typing.NamedTuple):
     heated_floor_area: str
     heating_cooling: str
     ventilation: typing.List[str]
-    water_heating: typing.List[str]
+    water_heating: str
 
 
 class HouseSnippet(_HouseSnippet):
@@ -59,10 +59,7 @@ def snip_house(house: element.Element) -> HouseSnippet:
     ventilation_strings = [hrv.to_string() for hrv in ventilation]
 
     water_heating = house.xpath('Components/HotWater')
-    water_heating_string = (
-        etree.tostring(water_heating[0], encoding='unicode') if water_heating else None
-    )
-
+    water_heating_string = water_heating[0].to_string() if water_heating else None
 
     return HouseSnippet(
         ceilings=[node.to_string() for node in ceilings],

--- a/python/tests/test_element.py
+++ b/python/tests/test_element.py
@@ -1,21 +1,89 @@
+import py._path.local
 import pytest
 from energuide import element
 
 
-def test_get_text() -> None:
-    node = element.Element.from_string('<Foo><Bar>baz</Bar></Foo>')
-    assert node.get_text('Bar') == 'baz'
+@pytest.fixture
+def fragment() -> str:
+    return "<Foo><Bar id='1'>baz</Bar><Bar id='1'>qux</Bar></Foo>"
 
 
-def test_get_text_raises_when_not_found() -> None:
-    node = element.Element.from_string('<Foo><Bar>baz</Bar></Foo>')
+@pytest.fixture
+def fragment_file_path(fragment: str, tmpdir: py._path.local.LocalPath) -> str:
+    file = tmpdir.join('data.xml')
+    file.write_text('<?xml version="1.0" encoding="UTF-8" ?>', encoding='utf-8')
+    file.write_text(fragment, encoding='utf-8')
+    return str(file)
+
+
+@pytest.fixture
+def fragment_node(fragment: str) -> element.Element:
+    return element.Element.from_string(fragment)
+
+
+def test_from_string(fragment: str) -> None:
+    output = element.Element.from_string(fragment)
+    assert isinstance(output, element.Element)
+    assert output.tag == 'Foo'
+
+
+def test_findtext(fragment_node: element.Element) -> None:
+    assert fragment_node.findtext('Bar') == 'baz'
+    assert fragment_node.findtext('Baz') is None
+
+
+def test_get_text(fragment_node: element.Element) -> None:
+    assert fragment_node.get_text('Bar') == 'baz'
+
+
+def test_get_text_raises_when_not_found(fragment_node: element.Element) -> None:
     with pytest.raises(AssertionError):
-        node.get_text('Baz')
+        fragment_node.get_text('Baz')
 
 
-def test_xpath_returns_elements() -> None:
-    node = element.Element.from_string("<Foo><Bar baz='1' /><Bar baz='2' /></Foo>")
-    output = node.xpath('Bar')
+def test_attrib(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.attrib['id'] == '1'
+    assert 'baz' not in bar_node.attrib
+
+
+def test_xpath_returns_elements(fragment_node: element.Element) -> None:
+    output = fragment_node.xpath('Bar')
     assert len(output) == 2
     assert all([isinstance(bar_node, element.Element) for bar_node in output])
-    assert output[0].attrib['baz'] == '1'
+    assert output[0].attrib['id'] == '1'
+
+
+def test_parse(fragment_file_path: str) -> None:
+    with open(fragment_file_path) as xml_file:
+        node = element.Element.parse(xml_file)
+    assert node.tag == 'Foo'
+
+
+def test_iter(fragment_node: element.Element) -> None:
+    child_nodes = [child for child in fragment_node]
+    assert len(child_nodes) == 2
+    assert all([isinstance(child, element.Element) for child in child_nodes])
+    assert all([child.tag == 'Bar' for child in child_nodes])
+
+
+def test_find(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.tag == 'Bar'
+    assert bar_node.attrib['id'] == '1'
+
+
+def test_find_returns_none(fragment_node: element.Element) -> None:
+    assert fragment_node.find('Baz') is None
+
+
+def test_to_string(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.to_string() == '<Bar id="1">baz</Bar>'
+
+
+def test_tag(fragment_node: element.Element) -> None:
+    assert fragment_node.tag == 'Foo'

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -1,38 +1,38 @@
 import os
-from lxml import etree
 import pytest
+from energuide import element
 from energuide import snippets
 from energuide import validator
 
 
 @pytest.fixture
-def doc() -> etree._ElementTree:
+def doc() -> element.Element:
     sample_filename = os.path.join(os.path.dirname(__file__), 'sample.h2k')
     with open(sample_filename, 'r') as h2k:
-        doc = etree.parse(h2k)
+        doc = element.Element.parse(h2k)
     return doc
 
 
 @pytest.fixture
-def house(doc: etree._ElementTree) -> etree._Element:
+def house(doc: element.Element) -> element.Element:
     house_node = doc.find('House')
     assert house_node is not None
     return house_node
 
 
 @pytest.fixture
-def code(doc: etree._ElementTree) -> etree._Element:
+def code(doc: element.Element) -> element.Element:
     code_node = doc.find('Codes')
     assert code_node is not None
     return code_node
 
 
-def test_house_snippet_to_dict(house: etree._Element) -> None:
+def test_house_snippet_to_dict(house: element.Element) -> None:
     output = snippets.snip_house(house).to_dict()
     assert len(output) == 9
 
 
-def test_ceiling_snippet(house: etree._Element) -> None:
+def test_ceiling_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.ceilings) == 2
     checker = validator.DwellingValidator({
@@ -42,7 +42,7 @@ def test_ceiling_snippet(house: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_floor_snippet(house: etree._Element) -> None:
+def test_floor_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.floors) == 1
     checker = validator.DwellingValidator({
@@ -52,7 +52,7 @@ def test_floor_snippet(house: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_wall_snippet(house: etree._Element) -> None:
+def test_wall_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.walls) == 3
     checker = validator.DwellingValidator({
@@ -62,7 +62,7 @@ def test_wall_snippet(house: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_window_snippet(house: etree._Element) -> None:
+def test_window_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.windows) == 10
     checker = validator.DwellingValidator({
@@ -72,7 +72,7 @@ def test_window_snippet(house: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_heated_floor_area_snippet(house: etree._Element) -> None:
+def test_heated_floor_area_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     checker = validator.DwellingValidator({
         'heated_floor': {'type': 'xml', 'coerce': 'parse_xml'}
@@ -143,13 +143,13 @@ def test_deeply_embedded_components() -> None:
 </Components></House>
     """
 
-    doc = etree.fromstring(xml_text)
+    doc = element.Element.from_string(xml_text)
     output = snippets.snip_house(doc)
     assert len(output.windows) == 2
     assert len(output.doors) == 2
 
 
-def test_wall_code_snippet(code: etree._Element) -> None:
+def test_wall_code_snippet(code: element.Element) -> None:
     output = snippets.snip_codes(code)
     assert len(output.wall) == 2
     checker = validator.DwellingValidator({
@@ -159,7 +159,7 @@ def test_wall_code_snippet(code: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_window_code_snippet(code: etree._Element) -> None:
+def test_window_code_snippet(code: element.Element) -> None:
     output = snippets.snip_codes(code)
     assert len(output.wall) == 2
     checker = validator.DwellingValidator({
@@ -169,7 +169,7 @@ def test_window_code_snippet(code: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_door_snippet(house: etree._Element) -> None:
+def test_door_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.doors) == 2
     checker = validator.DwellingValidator({
@@ -179,17 +179,17 @@ def test_door_snippet(house: etree._Element) -> None:
     assert checker.validate(doc)
 
 
-def test_heating_cooling_snippet(house: etree._Element) -> None:
+def test_heating_cooling_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
-    doc = etree.fromstring(output.heating_cooling)
+    doc = element.Element.from_string(output.heating_cooling)
     child_tags = {node.tag for node in doc}
     assert 'Label' in child_tags
     assert len(child_tags) == 6
 
 
-def test_ventilation_snippet(house: etree._Element) -> None:
+def test_ventilation_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
-    doc = etree.fromstring(output.ventilation[0])
+    doc = element.Element.from_string(output.ventilation[0])
     child_tags = {node.tag for node in doc}
     assert 'VentilatorType' in child_tags
     assert len(child_tags) == 3

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -195,9 +195,9 @@ def test_ventilation_snippet(house: element.Element) -> None:
     assert len(child_tags) == 3
 
 
-def test_water_heating(house: etree._Element) -> None:
+def test_water_heating(house: element.Element) -> None:
     output = snippets.snip_house(house)
-    doc = etree.fromstring(output.water_heating)
+    doc = element.Element.from_string(output.water_heating)
     nodes = doc.xpath('*[self::Primary or self::Secondary]')
     assert len(nodes) == 2
 


### PR DESCRIPTION
This PR replaces the last of the `lxml._Element` uses in the codebase with `element.Element` for type checking greatness.