### PR TITLE
move Wall to wall.py

### DIFF
--- a/python/src/energuide/dwelling.py
+++ b/python/src/energuide/dwelling.py
@@ -7,8 +7,8 @@ from energuide import validator
 from energuide.embedded import ceiling
 from energuide.embedded import code
 from energuide.embedded import floor
+from energuide.embedded import wall
 from energuide.extracted_datatypes import Door
-from energuide.extracted_datatypes import Wall
 from energuide.extracted_datatypes import Window
 from energuide.extracted_datatypes import HeatedFloorArea
 from energuide.extracted_datatypes import Ventilation
@@ -86,7 +86,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     forward_sortation_area: str
     ceilings: typing.List[ceiling.Ceiling]
     floors: typing.List[floor.Floor]
-    walls: typing.List[Wall]
+    walls: typing.List[wall.Wall]
     doors: typing.List[Door]
     windows: typing.List[Window]
     heated_floor_area: HeatedFloorArea
@@ -145,7 +145,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             forward_sortation_area=parsed['forwardSortationArea'],
             ceilings=[ceiling.Ceiling.from_data(ceiling_node) for ceiling_node in parsed['ceilings']],
             floors=[floor.Floor.from_data(floor_node) for floor_node in parsed['floors']],
-            walls=[Wall.from_data(wall, codes.wall) for wall in parsed['walls']],
+            walls=[wall.Wall.from_data(wall_node, codes.wall) for wall_node in parsed['walls']],
             doors=[Door.from_data(door) for door in parsed['doors']],
             windows=[Window.from_data(window, codes.window) for window in parsed['windows']],
             heated_floor_area=HeatedFloorArea.from_data(parsed['heatedFloorArea']),
@@ -163,7 +163,7 @@ class Evaluation:
                  modification_date: datetime.datetime,
                  ceilings: typing.List[ceiling.Ceiling],
                  floors: typing.List[floor.Floor],
-                 walls: typing.List[Wall],
+                 walls: typing.List[wall.Wall],
                  doors: typing.List[Door],
                  windows: typing.List[Window],
                  heated_floor_area: HeatedFloorArea,
@@ -225,7 +225,7 @@ class Evaluation:
         return self._floors
 
     @property
-    def walls(self) -> typing.List[Wall]:
+    def walls(self) -> typing.List[wall.Wall]:
         return self._walls
 
     @property

--- a/python/src/energuide/embedded/wall.py
+++ b/python/src/energuide/embedded/wall.py
@@ -1,0 +1,58 @@
+import typing
+from energuide.embedded import area
+from energuide.embedded import code
+from energuide.embedded import insulation
+from energuide.embedded import distance
+from energuide import element
+
+
+class _Wall(typing.NamedTuple):
+    label: str
+    wall_code: typing.Optional[code.WallCode]
+    nominal_insulation: insulation.Insulation
+    effective_insulation: insulation.Insulation
+    perimeter: distance.Distance
+    height: distance.Distance
+
+
+class Wall(_Wall):
+
+    @classmethod
+    def from_data(cls,
+                  wall: element.Element,
+                  wall_codes: typing.Dict[str, code.WallCode]) -> 'Wall':
+
+        code_id = wall.xpath('Construction/Type/@idref')
+        wall_code = wall_codes[code_id[0]] if code_id else None
+
+        return Wall(
+            label=wall.get_text('Label'),
+            wall_code=wall_code,
+            nominal_insulation=insulation.Insulation(float(wall.xpath('Construction/Type/@nominalInsulation')[0])),
+            effective_insulation=insulation.Insulation(float(wall.xpath('Construction/Type/@rValue')[0])),
+            perimeter=distance.Distance(float(wall.xpath('Measurements/@perimeter')[0])),
+            height=distance.Distance(float(wall.xpath('Measurements/@height')[0])),
+        )
+
+    @property
+    def _wall_area(self) -> area.Area:
+        return area.Area(self.perimeter.metres * self.height.metres)
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': self.label,
+            'structureTypeEnglish': self.wall_code.structure_type.english if self.wall_code else None,
+            'structureTypeFrench': self.wall_code.structure_type.french if self.wall_code else None,
+            'componentTypeSizeEnglish': self.wall_code.component_type_size.english if self.wall_code else None,
+            'componentTypeSizeFrench': self.wall_code.component_type_size.french if self.wall_code else None,
+            'nominalRsi': self.nominal_insulation.rsi,
+            'nominalR': self.nominal_insulation.r_value,
+            'effectiveRsi': self.effective_insulation.rsi,
+            'effectiveR': self.effective_insulation.r_value,
+            'areaMetres': self._wall_area.square_metres,
+            'areaFeet': self._wall_area.square_feet,
+            'perimeterMetres': self.perimeter.metres,
+            'perimeterFeet': self.perimeter.feet,
+            'heightMetres': self.height.metres,
+            'heightFeet': self.height.feet,
+        }

