### PR TITLE
make snippets more typesafe

### DIFF
--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -24,10 +24,10 @@ class _HouseSnippet(typing.NamedTuple):
     walls: typing.List[str]
     doors: typing.List[str]
     windows: typing.List[str]
-    heated_floor_area: str
-    heating_cooling: str
+    heated_floor_area: typing.Optional[str]
+    heating_cooling: typing.Optional[str]
     ventilation: typing.List[str]
-    water_heating: str
+    water_heating: typing.Optional[str]
 
 
 class HouseSnippet(_HouseSnippet):
@@ -46,19 +46,23 @@ class HouseSnippet(_HouseSnippet):
         }
 
 
+def _extract_nodes(node: element.Element, path: str) -> typing.List[element.Element]:
+    return node.xpath(path)
+
+
 def snip_house(house: element.Element) -> HouseSnippet:
-    ceilings = house.xpath('Components/Ceiling')
-    floors = house.xpath('Components/Floor')
-    walls = house.xpath('Components/Wall')
-    doors = house.xpath('Components//Components/Door')
-    windows = house.xpath('Components//Components/Window')
-    heated_floor_area = house.xpath('Specifications/HeatedFloorArea')
-    heating_cooling = house.xpath('HeatingCooling')
+    ceilings = _extract_nodes(house, 'Components/Ceiling')
+    floors = _extract_nodes(house, 'Components/Floor')
+    walls = _extract_nodes(house, 'Components/Wall')
+    doors = _extract_nodes(house, 'Components//Components/Door')
+    windows = _extract_nodes(house, 'Components//Components/Window')
+    heated_floor_area = _extract_nodes(house, 'Specifications/HeatedFloorArea')
+    heating_cooling = _extract_nodes(house, 'HeatingCooling')
     heating_cooling_string = heating_cooling[0].to_string() if heating_cooling else None
-    ventilation = house.xpath('Ventilation/WholeHouseVentilatorList/Hrv')
+    ventilation = _extract_nodes(house, 'Ventilation/WholeHouseVentilatorList/Hrv')
     ventilation_strings = [hrv.to_string() for hrv in ventilation]
 
-    water_heating = house.xpath('Components/HotWater')
+    water_heating = _extract_nodes(house, 'Components/HotWater')
     water_heating_string = water_heating[0].to_string() if water_heating else None
 
     return HouseSnippet(

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -181,6 +181,7 @@ def test_door_snippet(house: element.Element) -> None:
 
 def test_heating_cooling_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
+    assert output.heating_cooling
     doc = element.Element.from_string(output.heating_cooling)
     child_tags = {node.tag for node in doc}
     assert 'Label' in child_tags
@@ -197,6 +198,7 @@ def test_ventilation_snippet(house: element.Element) -> None:
 
 def test_water_heating(house: element.Element) -> None:
     output = snippets.snip_house(house)
+    assert output.water_heating
     doc = element.Element.from_string(output.water_heating)
     nodes = doc.xpath('*[self::Primary or self::Secondary]')
     assert len(nodes) == 2


### PR DESCRIPTION
I noticed that the inferred types here were all just `list`, so it wasn't detecting Nones being assigned to a `str` NamedTuple value. This PR corrects this.