### PR TITLE
move floor to separate module

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -5,7 +5,7 @@ from dateutil import parser
 from energuide import reader
 from energuide import validator
 from energuide.embedded import ceiling
-from energuide.extracted_datatypes import Floor
+from energuide.embedded import floor
 from energuide.extracted_datatypes import Door
 from energuide.extracted_datatypes import Wall
 from energuide.extracted_datatypes import Window
@@ -85,7 +85,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     region: Region
     forward_sortation_area: str
     ceilings: typing.List[ceiling.Ceiling]
-    floors: typing.List[Floor]
+    floors: typing.List[floor.Floor]
     walls: typing.List[Wall]
     doors: typing.List[Door]
     windows: typing.List[Window]
@@ -144,7 +144,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             region=Region.from_data(parsed['HOUSEREGION']),
             forward_sortation_area=parsed['forwardSortationArea'],
             ceilings=[ceiling.Ceiling.from_data(ceiling_node) for ceiling_node in parsed['ceilings']],
-            floors=[Floor.from_data(floor) for floor in parsed['floors']],
+            floors=[floor.Floor.from_data(floor_node) for floor_node in parsed['floors']],
             walls=[Wall.from_data(wall, codes.wall) for wall in parsed['walls']],
             doors=[Door.from_data(door) for door in parsed['doors']],
             windows=[Window.from_data(window, codes.window) for window in parsed['windows']],
@@ -162,7 +162,7 @@ class Evaluation:
                  creation_date: datetime.datetime,
                  modification_date: datetime.datetime,
                  ceilings: typing.List[ceiling.Ceiling],
-                 floors: typing.List[Floor],
+                 floors: typing.List[floor.Floor],
                  walls: typing.List[Wall],
                  doors: typing.List[Door],
                  windows: typing.List[Window],
@@ -221,7 +221,7 @@ class Evaluation:
         return self._ceilings
 
     @property
-    def floors(self) -> typing.List[Floor]:
+    def floors(self) -> typing.List[floor.Floor]:
         return self._floors
 
     @property

--- a/python/src/energuide/embedded/floor.py
+++ b/python/src/energuide/embedded/floor.py
@@ -1,0 +1,39 @@
+import typing
+from energuide import element
+from energuide.embedded import area
+from energuide.embedded import distance
+from energuide.embedded import insulation
+
+
+class _Floor(typing.NamedTuple):
+    label: str
+    nominal_insulation: insulation.Insulation
+    effective_insulation: insulation.Insulation
+    floor_area: area.Area
+    floor_length: distance.Distance
+
+
+class Floor(_Floor):
+
+    @classmethod
+    def from_data(cls, floor: element.Element) -> 'Floor':
+        return Floor(
+            label=floor.get_text('Label'),
+            nominal_insulation=insulation.Insulation(float(floor.xpath('Construction/Type/@nominalInsulation')[0])),
+            effective_insulation=insulation.Insulation(float(floor.xpath('Construction/Type/@rValue')[0])),
+            floor_area=area.Area(float(floor.xpath('Measurements/@area')[0])),
+            floor_length=distance.Distance(float(floor.xpath('Measurements/@length')[0])),
+        )
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': self.label,
+            'nominalRsi': self.nominal_insulation.rsi,
+            'nominalR': self.nominal_insulation.r_value,
+            'effectiveRsi': self.effective_insulation.rsi,
+            'effectiveR': self.effective_insulation.r_value,
+            'areaMetres': self.floor_area.square_metres,
+            'areaFeet': self.floor_area.square_feet,
+            'lengthMetres': self.floor_length.metres,
+            'lengthFeet': self.floor_length.feet,
+        }

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -82,14 +82,6 @@ class WaterHeaterType(enum.Enum):
     CSA_DHW_FRENCH = "Système combiné certifié pour le chauffage des locaux et de l’eau"
 
 
-class _Floor(typing.NamedTuple):
-    label: str
-    nominal_rsi: float
-    effective_rsi: float
-    area_metres: float
-    length_metres: float
-
-
 class _Wall(typing.NamedTuple):
     label: str
     structure_type_english: typing.Optional[str]
@@ -397,48 +389,6 @@ class Wall(_Wall):
             'areaFeet': self.area_feet,
             'perimeter': self.perimeter,
             'height': self.height,
