### PR TITLE
extract slab nodes

### DIFF
--- a/python/src/energuide/snippets.py
+++ b/python/src/energuide/snippets.py
@@ -30,6 +30,7 @@ class _HouseSnippet(typing.NamedTuple):
     water_heating: typing.Optional[str]
     basements: typing.List[str]
     crawlspaces: typing.List[str]
+    slabs: typing.List[str]
 
 
 class HouseSnippet(_HouseSnippet):
@@ -47,6 +48,7 @@ class HouseSnippet(_HouseSnippet):
             'waterHeatings': self.water_heating,
             'basements': self.basements,
             'crawlspaces': self.crawlspaces,
+            'slabs': self.slabs,
         }
 
 
@@ -71,6 +73,7 @@ def snip_house(house: element.Element) -> HouseSnippet:
 
     basements = _extract_nodes(house, 'Components/Basement')
     crawlspaces = _extract_nodes(house, 'Components/Crawlspace')
+    slabs = _extract_nodes(house, 'Components/Slab')
 
     return HouseSnippet(
         ceilings=[node.to_string() for node in ceilings],
@@ -84,6 +87,7 @@ def snip_house(house: element.Element) -> HouseSnippet:
         water_heating=water_heating_string,
         basements=[node.to_string() for node in basements],
         crawlspaces=[node.to_string() for node in crawlspaces],
+        slabs=[node.to_string() for node in slabs],
     )
 
 

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -29,7 +29,11 @@ def code(doc: element.Element) -> element.Element:
 
 def test_house_snippet_to_dict(house: element.Element) -> None:
     output = snippets.snip_house(house).to_dict()
+<<<<<<< HEAD
     assert len(output) == 11
+=======
+    assert len(output) == 10
+>>>>>>> extract basement nodes
 
 
 def test_ceiling_snippet(house: element.Element) -> None:
@@ -215,6 +219,7 @@ def test_basement_snippet(house: element.Element) -> None:
     }, allow_unknown=True)
     doc = {'basements': output.basements}
     assert checker.validate(doc)
+<<<<<<< HEAD
 
 
 def test_crawlspace_snippet(house: element.Element) -> None:
@@ -225,3 +230,5 @@ def test_crawlspace_snippet(house: element.Element) -> None:
     }, allow_unknown=True)
     doc = {'crawlspaces': output.crawlspaces}
     assert checker.validate(doc)
+=======
+>>>>>>> extract basement nodes

--- a/python/tests/test_snippets.py
+++ b/python/tests/test_snippets.py
@@ -29,11 +29,7 @@ def code(doc: element.Element) -> element.Element:
 
 def test_house_snippet_to_dict(house: element.Element) -> None:
     output = snippets.snip_house(house).to_dict()
-<<<<<<< HEAD
-    assert len(output) == 11
-=======
-    assert len(output) == 10
->>>>>>> extract basement nodes
+    assert len(output) == 12
 
 
 def test_ceiling_snippet(house: element.Element) -> None:
@@ -219,7 +215,6 @@ def test_basement_snippet(house: element.Element) -> None:
     }, allow_unknown=True)
     doc = {'basements': output.basements}
     assert checker.validate(doc)
-<<<<<<< HEAD
 
 
 def test_crawlspace_snippet(house: element.Element) -> None:
@@ -230,5 +225,13 @@ def test_crawlspace_snippet(house: element.Element) -> None:
     }, allow_unknown=True)
     doc = {'crawlspaces': output.crawlspaces}
     assert checker.validate(doc)
-=======
->>>>>>> extract basement nodes
+
+
+def test_slab_snippet(house: element.Element) -> None:
+    output = snippets.snip_house(house)
+    assert len(output.slabs) == 1
+    checker = validator.DwellingValidator({
+        'slabs': {'type': 'list', 'required': True, 'schema': {'type': 'xml', 'coerce': 'parse_xml'}}
+    }, allow_unknown=True)
+    doc = {'slabs': output.crawlspaces}
+    assert checker.validate(doc)


### PR DESCRIPTION
This PR extracts `Slab` nodes from the xml.
These, along with `Crawlspace` and `Slab` nodes all comprise the BASEMENT/FOUNDATION table

https://trello.com/c/MHCxw57a/107-extract-load-basement-data