### PR TITLE
Add localhost link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This will
 
 The API should be running now! Yes!! 🎉🎉🎉
 
-Check it out at [http://localhost:3000/graphiql]()
+Check it out at [http://localhost:3000/graphiql](http://localhost:3000/graphiql)
 
 Try out this query to get you going.
 


### PR DESCRIPTION
This PR fixes a small bug in the README where it was linking back to the current page instead of localhost.