### PR TITLE
Add ./bootstrap.sh file, refactor Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 **/.cache/
 **/.mypy_cache/
 python/env
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL ?= /usr/bin/bash
-run:
-	$(MAKE) -C api run
+
+.PHONY: start_mongodb stop_mongodb setup_python import_data setup
 start_mongodb:
 	brew services start mongodb
 stop_mongodb:
@@ -12,6 +12,10 @@ import_data:
 setup:
 	$(MAKE) start_mongodb
 	$(MAKE) -C python setup_python import_data
+
+.PHONY: run build test
+run:
+		$(MAKE) -C api run
 build:
 	$(MAKE) -C api build
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 SHELL ?= /usr/bin/bash
 run:
 	$(MAKE) -C api run
+start_mongodb:
+	brew services start mongodb
+stop_mongodb:
+	brew services stop mongodb
 setup_python:
 	$(MAKE) -C python setup_python
 import_data:
 	$(MAKE) -C python import_data
 setup:
+	$(MAKE) start_mongodb
 	$(MAKE) -C python setup_python import_data
 build:
 	$(MAKE) -C api build

--- a/README.md
+++ b/README.md
@@ -6,3 +6,101 @@ This is the API for NRCAN's Energuide data.
 
 This project is composed of two parts: the API itself and the ETL process that produces the data the API will serve.
 There are further details in the readme for each of the respective portions of the project.
