### PR TITLE
move ceiling out to its own module

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -4,8 +4,8 @@ import typing
 from dateutil import parser
 from energuide import reader
 from energuide import validator
+from energuide.embedded import ceiling
 from energuide.extracted_datatypes import Floor
-from energuide.extracted_datatypes import Ceiling
 from energuide.extracted_datatypes import Door
 from energuide.extracted_datatypes import Wall
 from energuide.extracted_datatypes import Window
@@ -84,7 +84,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     city: str
     region: Region
     forward_sortation_area: str
-    ceilings: typing.List[Ceiling]
+    ceilings: typing.List[ceiling.Ceiling]
     floors: typing.List[Floor]
     walls: typing.List[Wall]
     doors: typing.List[Door]
@@ -143,7 +143,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             city=parsed['CLIENTCITY'],
             region=Region.from_data(parsed['HOUSEREGION']),
             forward_sortation_area=parsed['forwardSortationArea'],
-            ceilings=[Ceiling.from_data(ceiling) for ceiling in parsed['ceilings']],
+            ceilings=[ceiling.Ceiling.from_data(ceiling_node) for ceiling_node in parsed['ceilings']],
             floors=[Floor.from_data(floor) for floor in parsed['floors']],
             walls=[Wall.from_data(wall, codes.wall) for wall in parsed['walls']],
             doors=[Door.from_data(door) for door in parsed['doors']],
@@ -161,7 +161,7 @@ class Evaluation:
                  entry_date: datetime.date,
                  creation_date: datetime.datetime,
                  modification_date: datetime.datetime,
-                 ceilings: typing.List[Ceiling],
+                 ceilings: typing.List[ceiling.Ceiling],
                  floors: typing.List[Floor],
                  walls: typing.List[Wall],
                  doors: typing.List[Door],
@@ -217,7 +217,7 @@ class Evaluation:
         return self._modification_date
 
     @property
-    def ceilings(self) -> typing.List[Ceiling]:
+    def ceilings(self) -> typing.List[ceiling.Ceiling]:
         return self._ceilings
 
     @property

--- a/python/src/energuide/embedded/ceiling.py
+++ b/python/src/energuide/embedded/ceiling.py
@@ -1,0 +1,49 @@
+import typing
+from energuide import bilingual
+from energuide import element
+from energuide.embedded import area
+from energuide.embedded import distance
+from energuide.embedded import insulation
+
+
+class _Ceiling(typing.NamedTuple):
+    label: str
+    ceiling_type: bilingual.Bilingual
+    nominal_insulation: insulation.Insulation
+    effective_insulation: insulation.Insulation
+    ceiling_area: area.Area
+    ceiling_length: distance.Distance
+
+
+class Ceiling(_Ceiling):
+
+    @classmethod
+    def from_data(cls, ceiling: element.Element) -> 'Ceiling':
+        return Ceiling(
+            label=ceiling.get_text('Label'),
+            ceiling_type=bilingual.Bilingual(
+                english=ceiling.get_text('Construction/Type/English'),
+                french=ceiling.get_text('Construction/Type/French'),
+            ),
+            nominal_insulation=insulation.Insulation(
+                float(ceiling.xpath('Construction/CeilingType/@nominalInsulation')[0])),
+            effective_insulation=insulation.Insulation(
+                float(ceiling.xpath('Construction/CeilingType/@rValue')[0])),
+            ceiling_area=area.Area(float(ceiling.xpath('Measurements/@area')[0])),
+            ceiling_length=distance.Distance(float(ceiling.xpath('Measurements/@length')[0])),
+        )
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': self.label,
+            'typeEnglish': self.ceiling_type.english,
+            'typeFrench': self.ceiling_type.french,
+            'nominalRsi': self.nominal_insulation.rsi,
+            'nominalR': self.nominal_insulation.r_value,
+            'effectiveRsi': self.effective_insulation.rsi,
+            'effectiveR': self.effective_insulation.r_value,
+            'areaMetres': self.ceiling_area.square_metres,
+            'areaFeet': self.ceiling_area.square_feet,
+            'lengthMetres': self.ceiling_length.metres,
+            'lengthFeet': self.ceiling_length.feet,
+        }

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -2,9 +2,6 @@ import enum
 import typing
 from energuide import element
 from energuide import bilingual
-from energuide.embedded import area
-from energuide.embedded import distance
-from energuide.embedded import insulation
 
 
 class WaterHeaterType(enum.Enum):
@@ -83,15 +80,6 @@ class WaterHeaterType(enum.Enum):
     SOLAR_COLLECTOR_SYSTEM_FRENCH = "Chauffe-eau solaire domestique"
     CSA_DHW_ENGLISH = "Certified combo system, space and domestic water heating"
     CSA_DHW_FRENCH = "Système combiné certifié pour le chauffage des locaux et de l’eau"
-
-
-class _Ceiling(typing.NamedTuple):
-    label: str
-    ceiling_type: bilingual.Bilingual
-    nominal_insulation: insulation.Insulation
-    effective_insulation: insulation.Insulation
-    ceiling_area: area.Area
-    ceiling_length: distance.Distance
 
 
 class _Floor(typing.NamedTuple):
@@ -409,40 +397,6 @@ class Wall(_Wall):
             'areaFeet': self.area_feet,
             'perimeter': self.perimeter,
             'height': self.height,