--- a/python/src/energuide/extracted_datatypes.py
+++ b/python/src/energuide/extracted_datatypes.py
@@ -83,18 +83,6 @@ class WaterHeaterType(enum.Enum):
     CSA_DHW_FRENCH = "Système combiné certifié pour le chauffage des locaux et de l’eau"
 
 
-class _Wall(typing.NamedTuple):
-    label: str
-    structure_type_english: typing.Optional[str]
-    structure_type_french: typing.Optional[str]
-    component_type_size_english: typing.Optional[str]
-    component_type_size_french: typing.Optional[str]
-    nominal_rsi: float
-    effective_rsi: float
-    perimeter: float
-    height: float
-
-
 class _Door(typing.NamedTuple):
     label: str
     type_english: str
@@ -249,64 +237,6 @@ class Window(_Window):
             'areaMetres': self.area_metres,
             'areaFeet': self.area_feet,
             'width': self.width,
-            'height': self.height,
-        }
-
-
-class Wall(_Wall):
-
-    @classmethod
-    def from_data(cls,
-                  wall: element.Element,
-                  wall_codes: typing.Dict[str, code.WallCode]) -> 'Wall':
-
-        code_id = wall.xpath('Construction/Type/@idref')
-        w_code: typing.Optional[code.WallCode] = None
-        if code_id:
-            w_code = wall_codes[code_id[0]]
-
-        return Wall(
-            label=wall.get_text('Label'),
-            structure_type_english=w_code.structure_type.english if w_code else None,
-            structure_type_french=w_code.structure_type.french if w_code else None,
-            component_type_size_english=w_code.component_type_size.english if w_code else None,
-            component_type_size_french=w_code.component_type_size.french if w_code else None,
-            nominal_rsi=float(wall.xpath('Construction/Type/@nominalInsulation')[0]),
-            effective_rsi=float(wall.xpath('Construction/Type/@rValue')[0]),
-            perimeter=float(wall.xpath('Measurements/@perimeter')[0]),
-            height=float(wall.xpath('Measurements/@height')[0]),
-        )
-
-    @property
-    def nominal_r(self) -> float:
-        return self.nominal_rsi * _RSI_MULTIPLIER
-
-    @property
-    def effective_r(self) -> float:
-        return self.effective_rsi * _RSI_MULTIPLIER
-
-    @property
-    def area_metres(self) -> float:
-        return self.perimeter * self.height
-
-    @property
-    def area_feet(self) -> float:
-        return self.area_metres * _FEET_SQUARED_MULTIPLIER
-
-    def to_dict(self) -> typing.Dict[str, typing.Any]:
-        return {
-            'label': self.label,
-            'structureTypeEnglish': self.structure_type_english,
-            'structureTypeFrench': self.structure_type_french,
-            'componentTypeSizeEnglish': self.component_type_size_english,
-            'componentTypeSizeFrench': self.component_type_size_french,
-            'nominalRsi': self.nominal_rsi,
-            'nominalR': self.nominal_r,
-            'effectiveRsi': self.effective_rsi,
-            'effectiveR': self.effective_r,
-            'areaMetres': self.area_metres,
-            'areaFeet': self.area_feet,
-            'perimeter': self.perimeter,
             'height': self.height,
         }
 