-        }
-
-
-class Floor(_Floor):
-
-    @classmethod
-    def from_data(cls, floor: element.Element) -> 'Floor':
-        return Floor(
-            label=floor.get_text('Label'),
-            nominal_rsi=float(floor.xpath('Construction/Type/@nominalInsulation')[0]),
-            effective_rsi=float(floor.xpath('Construction/Type/@rValue')[0]),
-            area_metres=float(floor.xpath('Measurements/@area')[0]),
-            length_metres=float(floor.xpath('Measurements/@length')[0]),
-        )
-
-    @property
-    def nominal_r(self) -> float:
-        return self.nominal_rsi * _RSI_MULTIPLIER
-
-    @property
-    def effective_r(self) -> float:
-        return self.effective_rsi * _RSI_MULTIPLIER
-
-    @property
-    def area_feet(self) -> float:
-        return self.area_metres * _FEET_SQUARED_MULTIPLIER
-
-    @property
-    def length_feet(self) -> float:
-        return self.length_metres * _FEET_MULTIPLIER
-
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
-        return {
-            'label': self.label,
-            'nominalRsi': self.nominal_rsi,
-            'nominalR': self.nominal_r,
-            'effectiveRsi': self.effective_rsi,
-            'effectiveR': self.effective_r,
-            'areaMetres': self.area_metres,
-            'areaFeet': self.area_feet,
-            'lengthMetres': self.length_metres,
-            'lengthFeet': self.length_feet,
         }
 
 

--- a/python/tests/embedded/test_floor.py
+++ b/python/tests/embedded/test_floor.py
@@ -1,0 +1,51 @@
+import pytest
+from energuide import element
+from energuide.embedded import area
+from energuide.embedded import distance
+from energuide.embedded import floor
+from energuide.embedded import insulation
+
+
+@pytest.fixture
+def sample_raw() -> element.Element:
+    doc = """
+    <Floor>
+        <Label>Rm over garage</Label>
+        <Construction>
+            <Type nominalInsulation='2.46' rValue='2.9181' />
+        </Construction>
+        <Measurements area='9.2903' length='3.048' />
+    </Floor>
+    """
+    return element.Element.from_string(doc)
+
+
+@pytest.fixture
+def sample() -> floor.Floor:
+    return floor.Floor(
+        label='Rm over garage',
+        nominal_insulation=insulation.Insulation(2.46),
+        effective_insulation=insulation.Insulation(2.9181),
+        floor_area=area.Area(9.2903),
+        floor_length=distance.Distance(3.048),
+    )
+
+
+def test_from_data(sample_raw: element.Element, sample: floor.Floor) -> None:
+    output = floor.Floor.from_data(sample_raw)
+    assert output == sample
+
+
+def test_to_dict(sample: floor.Floor) -> None:
+    output = sample.to_dict()
+    assert output == {
+        'label': 'Rm over garage',
+        'nominalRsi': 2.46,
+        'nominalR': 13.96852780902,
+        'effectiveRsi': 2.9181,
+        'effectiveR': 16.569740243699698,
+        'areaMetres': 9.2903,
+        'areaFeet': 99.99996334435568,
+        'lengthMetres': 3.048,
+        'lengthFeet': 10.00000032,
+    }

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -9,6 +9,7 @@ from energuide import extracted_datatypes
 from energuide.embedded import area
 from energuide.embedded import ceiling
 from energuide.embedded import distance
+from energuide.embedded import floor
 from energuide.embedded import insulation
 
 
@@ -484,12 +485,12 @@ class TestParsedDwellingDataRow:
                 )
             ],
             floors=[
-                extracted_datatypes.Floor(
+                floor.Floor(
                     label='Rm over garage',
-                    nominal_rsi=2.46,
-                    effective_rsi=2.9181,
-                    area_metres=9.2903,
-                    length_metres=3.048,
+                    nominal_insulation=insulation.Insulation(2.46),
+                    effective_insulation=insulation.Insulation(2.9181),
+                    floor_area=area.Area(9.2903),
+                    floor_length=distance.Distance(3.048),
                 )
             ],
             walls=[

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -268,38 +268,6 @@ class TestWall:
         assert output.area_feet == 1128.0000721920012
 
 
-class TestFloor:
-
-    @pytest.fixture
-    def sample(self) -> element.Element:
-        doc = """
-        <Floor>
-            <Label>Rm over garage</Label>
-            <Construction>
-                <Type nominalInsulation='2.46' rValue='2.9181' />
-            </Construction>
-            <Measurements area='9.2903' length='3.048' />
-        </Floor>
-        """
-        return element.Element.from_string(doc)
-
-    def test_from_data(self, sample: element.Element) -> None:
-        output = extracted_datatypes.Floor.from_data(sample)
-        assert output.label == 'Rm over garage'
-        assert output.area_metres == 9.2903
-
-    def test_to_dict(self, sample: element.Element) -> None:
-        output = extracted_datatypes.Floor.from_data(sample).to_dict()
-        assert output['areaMetres'] == 9.2903
-
-    def test_properties(self, sample: element.Element) -> None:
-        output = extracted_datatypes.Floor.from_data(sample)
-        assert output.nominal_r == 13.96852780902
-        assert output.effective_r == 16.569740243699698
-        assert output.area_feet == 99.99996334435568
-        assert output.length_feet == 10.00000032
-
-
 class TestDoor:
 
     @pytest.fixture


### PR DESCRIPTION
Similar to #137 this PR moves `Floor` to its own module in `embedded/floor.py` for clarity and improved tests.