### PR TITLE
extract crawlspace nodes

### DIFF
--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -29,6 +29,7 @@ class _HouseSnippet(typing.NamedTuple):
     ventilation: typing.List[str]
     water_heating: typing.Optional[str]
     basements: typing.List[str]
+    crawlspaces: typing.List[str]
 
 
 class HouseSnippet(_HouseSnippet):
@@ -44,7 +45,8 @@ class HouseSnippet(_HouseSnippet):
             'heating_cooling': self.heating_cooling,
             'ventilations': self.ventilation,
             'waterHeatings': self.water_heating,
-            'basements': self.basements
+            'basements': self.basements,
+            'crawlspaces': self.crawlspaces,
         }
 
 
@@ -68,6 +70,7 @@ def snip_house(house: element.Element) -> HouseSnippet:
     water_heating_string = water_heating[0].to_string() if water_heating else None
 
     basements = _extract_nodes(house, 'Components/Basement')
+    crawlspaces = _extract_nodes(house, 'Components/Crawlspace')
 
     return HouseSnippet(
         ceilings=[node.to_string() for node in ceilings],
@@ -80,6 +83,7 @@ def snip_house(house: element.Element) -> HouseSnippet:
         ventilation=ventilation_strings,
         water_heating=water_heating_string,
         basements=[node.to_string() for node in basements],
+        crawlspaces=[node.to_string() for node in crawlspaces],
     )
 
 

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -29,7 +29,7 @@ def code(doc: element.Element) -> element.Element:
 
 def test_house_snippet_to_dict(house: element.Element) -> None:
     output = snippets.snip_house(house).to_dict()
-    assert len(output) == 10
+    assert len(output) == 11
 
 
 def test_ceiling_snippet(house: element.Element) -> None:
@@ -214,4 +214,14 @@ def test_basement_snippet(house: element.Element) -> None:
         'basements': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
     }, allow_unknown=True)
     doc = {'basements': output.basements}
+    assert checker.validate(doc)
+
+
+def test_crawlspace_snippet(house: element.Element) -> None:
+    output = snippets.snip_house(house)
+    assert len(output.crawlspaces) == 1
+    checker = validator.DwellingValidator({
+        'crawlspaces': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
+    }, allow_unknown=True)
+    doc = {'crawlspaces': output.crawlspaces}
     assert checker.validate(doc)


### PR DESCRIPTION
This PR extracts `Crawlspace` nodes from the xml.
These, along with `Basement` and `Slab` nodes all comprise the BASEMENT/FOUNDATION table

https://trello.com/c/MHCxw57a/107-extract-load-basement-data