--- a/python/tests/embedded/test_wall.py
+++ b/python/tests/embedded/test_wall.py
@@ -1,0 +1,95 @@
+import typing
+import pytest
+from energuide import bilingual
+from energuide import element
+from energuide.embedded import code
+from energuide.embedded import distance
+from energuide.embedded import insulation
+from energuide.embedded import wall
+
+
+@pytest.fixture
+def raw_sample() -> element.Element:
+    doc = """
+    <Wall>
+        <Label>Second level</Label>
+        <Construction>
+            <Type idref='Code 1' nominalInsulation='1.432' rValue='1.8016' />
+        </Construction>
+        <Measurements perimeter='42.9768' height='2.4384' />
+    </Wall>
+    """
+    return element.Element.from_string(doc)
+
+
+@pytest.fixture
+def sample_wall_code() -> typing.Dict[str, code.WallCode]:
+    return {'Code 1': code.WallCode(
+        identifier='Code 1',
+        label='1201101121',
+        structure_type=bilingual.Bilingual(
+            english='Wood frame',
+            french='Ossature de bois',
+        ),
+        component_type_size=bilingual.Bilingual(
+            english='38x89 mm (2x4 in)',
+            french='38x89 (2x4)',
+        )
+    )}
+
+
+@pytest.fixture
+def sample(sample_wall_code: typing.Dict[str, code.WallCode]) -> wall.Wall:
+    return wall.Wall(
+        label='Second level',
+        wall_code=sample_wall_code['Code 1'],
+        nominal_insulation=insulation.Insulation(1.432),
+        effective_insulation=insulation.Insulation(1.8016),
+        perimeter=distance.Distance(42.9768),
+        height=distance.Distance(2.4384),
+    )
+
+
+def test_from_data(raw_sample: element.Element,
+                   sample_wall_code: typing.Dict[str, code.WallCode],
+                   sample: wall.Wall) -> None:
+    output = wall.Wall.from_data(raw_sample, sample_wall_code)
+    assert output == sample
+
+
+def test_from_data_missing_codes() -> None:
+    doc = """
+    <Wall>
+        <Label>Test Floor</Label>
+        <Construction>
+            <Type rValue="2.6892" nominalInsulation="3.3615">User specified</Type>
+        </Construction>
+        <Measurements perimeter='42.9768' height='2.4384' />
+    </Wall>
+    """
+    sample = element.Element.from_string(doc)
+    output = wall.Wall.from_data(sample, {})
+    assert output.label == 'Test Floor'
+    assert output.wall_code is None
+    assert output.to_dict()['structureTypeEnglish'] is None
+
+
+def test_to_dict(sample: wall.Wall) -> None:
+    output = sample.to_dict()
+    assert output == {
+        'label': 'Second level',
+        'structureTypeEnglish': 'Wood frame',
+        'structureTypeFrench': 'Ossature de bois',
+        'componentTypeSizeEnglish': '38x89 mm (2x4 in)',
+        'componentTypeSizeFrench': '38x89 (2x4)',
+        'nominalRsi': 1.432,
+        'nominalR': 8.131273098584,
+        'effectiveRsi': 1.8016,
+        'effectiveR': 10.2299592279392,
+        'areaMetres': 104.79462912,
+        'areaFeet': 1128.0000721920012,
+        'perimeterMetres': 42.9768,
+        'perimeterFeet': 141.000004512,
+        'heightMetres': 2.4384,
+        'heightFeet': 8.000000256,
+    }

--- a/python/tests/test_dwelling.py
+++ b/python/tests/test_dwelling.py
@@ -8,9 +8,11 @@ from energuide import reader
 from energuide import extracted_datatypes
 from energuide.embedded import area
 from energuide.embedded import ceiling
+from energuide.embedded import code
 from energuide.embedded import distance
 from energuide.embedded import floor
 from energuide.embedded import insulation