-        }
-
-
-class Ceiling(_Ceiling):
-
-    @classmethod
-    def from_data(cls, ceiling: element.Element) -> 'Ceiling':
-        return Ceiling(
-            label=ceiling.get_text('Label'),
-            ceiling_type=bilingual.Bilingual(
-                english=ceiling.get_text('Construction/Type/English'),
-                french=ceiling.get_text('Construction/Type/French'),
-            ),
-            nominal_insulation=insulation.Insulation(
-                float(ceiling.xpath('Construction/CeilingType/@nominalInsulation')[0])),
-            effective_insulation=insulation.Insulation(
-                float(ceiling.xpath('Construction/CeilingType/@rValue')[0])),
-            ceiling_area=area.Area(float(ceiling.xpath('Measurements/@area')[0])),
-            ceiling_length=distance.Distance(float(ceiling.xpath('Measurements/@length')[0])),
-        )
-
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
-        return {
-            'label': self.label,
-            'typeEnglish': self.ceiling_type.english,
-            'typeFrench': self.ceiling_type.french,
-            'nominalRsi': self.nominal_insulation.rsi,
-            'nominalR': self.nominal_insulation.r_value,
-            'effectiveRsi': self.effective_insulation.rsi,
-            'effectiveR': self.effective_insulation.r_value,
-            'areaMetres': self.ceiling_area.square_metres,
-            'areaFeet': self.ceiling_area.square_feet,
-            'lengthMetres': self.ceiling_length.metres,
-            'lengthFeet': self.ceiling_length.feet,
         }
 
 

--- a/python/tests/embedded/test_ceiling.py
+++ b/python/tests/embedded/test_ceiling.py
@@ -1,0 +1,59 @@
+import pytest
+from energuide import bilingual
+from energuide import element
+from energuide.embedded import area
+from energuide.embedded import ceiling
+from energuide.embedded import distance
+from energuide.embedded import insulation
+
+
+@pytest.fixture
+def sample_raw() -> element.Element:
+    data = """
+<Ceiling>
+    <Label>Main attic</Label>
+    <Construction>
+        <Type>
+            <English>Attic/gable</English>
+            <French>Combles/pignon</French>
+        </Type>
+        <CeilingType nominalInsulation='2.864' rValue='2.9463' />
+    </Construction>
+    <Measurements area='46.4515' length='23.875' />
+</Ceiling>
+    """
+    return element.Element.from_string(data)
+
+
+@pytest.fixture
+def sample() -> ceiling.Ceiling:
+    return ceiling.Ceiling(
+        label='Main attic',
+        ceiling_type=bilingual.Bilingual(english='Attic/gable', french='Combles/pignon'),
+        nominal_insulation=insulation.Insulation(2.864),
+        effective_insulation=insulation.Insulation(2.9463),
+        ceiling_area=area.Area(46.4515),
+        ceiling_length=distance.Distance(23.875),
+    )
+
+
+def test_from_data(sample_raw: element.Element, sample: ceiling.Ceiling) -> None:
+    output = ceiling.Ceiling.from_data(sample_raw)
+    assert output == sample
+
+
+def test_to_dict(sample: ceiling.Ceiling) -> None:
+    output = sample.to_dict()
+    assert output == {
+        'label': 'Main attic',
+        'typeEnglish': 'Attic/gable',
+        'typeFrench': 'Combles/pignon',
+        'nominalRsi': 2.864,
+        'nominalR': 16.262546197168,
+        'effectiveRsi': 2.9463,
+        'effectiveR': 16.729867269803098,
+        'areaMetres': 46.4515,
+        'areaFeet': 499.9998167217784,
+        'lengthMetres': 23.875,
+        'lengthFeet': 78.330055,
+    }

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -7,6 +7,7 @@ from energuide import dwelling
 from energuide import reader
 from energuide import extracted_datatypes
 from energuide.embedded import area
+from energuide.embedded import ceiling
 from energuide.embedded import distance
 from energuide.embedded import insulation
 
@@ -473,7 +474,7 @@ class TestParsedDwellingDataRow:
             region=dwelling.Region.ONTARIO,
             forward_sortation_area='K1P',
             ceilings=[
-                extracted_datatypes.Ceiling(
+                ceiling.Ceiling(
                     label='Main attic',
                     ceiling_type=bilingual.Bilingual(english='Attic/gable', french='Combles/pignon'),
                     nominal_insulation=insulation.Insulation(2.864),

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -268,39 +268,6 @@ class TestWall:
         assert output.area_feet == 1128.0000721920012
 
 
-class TestCeiling:
-
-    @pytest.fixture
-    def sample(self) -> element.Element:
-        data = """
-<Ceiling>
-    <Label>Main attic</Label>
-    <Construction>
-        <Type>
-            <English>Attic/gable</English>
-            <French>Combles/pignon</French>
-        </Type>
-        <CeilingType nominalInsulation='2.864' rValue='2.9463' />
-    </Construction>
-    <Measurements area='46.4515' length='23.875' />
-</Ceiling>
-        """
-        return element.Element.from_string(data)
-
-    def test_from_data(self, sample: element.Element):
-        output = extracted_datatypes.Ceiling.from_data(sample)
-        assert output.label == 'Main attic'
-        assert output.ceiling_area.square_metres == 46.4515
-
-    def test_to_dict(self, sample: element.Element) -> None:
-        output = extracted_datatypes.Ceiling.from_data(sample).to_dict()
-        assert output['areaMetres'] == 46.4515
-        assert output['nominalR'] == 16.262546197168
-        assert output['effectiveR'] == 16.729867269803098
-        assert output['areaFeet'] == 499.9998167217784
-        assert output['lengthFeet'] == 78.330055
-
-
 class TestFloor:
 
     @pytest.fixture


### PR DESCRIPTION
I've been uncomfortable with the `extracted_datatypes` module for a while, so this is the first step in moving `Ceiling` out to `embedded/ceiling.py`. Also tightens up the tests on `Ceiling` a bit.