### PR TITLE
Small exceptions change

### DIFF
--- a/python/src/energuide/exceptions.py
+++ b/python/src/energuide/exceptions.py
@@ -1,3 +1,5 @@
+import typing
+
 class EnerguideException(Exception):
     pass
 
@@ -12,7 +14,6 @@ class InvalidInputDataException(EnerguideException):
 
 class InvalidEmbeddedDataTypeException(EnerguideException):
 
-    def __init__(self, data_class, *args, parent=None, **kwargs):
+    def __init__(self, data_class: type, *args: typing.Tuple, **kwargs: typing.Dict) -> None:
         super().__init__(*args, **kwargs)
         self.data_class = data_class
-        self.parent = parent


### PR DESCRIPTION
This PR simplifies InvalidEmbeddedDataTypeException based on [PEP 3134](https://www.python.org/dev/peps/pep-3134/), and adds missing type hints.