+from energuide.embedded import wall
 
 
 # pylint: disable=no-self-use
@@ -464,6 +466,20 @@ class TestParsedDwellingDataRow:
 
     def test_from_row(self, sample_input_d: reader.InputData) -> None:
         output = dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
+
+        wall_code = code.WallCode(
+            identifier='Code 1',
+            label='1201101121',
+            structure_type=bilingual.Bilingual(
+                english='Wood frame',
+                french='Ossature de bois',
+            ),
+            component_type_size=bilingual.Bilingual(
+                english='38x89 mm (2x4 in)',
+                french='38x89 (2x4)',
+            )
+        )
+
         assert output == dwelling.ParsedDwellingDataRow(
             eval_id=123,
             eval_type=dwelling.EvaluationType.PRE_RETROFIT,
@@ -494,16 +510,13 @@ class TestParsedDwellingDataRow:
                 )
             ],
             walls=[
-                extracted_datatypes.Wall(
+                wall.Wall(
                     label='Second level',
-                    structure_type_english='Wood frame',
-                    structure_type_french='Ossature de bois',
-                    component_type_size_english='38x89 mm (2x4 in)',
-                    component_type_size_french='38x89 (2x4)',
-                    nominal_rsi=1.432,
-                    effective_rsi=1.8016,
-                    perimeter=42.9768,
-                    height=2.4384,
+                    wall_code=wall_code,
+                    nominal_insulation=insulation.Insulation(1.432),
+                    effective_insulation=insulation.Insulation(1.8016),
+                    perimeter=distance.Distance(42.9768),
+                    height=distance.Distance(2.4384),
                 )
             ],
             doors=[

--- a/python/tests/test_extracted_datatypes.py
+++ b/python/tests/test_extracted_datatypes.py
@@ -111,53 +111,6 @@ class TestWindow:
         assert output['areaMetres'] == 2.6014871808862
 
 
-class TestWall:
-
-    @pytest.fixture
-    def sample(self) -> element.Element:
-        doc = """
-        <Wall>
-            <Label>Second level</Label>
-            <Construction>
-                <Type idref='Code 1' nominalInsulation='1.432' rValue='1.8016' />
-            </Construction>
-            <Measurements perimeter='42.9768' height='2.4384' />
-        </Wall>
-        """
-        return element.Element.from_string(doc)
-
-    def test_from_data(self, sample: element.Element, codes: code.Codes) -> None:
-        output = extracted_datatypes.Wall.from_data(sample, codes.wall)
-        assert output.label == 'Second level'
-        assert output.perimeter == 42.9768
-
-    def test_from_data_missing_codes(self, codes: code.Codes) -> None:
-        doc = """
-        <Wall>
-            <Label>Test Floor</Label>
-            <Construction>
-                <Type rValue="2.6892" nominalInsulation="3.3615">User specified</Type>
-            </Construction>
-            <Measurements perimeter='42.9768' height='2.4384' />
-        </Wall>
-        """
-        sample = element.Element.from_string(doc)
-        output = extracted_datatypes.Wall.from_data(sample, codes.wall)
-        assert output.label == 'Test Floor'
-        assert output.structure_type_english is None
-
-    def test_to_dict(self, sample: element.Element, codes: code.Codes) -> None:
-        output = extracted_datatypes.Wall.from_data(sample, codes.wall).to_dict()
-        assert output['areaMetres'] == 42.9768 * 2.4384
-
-    def test_properties(self, sample: element.Element, codes: code.Codes) -> None:
-        output = extracted_datatypes.Wall.from_data(sample, codes.wall)
-        assert output.nominal_r == 8.131273098584
-        assert output.effective_r == 10.2299592279392
-        assert output.area_metres == 104.79462912
-        assert output.area_feet == 1128.0000721920012
-
-
 class TestDoor:
 
     @pytest.fixture


### PR DESCRIPTION
Continuing from #139, this PR moves `Wall` out to its own module. Also now embeds the actual `WallCode` object directly in the named tuple, rather than storing separately the english and french versions of two properties.
