### PR TITLE
Add integration tests that fail when data changes

### DIFF
--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -38,8 +38,8 @@ describe('Schema', () => {
       expect(fields).toEqual([
         'typeEnglish',
         'typeFrench',
-        'rsi',
-        'rValue',
+        'insulationRsi',
+        'insulationR',
         'uFactor',
         'uFactorImperial',
         'areaMetres',
@@ -62,14 +62,16 @@ describe('Schema', () => {
         'structureTypeFrench',
         'componentTypeSizeEnglish',
         'componentTypeSizeFrench',
-        'nominalRsi',
-        'nominalR',
-        'effectiveRsi',
-        'effectiveR',
+        'insulationNominalRsi',
+        'insulationNominalR',
+        'insulationEffectiveRsi',
+        'insulationEffectiveR',
         'areaMetres',
         'areaFeet',
-        'perimeter',
-        'height',
+        'perimeterMetres',
+        'perimeterFeet',
+        'heightMetres',
+        'heightFeet',
       ])
     })
   })
@@ -86,10 +88,10 @@ describe('Schema', () => {
         'label',
         'typeEnglish',
         'typeFrench',
-        'nominalRsi',
-        'nominalR',
-        'effectiveRsi',
-        'effectiveR',
+        'insulationNominalRsi',
+        'insulationNominalR',
+        'insulationEffectiveRsi',
+        'insulationEffectiveR',
         'areaMetres',
         'areaFeet',
         'lengthMetres',
@@ -132,8 +134,8 @@ describe('Schema', () => {
       const fields = Object.keys(Window.getFields())
       expect(fields).toEqual([
         'label',
-        'rsi',
-        'rvalue',
+        'insulationRsi',
+        'insulationR',
         'glazingTypesEnglish',
         'glazingTypesFrench',
         'coatingsTintsEnglish',
@@ -148,8 +150,10 @@ describe('Schema', () => {
         'frameMaterialFrench',
         'areaMetres',
         'areaFeet',
-        'width',
-        'height',
+        'widthMetres',
+        'widthFeet',
+        'heightMetres',
+        'heightFeet',
       ])
     })
   })
@@ -204,7 +208,7 @@ describe('Schema', () => {
         'airFlowRateCfm',
       ])
     })
