### PR TITLE
Fix linting rules

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,7 @@
     "extract": "lingui extract",
     "compile": "lingui compile",
     "precommit": "lint-staged",
-    "lint": "eslint src/**, test/**"
+    "lint": "eslint src/** test/** --ignore-pattern src/locale"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Linting wasn't finding the files, so removing a `,` after `src/**,` in the package.json fixed it
2. Then it was finding some files we didn't want to lint, so I added a flag to ignore the autogenerated stuff in `locale`