### PR TITLE
Lowercase 'tankVolumeGallon' key in 'waterHeatings'

### DIFF
--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -223,7 +223,7 @@ describe('Schema', () => {
         'typeEnglish',
         'typeFrench',
         'tankVolumeLitres',
-        'TankVolumeGallon',
+        'tankVolumeGallon',
         'efficiency',
       ])
     })

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -35,7 +35,7 @@ const Schema = i18n => {
       typeEnglish: String
       typeFrench: String
       tankVolumeLitres: Float
-      TankVolumeGallon: Float
+      tankVolumeGallon: Float
       efficiency: Float
     }
 

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -229,7 +229,7 @@ describe('queries', () => {
                   typeEnglish
                   typeFrench
                   tankVolumeLitres
-                  TankVolumeGallon
+                  tankVolumeGallon
                   efficiency
                 }
             }
@@ -241,7 +241,7 @@ describe('queries', () => {
       let [first] = evaluations
       let [waterHeatings] = first.waterHeatings
       expect(waterHeatings).toEqual({
-        TankVolumeGallon: 39.995640800000004,
+        tankVolumeGallon: 39.995640800000004,
         efficiency: 0.554,
         tankVolumeLitres: 151.4,
         typeEnglish: "Natural gas storage tank",

--- a/python/src/energuide/embedded/water_heating.py
+++ b/python/src/energuide/embedded/water_heating.py
@@ -315,6 +315,6 @@ class WaterHeating(_WaterHeating):
             'typeEnglish': translation.english,
             'typeFrench': translation.french,
             'tankVolumeLitres': self.tank_volume,
-            'TankVolumeGallon': self.tank_volume_gallon,
+            'tankVolumeGallon': self.tank_volume_gallon,
             'efficiency': self.efficiency,
         }

--- a/python/tests/embedded/test_water_heating.py
+++ b/python/tests/embedded/test_water_heating.py
@@ -49,7 +49,7 @@ def test_to_dict(sample: element.Element) -> None:
         'typeEnglish': 'Electric storage tank',
         'typeFrench': 'Réservoir électrique',
         'tankVolumeLitres': 189.3001,
-        'TankVolumeGallon': 50.0077860172,
+        'tankVolumeGallon': 50.0077860172,
         'efficiency': 0.8217,
     }
 


### PR DESCRIPTION
tankVolumeGallon is not more important than any other tankVolume.

***

**WARNING**

You will need to drop the existing test data and reimport after merging this. 
If you are running on a macOS laptop, you can run `make setup` and then `make run` from the root folder.