-    })
+  })
 
   describe('WaterHeater', () => {
     it('is defined', () => {

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -43,36 +43,38 @@ const Schema = i18n => {
     }
 
     type Wall {
-      label: String
-      structureTypeEnglish: String
-      structureTypeFrench: String
-      componentTypeSizeEnglish: String
-      componentTypeSizeFrench: String
-      nominalRsi: Float
-      nominalR: Float
-      effectiveRsi: Float
-      effectiveR: Float
-      areaMetres: Float
-      areaFeet: Float
-      perimeter: Float
-      height: Float
+			label: String
+			structureTypeEnglish: String
+			structureTypeFrench: String
+			componentTypeSizeEnglish: String
+			componentTypeSizeFrench: String
+			insulationNominalRsi: Float
+			insulationNominalR: Float
+			insulationEffectiveRsi: Float
+			insulationEffectiveR: Float
+			areaMetres: Float
+			areaFeet: Float
+			perimeterMetres: Float
+			perimeterFeet: Float
+			heightMetres: Float
+			heightFeet: Float
     }
 
     type Door {
-      typeEnglish: String
-      typeFrench: String
-      rsi: Float
-      rValue: Float
-      uFactor: Float
-      uFactorImperial: Float
-      areaMetres: Float
-      areaFeet: Float
+			typeEnglish: String
+			typeFrench: String
+			insulationRsi: Float
+			insulationR: Float
+			uFactor: Float
+			uFactorImperial: Float
+			areaMetres: Float
+			areaFeet: Float
     }
 
     type Window {
       label: String
-      rsi: Float
-      rvalue: Float
+      insulationRsi: Float
+      insulationR: Float
       glazingTypesEnglish: String
       glazingTypesFrench: String
       coatingsTintsEnglish: String
@@ -87,18 +89,20 @@ const Schema = i18n => {
       frameMaterialFrench: String
       areaMetres: Float
       areaFeet: Float
-      width: Float
-      height: Float
+      widthMetres: Float
+      widthFeet: Float
+      heightMetres: Float
+      heightFeet: Float
     }
 
     type Ceiling {
       label: String
       typeEnglish: String
       typeFrench: String
-      nominalRsi: Float
-      nominalR: Float
-      effectiveRsi: Float
-      effectiveR: Float
+      insulationNominalRsi: Float
+      insulationNominalR: Float
+      insulationEffectiveRsi: Float
+      insulationEffectiveR: Float
       areaMetres: Float
       areaFeet: Float
       lengthMetres: Float

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -43,32 +43,32 @@ const Schema = i18n => {
     }
 
     type Wall {
-			label: String
-			structureTypeEnglish: String
-			structureTypeFrench: String
-			componentTypeSizeEnglish: String
-			componentTypeSizeFrench: String
-			insulationNominalRsi: Float
-			insulationNominalR: Float
-			insulationEffectiveRsi: Float
-			insulationEffectiveR: Float
-			areaMetres: Float
-			areaFeet: Float
-			perimeterMetres: Float
-			perimeterFeet: Float
-			heightMetres: Float
-			heightFeet: Float
+      label: String
+      structureTypeEnglish: String
+      structureTypeFrench: String
+      componentTypeSizeEnglish: String
+      componentTypeSizeFrench: String
+      insulationNominalRsi: Float
+      insulationNominalR: Float
+      insulationEffectiveRsi: Float
+      insulationEffectiveR: Float
+      areaMetres: Float
+      areaFeet: Float
+      perimeterMetres: Float
+      perimeterFeet: Float
+      heightMetres: Float
+      heightFeet: Float
     }
 
     type Door {
-			typeEnglish: String
-			typeFrench: String
-			insulationRsi: Float
-			insulationR: Float
-			uFactor: Float
-			uFactorImperial: Float
-			areaMetres: Float
-			areaFeet: Float
+      typeEnglish: String
+      typeFrench: String
+      insulationRsi: Float
+      insulationR: Float
+      uFactor: Float
+      uFactorImperial: Float
+      areaMetres: Float
+      areaFeet: Float
     }
 
     type Window {

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -89,64 +89,41 @@ describe('queries', () => {
         .set('Content-Type', 'application/json; charset=utf-8')
         .send({
           query: `{
-          evaluations:evaluationsFor(account: 189250) {
+          evaluationsFor(account: 189250) {
             evaluations {
               ceilings {
-                label
-                typeEnglish
-                typeFrench
-                nominalRsi
-                nominalR
-                effectiveRsi
-                effectiveR
-                areaMetres
-                areaFeet
-                lengthMetres
-                lengthFeet
+								label
+								typeEnglish
+								typeFrench
+								insulationNominalRsi
+								insulationNominalR
+								insulationEffectiveRsi
+								insulationEffectiveR
+								areaMetres
+								areaFeet
+								lengthMetres
+								lengthFeet
               }
             }
           }
         }`,
         })
 
-      let { evaluations } = response.body.data
-      expect(evaluations).toEqual({
-        evaluations: [
-          {
-            ceilings: [
-              {
-                areaFeet: 830.1171300283143,
-                areaMetres: 77.1204,
-                effectiveR: 36.3397497041326,
-                effectiveRsi: 6.3998,
-                label: 'Ceiling01',
-                lengthFeet: 47.66404352,
-                lengthMetres: 14.528,
-                nominalR: 36.3397497041326,
-                nominalRsi: 6.3998,
-                typeEnglish: 'Attic/gable',
-                typeFrench: 'Combles/pignon',
-              },
-            ],
-          },
-          {
-            ceilings: [
-              {
-                areaFeet: 830.1171300283143,
-                areaMetres: 77.1204,
-                effectiveR: 36.3397497041326,
-                effectiveRsi: 6.3998,
-                label: 'Ceiling01',
-                lengthFeet: 47.66404352,
-                lengthMetres: 14.528,
-                nominalR: 36.3397497041326,
-                nominalRsi: 6.3998,
-                typeEnglish: 'Attic/gable',
-                typeFrench: 'Combles/pignon',
-              },
-            ],
-          },
-        ],
+      let { evaluationsFor: { evaluations } } = response.body.data
+      let [first] = evaluations
+      let [ceiling] = first.ceilings
+      expect(ceiling).toEqual({
+        areaFeet: 830.1171300283143,
+        areaMetres: 77.1204,
+        insulationEffectiveR: 36.3397497041326,
+        insulationEffectiveRsi: 6.3998,
+        insulationNominalR: 36.3397497041326,
+        insulationNominalRsi: 6.3998,
+        label: 'Ceiling01',
+        lengthFeet: 47.66404352,
+        lengthMetres: 14.528,
+        typeEnglish: 'Attic/gable',
+        typeFrench: 'Combles/pignon',
       })
     })
 
@@ -156,70 +133,49 @@ describe('queries', () => {
         .set('Content-Type', 'application/json; charset=utf-8')
         .send({
           query: `{
-          evaluations:evaluationsFor(account: 189250) {
+          evaluationsFor(account: 189250) {
             evaluations {
               walls {
-                label
-                structureTypeEnglish
-                structureTypeFrench
-                componentTypeSizeEnglish
-                componentTypeSizeFrench
-                nominalRsi
-                nominalR
-                effectiveRsi
-                effectiveR
-                areaMetres
-                areaFeet
-                perimeter
-                height
+								label
+								structureTypeEnglish
+								structureTypeFrench
+								componentTypeSizeEnglish
+								componentTypeSizeFrench
+								insulationNominalRsi
+								insulationNominalR
+								insulationEffectiveRsi
+								insulationEffectiveR
+								areaMetres
+								areaFeet
+								perimeterMetres
+								perimeterFeet
+								heightMetres
+								heightFeet
               }
             }
           }
         }`,
         })
 
-      let { evaluations } = response.body.data
-      expect(evaluations).toEqual({
-        evaluations: [
-          {
-            walls: [
-              {
-                areaFeet: 1000.7916833561255,
-                areaMetres: 92.97658384,
-                componentTypeSizeEnglish: null,
-                componentTypeSizeFrench: null,
-                effectiveR: 15.2699857658604,
-                effectiveRsi: 2.6892,
-                height: 2.5999,
-                label: 'Main floor',
-                nominalR: 19.0874822073255,
-                nominalRsi: 3.3615,
-                perimeter: 35.7616,
-                structureTypeEnglish: null,
-                structureTypeFrench: null,
-              },
-            ],
-          },
-          {
-            walls: [
-              {
-                areaFeet: 1000.7916833561255,
-                areaMetres: 92.97658384,
-                componentTypeSizeEnglish: null,
-                componentTypeSizeFrench: null,
-                effectiveR: 15.2699857658604,
-                effectiveRsi: 2.6892,
-                height: 2.5999,
-                label: 'Main floor',
-                nominalR: 19.0874822073255,
-                nominalRsi: 3.3615,
-                perimeter: 35.7616,
-                structureTypeEnglish: null,
-                structureTypeFrench: null,
-              },
-            ],
-          },
-        ],
+      let { evaluationsFor: { evaluations } } = response.body.data
+      let [first] = evaluations
+      let [wall] = first.walls
+      expect(wall).toEqual({
+        areaFeet: 1000.7916833561255,
+        areaMetres: 92.97658384,
+        componentTypeSizeEnglish: null,
+        componentTypeSizeFrench: null,
+        heightFeet: 8.529855915999999,
+        heightMetres: 2.5999,
+        insulationEffectiveR: 15.2699857658604,
+        insulationEffectiveRsi: 2.6892,
+        insulationNominalR: 19.0874822073255,
+        insulationNominalRsi: 3.3615,
+        label: 'Main floor',
+        perimeterFeet: 117.328087744,
+        perimeterMetres: 35.7616,
+        structureTypeEnglish: null,
+        structureTypeFrench: null,
       })
     })
 
@@ -229,79 +185,35 @@ describe('queries', () => {
         .set('Content-Type', 'application/json; charset=utf-8')
         .send({
           query: `{
-          evaluations:evaluationsFor(account: 189250) {
+          evaluationsFor(account: 189250) {
             evaluations {
               doors {
-                typeEnglish
-                typeFrench
-                rsi
-                rValue
-                uFactor
-                uFactorImperial
-                areaMetres
-                areaFeet
+								typeEnglish
+								typeFrench
+								insulationRsi
+								insulationR
+								uFactor
+								uFactorImperial
+								areaMetres
+								areaFeet
               }
             }
           }
         }`,
         })
 
-      let { evaluations } = response.body.data
-      expect(evaluations).toEqual({
-        evaluations: [
-          {
-            doors: [
-              {
-                areaFeet: 18.9875391902784,
-                areaMetres: 1.764,
-                rValue: 6.4732202041799995,
-                rsi: 1.14,
-                typeEnglish: 'Steel Medium density spray foam core',
-                typeFrench:
-                  'Acier / âme en mousse à vaporiser de densité moyenne',
-                uFactor: 0.8771929824561404,
-                uFactorImperial: 0.15448261737709199,
-              },
-              {
-                areaFeet: 18.9875391902784,
-                areaMetres: 1.764,
-                rValue: 6.4732202041799995,
-                rsi: 1.14,
-                typeEnglish: 'Steel Medium density spray foam core',
-                typeFrench:
-                  'Acier / âme en mousse à vaporiser de densité moyenne',
-                uFactor: 0.8771929824561404,
-                uFactorImperial: 0.15448261737709199,
-              },
-            ],
-          },
-          {
-            doors: [
-              {
-                areaFeet: 18.9875391902784,
-                areaMetres: 1.764,
-                rValue: 6.4732202041799995,
-                rsi: 1.14,
-                typeEnglish: 'Steel Medium density spray foam core',
-                typeFrench:
-                  'Acier / âme en mousse à vaporiser de densité moyenne',
-                uFactor: 0.8771929824561404,
-                uFactorImperial: 0.15448261737709199,
-              },
-              {
-                areaFeet: 18.9875391902784,
-                areaMetres: 1.764,
-                rValue: 6.4732202041799995,
-                rsi: 1.14,
-                typeEnglish: 'Steel Medium density spray foam core',
-                typeFrench:
-                  'Acier / âme en mousse à vaporiser de densité moyenne',
-                uFactor: 0.8771929824561404,
-                uFactorImperial: 0.15448261737709199,
-              },
-            ],
-          },
-        ],
+      let { evaluationsFor: { evaluations } } = response.body.data
+      let [first] = evaluations
+      let [door] = first.doors
+      expect(door).toEqual({
+        areaFeet: 18.9875391902784,
+        areaMetres: 1.764,
+        insulationR: 6.4732202041799995,
+        insulationRsi: 1.14,
+        typeEnglish: 'Steel Medium density spray foam core',
+        typeFrench: 'Acier / âme en mousse à vaporiser de densité moyenne',
+        uFactor: 0.8771929824561404,
+        uFactorImperial: 0.15448261737709199,
       })
     })
 
@@ -314,25 +226,27 @@ describe('queries', () => {
           evaluations:evaluationsFor(account: 189250) {
             evaluations {
               windows {
-                label
-                rsi
-                rvalue
-                glazingTypesEnglish
-                glazingTypesFrench
-                coatingsTintsEnglish
-                coatingsTintsFrench
-                fillTypeEnglish
-                fillTypeFrench
-                spacerTypeEnglish
-                spacerTypeFrench
-                typeEnglish
-                typeFrench
-                frameMaterialEnglish
-                frameMaterialFrench
-                areaMetres
-                areaFeet
-                width
-                height
+								label
+								insulationRsi
+								insulationR
+								glazingTypesEnglish
+								glazingTypesFrench
+								coatingsTintsEnglish
+								coatingsTintsFrench
+								fillTypeEnglish
+								fillTypeFrench
+								spacerTypeEnglish
+								spacerTypeFrench
+								typeEnglish
+								typeFrench
+								frameMaterialEnglish
+								frameMaterialFrench
+								areaMetres
+								areaFeet
+								widthMetres
+								widthFeet
+								heightMetres
+								heightFeet
               }
             }
           }
@@ -342,25 +256,27 @@ describe('queries', () => {
       let { evaluations: { evaluations: [first] } } = response.body.data
       let [eastWindow] = first.windows
       expect(eastWindow).toEqual({
-        label: 'East0001',
-        rsi: 0.2685,
-        rvalue: 1.5246137059845,
-        glazingTypesEnglish: 'Double/double with 1 coat',
-        glazingTypesFrench: 'Double/double, 1 couche',
+        areaFeet: 14.111997194858986,
+        areaMetres: 1.31104735596684,
         coatingsTintsEnglish: 'Clear',
         coatingsTintsFrench: 'Transparent',
         fillTypeEnglish: '13 mm Air',
         fillTypeFrench: "13 mm d'air",
+        frameMaterialEnglish: 'Aluminum',
+        frameMaterialFrench: 'Aluminium',
+        glazingTypesEnglish: 'Double/double with 1 coat',
+        glazingTypesFrench: 'Double/double, 1 couche',
+        heightFeet: 4.002377424664,
+        heightMetres: 1.2199246000000001,
+        insulationR: 1.5246137059845,
+        insulationRsi: 0.2685,
+        label: 'East0001',
         spacerTypeEnglish: 'Metal',
         spacerTypeFrench: 'Métal',
         typeEnglish: 'Picture',
         typeFrench: 'Fixe',
-        frameMaterialEnglish: 'Aluminum',
-        frameMaterialFrench: 'Aluminium',
-        areaMetres: 1.31104735596684,
-        areaFeet: 14.111997194858986,
-        width: 1.0746954,
-        height: 1.2199246000000001,
+        widthFeet: 3.5259036561359998,
+        widthMetres: 1.0746954,
       })
     })
   })

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -20,6 +20,351 @@ describe('queries', () => {
     client.close()
   })
 
+  describe('Dwelling data', () => {
+    it('retrieves all top level keys of the dwelling data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+              houseId
+              yearBuilt
+              city
+              region
+              forwardSortationArea
+            }
+        }`,
+        })
+
+      let { evaluations } = response.body.data
+      expect(evaluations).toEqual({
+        city: 'Charlottetown',
+        forwardSortationArea: 'C1A',
+        houseId: 189250,
+        region: 'PE',
+        yearBuilt: 1900,
+      })
+    })
+
+    it('retrieves all top level keys of the evaluation data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+            evaluations {
+              evaluationType
+              entryDate
+              creationDate
+              modificationDate
+            }
+          }
+        }`,
+        })
+
+      let { evaluations } = response.body.data
+      expect(evaluations).toEqual({
+        evaluations: [
+          {
+            creationDate: '2012-10-01T15:08:41',
+            entryDate: '2011-11-18',
+            evaluationType: 'E',
+            modificationDate: '2012-06-09T11:20:20',
+          },
+          {
+            creationDate: '2012-10-01T15:08:39',
+            entryDate: '2011-08-18',
+            evaluationType: 'D',
+            modificationDate: '2012-06-09T11:20:20',
+          },
+        ],
+      })
+    })
+
+    it('retrieves all top level keys of the ceiling data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+            evaluations {
+              ceilings {
+                label
+                typeEnglish
+                typeFrench
+                nominalRsi
+                nominalR
+                effectiveRsi
+                effectiveR
+                areaMetres
+                areaFeet
+                lengthMetres
+                lengthFeet
+              }
+            }
+          }
+        }`,
+        })
+
+      let { evaluations } = response.body.data
+      expect(evaluations).toEqual({
+        evaluations: [
+          {
+            ceilings: [
+              {
+                areaFeet: 830.1171300283143,
+                areaMetres: 77.1204,
+                effectiveR: 36.3397497041326,
+                effectiveRsi: 6.3998,
+                label: 'Ceiling01',
+                lengthFeet: 47.66404352,
+                lengthMetres: 14.528,
+                nominalR: 36.3397497041326,
+                nominalRsi: 6.3998,
+                typeEnglish: 'Attic/gable',
+                typeFrench: 'Combles/pignon',
+              },
+            ],
+          },
+          {
+            ceilings: [
+              {
+                areaFeet: 830.1171300283143,
+                areaMetres: 77.1204,
+                effectiveR: 36.3397497041326,
+                effectiveRsi: 6.3998,
+                label: 'Ceiling01',
+                lengthFeet: 47.66404352,
+                lengthMetres: 14.528,
+                nominalR: 36.3397497041326,
+                nominalRsi: 6.3998,
+                typeEnglish: 'Attic/gable',
+                typeFrench: 'Combles/pignon',
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('retrieves all top level keys of the wall data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+            evaluations {
+              walls {
+                label
+                structureTypeEnglish
+                structureTypeFrench
+                componentTypeSizeEnglish
+                componentTypeSizeFrench
+                nominalRsi
+                nominalR
+                effectiveRsi
+                effectiveR
+                areaMetres
+                areaFeet
+                perimeter
+                height
+              }
+            }
+          }
+        }`,
+        })
+
+      let { evaluations } = response.body.data
+      expect(evaluations).toEqual({
+        evaluations: [
+          {
+            walls: [
+              {
+                areaFeet: 1000.7916833561255,
+                areaMetres: 92.97658384,
+                componentTypeSizeEnglish: null,
+                componentTypeSizeFrench: null,
+                effectiveR: 15.2699857658604,
+                effectiveRsi: 2.6892,
+                height: 2.5999,
+                label: 'Main floor',
+                nominalR: 19.0874822073255,
+                nominalRsi: 3.3615,
+                perimeter: 35.7616,
+                structureTypeEnglish: null,
+                structureTypeFrench: null,
+              },
+            ],
+          },
+          {
+            walls: [
+              {
+                areaFeet: 1000.7916833561255,
+                areaMetres: 92.97658384,
+                componentTypeSizeEnglish: null,
+                componentTypeSizeFrench: null,
+                effectiveR: 15.2699857658604,
+                effectiveRsi: 2.6892,
+                height: 2.5999,
+                label: 'Main floor',
+                nominalR: 19.0874822073255,
+                nominalRsi: 3.3615,
+                perimeter: 35.7616,
+                structureTypeEnglish: null,
+                structureTypeFrench: null,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('retrieves all top level keys of the door data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+            evaluations {
+              doors {
+                typeEnglish
+                typeFrench
+                rsi
+                rValue
+                uFactor
+                uFactorImperial
+                areaMetres
+                areaFeet
+              }
+            }
+          }
+        }`,
+        })
+
+      let { evaluations } = response.body.data
+      expect(evaluations).toEqual({
+        evaluations: [
+          {
+            doors: [
+              {
+                areaFeet: 18.9875391902784,
+                areaMetres: 1.764,
+                rValue: 6.4732202041799995,
+                rsi: 1.14,
+                typeEnglish: 'Steel Medium density spray foam core',
+                typeFrench:
+                  'Acier / âme en mousse à vaporiser de densité moyenne',
+                uFactor: 0.8771929824561404,
+                uFactorImperial: 0.15448261737709199,
+              },
+              {
+                areaFeet: 18.9875391902784,
+                areaMetres: 1.764,
+                rValue: 6.4732202041799995,
+                rsi: 1.14,
+                typeEnglish: 'Steel Medium density spray foam core',
+                typeFrench:
+                  'Acier / âme en mousse à vaporiser de densité moyenne',
+                uFactor: 0.8771929824561404,
+                uFactorImperial: 0.15448261737709199,
+              },
+            ],
+          },
+          {
+            doors: [
+              {
+                areaFeet: 18.9875391902784,
+                areaMetres: 1.764,
+                rValue: 6.4732202041799995,
+                rsi: 1.14,
+                typeEnglish: 'Steel Medium density spray foam core',
+                typeFrench:
+                  'Acier / âme en mousse à vaporiser de densité moyenne',
+                uFactor: 0.8771929824561404,
+                uFactorImperial: 0.15448261737709199,
+              },
+              {
+                areaFeet: 18.9875391902784,
+                areaMetres: 1.764,
+                rValue: 6.4732202041799995,
+                rsi: 1.14,
+                typeEnglish: 'Steel Medium density spray foam core',
+                typeFrench:
+                  'Acier / âme en mousse à vaporiser de densité moyenne',
+                uFactor: 0.8771929824561404,
+                uFactorImperial: 0.15448261737709199,
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('retrieves all top level keys of the window data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+          evaluations:evaluationsFor(account: 189250) {
+            evaluations {
+              windows {
+                label
+                rsi
+                rvalue
+                glazingTypesEnglish
+                glazingTypesFrench
+                coatingsTintsEnglish
+                coatingsTintsFrench
+                fillTypeEnglish
+                fillTypeFrench
+                spacerTypeEnglish
+                spacerTypeFrench
+                typeEnglish
+                typeFrench
+                frameMaterialEnglish
+                frameMaterialFrench
+                areaMetres
+                areaFeet
+                width
+                height
+              }
+            }
+          }
+        }`,
+        })
+
+      let { evaluations: { evaluations: [first] } } = response.body.data
+      let [eastWindow] = first.windows
+      expect(eastWindow).toEqual({
+        label: 'East0001',
+        rsi: 0.2685,
+        rvalue: 1.5246137059845,
+        glazingTypesEnglish: 'Double/double with 1 coat',
+        glazingTypesFrench: 'Double/double, 1 couche',
+        coatingsTintsEnglish: 'Clear',
+        coatingsTintsFrench: 'Transparent',
+        fillTypeEnglish: '13 mm Air',
+        fillTypeFrench: "13 mm d'air",
+        spacerTypeEnglish: 'Metal',
+        spacerTypeFrench: 'Métal',
+        typeEnglish: 'Picture',
+        typeFrench: 'Fixe',
+        frameMaterialEnglish: 'Aluminum',
+        frameMaterialFrench: 'Aluminium',
+        areaMetres: 1.31104735596684,
+        areaFeet: 14.111997194858986,
+        width: 1.0746954,
+        height: 1.2199246000000001,
+      })
+    })
+  })
+
   describe('evaluationsFor', () => {
     it('retrieves evaluations given an account id and a postalcode', async () => {
       let response = await request(server)

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -92,17 +92,17 @@ describe('queries', () => {
           evaluationsFor(account: 189250) {
             evaluations {
               ceilings {
-								label
-								typeEnglish
-								typeFrench
-								insulationNominalRsi
-								insulationNominalR
-								insulationEffectiveRsi
-								insulationEffectiveR
-								areaMetres
-								areaFeet
-								lengthMetres
-								lengthFeet
+                label
+                typeEnglish
+                typeFrench
+                insulationNominalRsi
+                insulationNominalR
+                insulationEffectiveRsi
+                insulationEffectiveR
+                areaMetres
+                areaFeet
+                lengthMetres
+                lengthFeet
               }
             }
           }
@@ -136,21 +136,21 @@ describe('queries', () => {
           evaluationsFor(account: 189250) {
             evaluations {
               walls {
-								label
-								structureTypeEnglish
-								structureTypeFrench
-								componentTypeSizeEnglish
-								componentTypeSizeFrench
-								insulationNominalRsi
-								insulationNominalR
-								insulationEffectiveRsi
-								insulationEffectiveR
-								areaMetres
-								areaFeet
-								perimeterMetres
-								perimeterFeet
-								heightMetres
-								heightFeet
+                label
+                structureTypeEnglish
+                structureTypeFrench
+                componentTypeSizeEnglish
+                componentTypeSizeFrench
+                insulationNominalRsi
+                insulationNominalR
+                insulationEffectiveRsi
+                insulationEffectiveR
+                areaMetres
+                areaFeet
+                perimeterMetres
+                perimeterFeet
+                heightMetres
+                heightFeet
               }
             }
           }
@@ -188,14 +188,14 @@ describe('queries', () => {
           evaluationsFor(account: 189250) {
             evaluations {
               doors {
-								typeEnglish
-								typeFrench
-								insulationRsi
-								insulationR
-								uFactor
-								uFactorImperial
-								areaMetres
-								areaFeet
+                typeEnglish
+                typeFrench
+                insulationRsi
+                insulationR
+                uFactor
+                uFactorImperial
+                areaMetres
+                areaFeet
               }
             }
           }
@@ -226,27 +226,27 @@ describe('queries', () => {
           evaluations:evaluationsFor(account: 189250) {
             evaluations {
               windows {
-								label
-								insulationRsi
-								insulationR
-								glazingTypesEnglish
-								glazingTypesFrench
-								coatingsTintsEnglish
-								coatingsTintsFrench
-								fillTypeEnglish
-								fillTypeFrench
-								spacerTypeEnglish
-								spacerTypeFrench
-								typeEnglish
-								typeFrench
-								frameMaterialEnglish
-								frameMaterialFrench
-								areaMetres
-								areaFeet
-								widthMetres
-								widthFeet
-								heightMetres
-								heightFeet
+                label
+                insulationRsi
+                insulationR
+                glazingTypesEnglish
+                glazingTypesFrench
+                coatingsTintsEnglish
+                coatingsTintsFrench
+                fillTypeEnglish
+                fillTypeFrench
+                spacerTypeEnglish
+                spacerTypeFrench
+                typeEnglish
+                typeFrench
+                frameMaterialEnglish
+                frameMaterialFrench
+                areaMetres
+                areaFeet
+                widthMetres
+                widthFeet
+                heightMetres
+                heightFeet
               }
             }
           }
@@ -376,8 +376,8 @@ describe('queries', () => {
            forwardSortationArea: "C1A"
           ) {
             results {
-							yearBuilt
-						}
+              yearBuilt
+            }
           }
         }`,
         })
@@ -398,9 +398,9 @@ describe('queries', () => {
                   forwardSortationArea: "C1A"
                   filter: {field: yearBuilt gt: "1900"}
                  ) {
-										results {
-											yearBuilt
-										}
+                    results {
+                      yearBuilt
+                    }
                  }
                }`,
             })
@@ -419,9 +419,9 @@ describe('queries', () => {
                   forwardSortationArea: "C1A"
                   filter: {field: city eq: "Charlottetown"}
                  ) {
-									 results {
-										 yearBuilt
-									 }
+                   results {
+                     yearBuilt
+                   }
                  }
                }`,
             })
@@ -441,9 +441,9 @@ describe('queries', () => {
                   forwardSortationArea: "C1A"
                   filter: {field: yearBuilt lt: "2000"}
                  ) {
-									 results {
-                     yearBuilt
-									 }
+                     results {
+                       yearBuilt
+                    }
                  }
                }`,
             })
@@ -464,8 +464,8 @@ describe('queries', () => {
                   filter: {field: yearBuilt eq: "1900"}
                  ) {
                    results {
-										 yearBuilt
-								   }
+                     yearBuilt
+                   }
                  }
                }`,
             })
@@ -485,9 +485,9 @@ describe('queries', () => {
                 forwardSortationArea: "M8H"
                 filter: {field: yearBuilt gt: "1979" lt: "1979"}
               ) {
-								results {
-								 yearBuilt
-							 }
+                results {
+                 yearBuilt
+               }
              }
            }`,
           })
@@ -504,9 +504,9 @@ describe('queries', () => {
            dwellings:dwellingsInFSA(
              forwardSortationArea: "C1A"
            ) {
-					results {
-						yearBuilt
-					}
+          results {
+            yearBuilt
+          }
         }
       }`,
         })


### PR DESCRIPTION
These integration tests assert against the actual values currently being
returned by the fixture data. If the data shifts, and the values change
(or are null) these tests will fail and stop the build/deployment
process.

In the end, the effect we were looking for was easy to get. :smile_cat: 