+
+## Quickstart
+
+### TL;DR
+
+If you're really keen (and on a Mac), this should do you. Continue reading for more details.
+
+```sh
+# install python 3 and mongo
+./bootstrap.sh
+
+# import data
+make setup
+
+# export Apollo Engine API Key
+export NRCAN_ENGINE_API_KEY=your_api_key
+
+# boot up API
+make run
+```
+
+### bootstrap.sh
+
+The [bootstrap.sh]() file is a quick way to get up-and-running on a macOS environment. It relies on [Homebrew](https://brew.sh/) to install both Python 3 (using [pyenv](https://github.com/pyenv/pyenv#homebrew-on-mac-os-x)) and [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/#install-mongodb-community-edition-with-homebrew).
+
+To get started, run
+
+```
+./bootstrap.sh
+```
+
+*Note that to get pyenv running by default in your preferred shell, you'll need to add `eval "$(pyenv init -)"` to your `~/.bash_profile` or `~/.zshrc` or after installing pyenv.*
+
+Once the script runs through, you'll need to import the data into your database, and then boot up the API that connects to it.
+
+#### importing data
+
+The Python code in `/python` transforms the data from its default formatting by NRCAN and then inserts it into our Mongo database. More details can be found in the [README](https://github.com/cds-snc/nrcan_api/blob/master/python/README.md).
+
+For local development, run
+```
+make setup
+```
+This will
+- install the needed Python dependencies
+- drop your current test data (if you have any)
+- import fresh test data
+
+Now that we have data, it's time to boot up the API.
+
+#### running the API
+
+##### Getting an Apollo Engine API Key
+
+Apollo Engine is a monitoring/logging layer that gives us out-of-the-box diagnostic information about our graphql instance. You'll need your own API key to get the API running, so [sign up for one here](https://engine.apollographql.com/login).
+
+Once you have one, you'll need to
+```
+export NRCAN_ENGINE_API_KEY=your_api_key
+```
+
+
+##### booting up the API
+
+The JavaScript code in `/api` builds us a [GraphQL](http://graphql.org/learn/) API which allows us to query NRCAN data from the Mongo database. More info in the [README](https://github.com/cds-snc/nrcan_api/blob/master/api/README.md).
+
+To build the app and connect it to mongo, run
+```
+make run
+```
+
+This will
+- install the needed JavaScript dependencies
+- build the app
+- serve it up locally
+
+### Using the API locally
+
+The API should be running now! Yes!! 🎉🎉🎉
+
+Check it out at [http://localhost:3000/graphiql]()
+
+Try out this query to get you going.
+
+```
+{
+  dwellingsInFSA(
+    forwardSortationArea: "C1A"
+  ) {
+    results {
+    yearBuilt
+    city
+    }
+  }
+}
+```
+
+<super>Or just [click here](http://localhost:3000/graphiql?query=%7B%0A%20%20dwellingsInFSA(%0A%20%20%20%20forwardSortationArea%3A%20%22C1A%22%0A%20%20)%20%7B%0A%20%20%20%20results%20%7B%0A%20%20%20%20yearBuilt%0A%20%20%20%20city%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)</super>

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,10 +1,18 @@
 SHELL ?= /usr/bin/bash
-.PHONY: run build test
-run:
+export NRCAN_DB_CONNECTION_STRING ?= mongodb://localhost:27017
+export NRCAN_DB_NAME ?= energuide
+export NRCAN_COLLECTION_NAME ?= dwellings
+
+.PHONY: run build test install check_api_key
+check_api_key:
+	[ -z $$NRCAN_ENGINE_API_KEY ] && echo "NRCAN_ENGINE_API_KEY must be set!" && exit 1 || echo "NRCAN_ENGINE_API_KEY is set"
+install: check_api_key
+	yarn install
+run: install
 	yarn build && yarn start
-build:
+build: install
 	yarn dockerize
-test:
+test: install
 	yarn test
 	yarn integration
 .ONESHELL:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+if test ! $(which brew); then
+    echo "ERROR: It looks like you need to install Homebrew first."
+    exit 1 # terminate with error
+fi
+
+# Update homebrew recipes
+echo "----> Updating Homebrew"
+brew update
+
+# Pyenv
+if [[ ! $(brew ls pyenv --versions) ]]; then
+    echo "----> Installing pyenv with Homebrew"
+    brew install pyenv
+
+    echo ''
+    echo ''
+    echo '**IMPORTANT**'
+    echo 'Please make sure to put '"'"'eval "$(pyenv init -)"'"'"' near the bottom of your shell configuration file (eg, ~/.bash_profile or ~/.zshrc).'
+    echo 'For more information, refer to pyenv installation instructions.'
+    echo ''
+    echo ''
+    eval "$(pyenv init -)"
+
+    PYTHON_VERSION=3.6.4
+
+    if [[ ! $(python --version) = "Python ${PYTHON_VERSION}" ]]; then
+      echo "----> Installing Python ${PYTHON_VERSION}"
+      exit 0
+      pyenv install $PYTHON_VERSION
+      pyenv local $PYTHON_VERSION
+    fi
+fi
+
+# MongoDB
+if [[ ! $(brew ls mongodb --versions) ]]; then
+  echo "----> Installing mongodb with Homebrew"
+  brew install mongodb
+fi
+
+# Install homebrew services (does nothing if already installed)
+brew tap homebrew/services
+
+echo "----> Run 'make setup' to import the test data"
+echo "----> export NRCAN_ENGINE_API_KEY='your_api_key'"
+echo "----> Run 'make run' to boot up the API"
+exit 0

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,13 +1,27 @@
 SHELL ?= /usr/bin/bash
-.PHONY: setup_python import_data
-setup_python:
-	python3 -m venv env
-	source env/bin/activate
-	pip install -q -r requirements.txt
-	pip install -q -e .
-import_data:
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/env || echo $$VIRTUAL_ENV)
+
+.PHONY: virtualenv
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && [ ! -d env ] && python3 -m venv env || true
+
+.PHONY: setup_python
+setup_python:  virtualenv requirements.txt
+		${VIRTUALENV_ROOT}/bin/pip install -q -r requirements.txt
+		${VIRTUALENV_ROOT}/bin/pip install -q -e .
+
+.PHONY: import_data
+import_data: virtualenv
+	echo "Removing all NRCAN data"
 	mongo energuide --eval "db.dwellings.drop()"
-	energuide extract --infile tests/randomized_energuide_data.csv --outfile allthedata.zip
-	energuide load --filename allthedata.zip
+	${VIRTUALENV_ROOT}/bin/energuide extract --infile tests/randomized_energuide_data.csv --outfile allthedata.zip
+	echo "Importing new NRCAN data"
+	${VIRTUALENV_ROOT}/bin/energuide load --filename allthedata.zip
 	rm allthedata.zip
+
+.PHONY: test_python
+test_python: virtualenv
+	${VIRTUALENV_ROOT}/bin/pytest tests
+	${VIRTUALENV_ROOT}/bin/pylint src tests
+	${VIRTUALENV_ROOT}/bin/mypy src tests --ignore-missing-imports
 .ONESHELL:


### PR DESCRIPTION
**Note**

I'm going to add information about this in the README but at the minute I'm just pushing up the code so that it's visible.  Anything looks odd, let me know. 

---

The "get up and going" process is (should be) much easier now.

The `./bootstrap.sh` file installs all the things we need to install once (pyenv, mongodb, etc), and then the Makefiles have all the commands we need to run multiple times.

- The `/python/Makefile` runs everything without tripping over virtualenv problems now.
- The `/api/Makefile` looks for an `NRCAN_ENGINE_API_KEY` to be set or else it won't run.

Also, I've tested this on my Macbook the best that I can. In theory, it should work on everyone's computers as well, but I haven't been able to confirm that it does.

