### PR TITLE
Readme cleanup/updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ CircleCI Status: [![CircleCI](https://circleci.com/gh/cds-snc/nrcan_api.svg?styl
 This is the API for NRCAN's Energuide data.
 
 This project is composed of two parts: the API itself and the ETL process that produces the data the API will serve.
-There are further details in the readme for each of the respective portions of the project.
+There are further details in the READMEs for each of the respective portions of the project.
 
 - [Windows Installation Instructions](#windows-installation)
 - [MacOS Installation Instructions](#tldr)
@@ -14,7 +14,7 @@ There are further details in the readme for each of the respective portions of t
 
 ### TL;DR
 
-If you're really keen (and on a Mac), this should do you. Continue reading for more details.
+If you're really keen (and on a Mac), this should do you. Or continue reading for more details.
 
 ```sh
 # install python 3 and mongo
@@ -46,7 +46,7 @@ Once the script runs through, you'll need to import the data into your database,
 
 #### importing data
 
-The Python code in `/python` transforms the data from its default formatting by NRCAN and then inserts it into our Mongo database. More details can be found in the [README](https://github.com/cds-snc/nrcan_api/blob/master/python/README.md).
+The Python code in `/python` transforms the data from the default formatting set by NRCAN, and then inserts it into our Mongo database. More details can be found in the [README](https://github.com/cds-snc/nrcan_api/blob/master/python/README.md).
 
 For local development, run
 ```
@@ -77,13 +77,14 @@ The JavaScript code in `/api` builds us a [GraphQL](http://graphql.org/learn/) A
 
 To build the app and connect it to mongo, run
 ```
-make run
+make watch
 ```
 
 This will
 - install the needed JavaScript dependencies
 - build the app
 - serve it up locally
+- rebuild when files are changed
 
 ## Windows installation
 
@@ -97,64 +98,84 @@ Version 3.6.4 or higher is required.
 3. Download Node.js from [here](https://nodejs.org/en/download/). Version >=8.x of Node is required.
 
 Check if the libraries are accessible by running the following commands in a terminal window
-```
+```sh
 python --version
 
 mongo --version
 
 node --version
 ```
-If version is not shown, the path to the library has to be added to the 'PATH' environment variable in system properties
+If version is not shown, the path to the library has to be added to the 'PATH' environment variable in System Properties.
 
 ### Run python extractor
 
 Installing Python applications in a `virtualenv` is considered best practice. To do so, run:
-```
+```sh
 cd \python
 python -m venv env
 env\Scripts\activate.bat
 ```
 Inside an activated `virtualenv`, and from the python folder of the project, run:
 
-```
+```sh
 pip install -r requirements.txt
 pip install -e .
 ```
-"." is the part of command
+*Note: "." is part of the command*
 
 `Mongodb` must be started before going to the next step. Open new terminal window and type
-```
-md \data\db    #required run just first time
-mongo
+```sh
+# this directory is required when running mongod for the first time
+md \data\db
+mongod
 ```
 Keep this window open to continue running the database and open a new one to finish extracting the data.
 
 Finish python part of installation.
 
-Following command drop existing `energuide mongodb` test data.
+Run the following command drop existing `energuide mongodb` test data.
 ```
 mongo energuide --eval "db.dwellings.drop()"
 ```
 
-Run python command:
-```
-energuide extract --infile tests/randomized_energuide_data.csv --outfile allthedata.zip  #extract from csv to zip file
-energuide load --filename allthedata.zip	#load data into mongodb
-del allthedata.zip							#delete zip file
+Run the following python commands:
+```sh
+# extract from csv to zip file
+energuide extract --infile tests/randomized_energuide_data.csv --outfile allthedata.zip
+
+# load data into mongodb
+energuide load --filename allthedata.zip
+
+# delete zip file
+del allthedata.zip							
 ```
 Unit tests for the python code.
-```
+```sh
 pytest tests
 mypy src tests --ignore-missing-imports
 ```
-Open new terminal window. Run following command to connect to `energuide`db:
-```
-mongo												#open db client
-show dbs											#show db exists
-use energuide										#connect energuide schema
-db.dwellings.count()								#total number of entry data. Should be 7
-db.dwellings.find({}, {'forwardSortationArea': 1})	#select some fields
-#result shuld looks like:
+
+#### using the mongodb command-line client
+We can verify the data has actually been imported by using the mongodb command-line client. [More detailed docs exist](https://docs.mongodb.com/manual/reference/mongo-shell/), but these should get you going.
+
+Run following command to connect to `energuide`db:
+```sh
+#open db client
+mongo
+
+# show available databases ('energuide' should exist)
+show dbs
+
+# set energuide as the default 'db'
+use energuide
+
+# get the count of entries in 'dwellings' (should be 7)
+db.dwellings.count()
+
+# select 'forwardSortationArea' value of each dwelling
+db.dwellings.find({}, {'forwardSortationArea': 1})
+
+# result should  look like:
 { "_id" : ObjectId("5a848002e349de06d4bc8205"), "forwardSortationArea" : "T0J" }
 { "_id" : ObjectId("5a848002e349de06d4bc8206"), "forwardSortationArea" : "A2H" }
 { "_id" : ObjectId("5a848002e349de06d4bc8207"), "forwardSortationArea" : "Y1A" }
@@ -162,27 +183,38 @@ db.dwellings.find({}, {'forwardSortationArea': 1})	#select some fields
 { "_id" : ObjectId("5a848002e349de06d4bc8209"), "forwardSortationArea" : "B2R" }
 { "_id" : ObjectId("5a848002e349de06d4bc820a"), "forwardSortationArea" : "X0A" }
 { "_id" : ObjectId("5a848002e349de06d4bc820b"), "forwardSortationArea" : "C1A" }
-quit()												#disconnect for db
+
+# disconnect from mongodb
+quit()
 ```
 
 ### Run `GraphQL API`  
 
-Move to `nrcan_api\api` folder
+Move to `nrcan_api\api` folder.
+
 `API` utilizes Apollo Engine to monitor activities on host with `GraphQL` website.
 Apollo Engine is a monitoring/logging layer that gives us out-of-the-box diagnostic information about our graphql instance. You'll need your own API key to get the API running, so [sign up for one here](https://engine.apollographql.com/login).
 Key looks similar to: `service:yname-8241:lQ3g_8Yojs4stdIWqwwj-bQ`
 
 Set following variables:
-```
+```sh
 set NRCAN_DB_CONNECTION_STRING=mongodb://localhost:27017
 set NRCAN_DB_NAME=energuide
 set NRCAN_COLLECTION_NAME=dwellings
 set NRCAN_ENGINE_API_KEY=service:yname-8241:lQ3g_8Yojs4stdIWqwwj-bQ
 ```
 
-Next command start `GraphQL`
+Make sure `yarn` is installed
+
+```sh
+# should return a version number
+yarn --version
 ```
-npm run start
+If `yarn` is not installed, run `npm install --global yarn` to install.
+
+Next command start `GraphQL`
+```sh
+yarn start
 ```
 
 ### Using the API locally
@@ -199,11 +231,11 @@ Try out this query to get you going.
     forwardSortationArea: "C1A"
   ) {
     results {
-    yearBuilt
-    city
+      yearBuilt
+      city
     }
   }
 }
 ```
 
-<super>Or just [click here](http://localhost:3000/graphiql?query=%7B%0A%20%20dwellingsInFSA(%0A%20%20%20%20forwardSortationArea%3A%20%22C1A%22%0A%20%20)%20%7B%0A%20%20%20%20results%20%7B%0A%20%20%20%20yearBuilt%0A%20%20%20%20city%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)</super>
+<sup>Or just [click here](http://localhost:3000/graphiql?query=%7B%0A%20%20dwellingsInFSA(%0A%20%20%20%20forwardSortationArea%3A%20%22C1A%22%0A%20%20)%20%7B%0A%20%20%20%20results%20%7B%0A%20%20%20%20%20%20yearBuilt%0A%20%20%20%20%20%20city%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D)</sup>

--- a/api/README.md
+++ b/api/README.md
@@ -6,6 +6,27 @@ This is the API for NRCAN's Energuide data.
 
 ## Running the server
 
+#### Quickstart
+
+```sh
+# make sure to set your NRCAN_ENGINE_API_KEY environment variable
+export NRCAN_ENGINE_API_KEY=your_apollo_engine_api_key
+
+# build and run the API
+make watch
+```
+
+`make watch` will do a few things for you
+- install all missing dependencies
+- build the app
+- serve the API locally
+- rebuild and restart if you make any changes
+
+Once it's running, check it out at [http://localhost:3000/](http://localhost:3000/).
+Or [here's an example query](http://localhost:3000/graphiql?query=%7B%0A%20%20dwellingsInFSA(%0A%20%20%20%20forwardSortationArea%3A%20%22C1A%22%0A%20%20)%20%7B%0A%20%20%20%20results%20%7B%0A%20%20%20%20%20%20yearBuilt%0A%20%20%20%20%20%20city%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D) to get you going.
+
+### Manually starting the server
+
 Running the sever requires a MongoDB server running somewhere and the following environmental variables defined:
 
 * NRCAN_ENGINE_API_KEY
@@ -38,14 +59,22 @@ Monitoring and caching is done with [Apollo Engine](https://engine.apollographql
 Assuming the DB credentials/connectivity is correct, the command above will
 start a graphql endpoint that will respond to the following `curl` commands:
 
-```
-curl -s -H "Content-Type: application/json" -d '{"query": "{dwellingsInFSA(forwardSortationArea: \"M8H\"){ yearBuilt }}"}'  "localhost:3000/graphql"
+```sh
+curl -s -H "Content-Type: application/json" -d '{"query": "{dwellingsInFSA(forwardSortationArea: \"C1A\"){ results { yearBuilt }}}"}'  "localhost:3000/graphql"
 ```
 
 It is also possible to access the API via `/graphiql` which will serve up a Graphical IDE to allow you to explore the functionality the API offers and run queries against it.
 
 ## Running the tests
 
+Run the unit tests
+
 ```sh
-> yarn test
+yarn test
+```
+
+Run the integration tests
+
+```sh
+yarn integration
 ```


### PR DESCRIPTION
This PR updates the top-level README and the /api/README.

#### For the main README:

- I cleaned up some of the windows commands (which were hard to copy from with trailing comments)
- added `make watch`
- added instructions to install (and use) `yarn` rather than `npm`

#### For the /api/README:
- I added a 'get up and running quickly' section
- I fixed the curl request 
- I added the command for the yarn integration test
