### PR TITLE
[DEMO-1] Create /welcome page for a "show-the-thing" demo

### DIFF
--- a/api/src/server.js
+++ b/api/src/server.js
@@ -3,10 +3,10 @@ import bodyParser from 'body-parser'
 import cors from 'cors'
 import { graphqlExpress, graphiqlExpress } from 'apollo-server-express'
 import Schema from './schema'
-import { i18n , unpackCatalog } from 'lingui-i18n'
+import { i18n, unpackCatalog } from 'lingui-i18n'
 import requestLanguage from 'express-request-language'
 
-i18n.load({ 
+i18n.load({
   fr: unpackCatalog(require('./locale/fr/messages.js')),
   en: unpackCatalog(require('./locale/en/messages.js')),
 })
@@ -15,25 +15,25 @@ function Server(context = {}, ...middlewares) {
   const server = express()
   middlewares.forEach(middleware => server.use(middleware))
   server
-  .use(
-    requestLanguage({
-      languages: i18n.availableLanguages.sort(),
-    }),
-  )
-  .use(cors())
-  .use(
-    '/graphql',
-    bodyParser.json(),
-    graphqlExpress(request => {
-      i18n.activate(request.language)
-      return {
-        schema: new Schema(i18n),
-        context,
-        tracing: true,
-        cacheControl: true,
-      }
-    }),
-  )
+    .use(
+      requestLanguage({
+        languages: i18n.availableLanguages.sort(),
+      }),
+    )
+    .use(cors())
+    .use(
+      '/graphql',
+      bodyParser.json(),
+      graphqlExpress(request => {
+        i18n.activate(request.language)
+        return {
+          schema: new Schema(i18n),
+          context,
+          tracing: true,
+          cacheControl: true,
+        }
+      }),
+    )
   server.get('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }))
   return server
 }

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -35,6 +35,14 @@ function Server(context = {}, ...middlewares) {
       }),
     )
   server.get('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }))
+
+  // TODO: Remove after demo is over (which is easy because we are super agile)
+  server.get('/welcome', function(req, res) {
+    res.send(
+      '<h1 style="font-size:2.5em;">Welcome to the super agile <strong style="color:inherited;">ENER-CAN API</strong>!</h1>',
+    )
+  })
+
   return server
 }
 


### PR DESCRIPTION
The diff includes some prettify formatting changes to server.js, but the only functional changes are from lines 38-45 which add a pretty minimal `/welcome` page we can use for the demo.

## Screenshot

<img width="1312" alt="screen shot 2018-02-14 at 5 43 20 pm" src="https://user-images.githubusercontent.com/2454380/36232534-233aac4a-11b0-11e8-8799-2b5e71650def.png">


### why add code just for demo purposes?

A few reasons, I think. Other suggestions were to demo a redirect rule or a change to the API output.

- demoing a redirect is less visual (ie, less impactful during a presentation)
- similarly, demoing an API response change is probably less not very interesting for a non-technical person
- we're agile, so it's easy for us to remove stuff we don't need

