### PR TITLE
Bigfix: updating NPM script for Windows compatibility

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,7 @@
     "compile": "lingui compile",
     "precommit": "lint-staged",
     "lint": "eslint src/** test/** --ignore-pattern src/locale",
-    "watch": "nodemon -x 'yarn build && node' -w 'src' -i 'src/__tests__' dist/index.js"
+    "watch": "nodemon --watch \"src\" --ignore \"src/__tests__\" --exec \"yarn build && yarn start\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
NPM scripts that require quotes need to be escaped double quotes to work properly on Windows.
With single quotes, Windows includes the single quote as part of the command (ie, it says it doesn't know how to run `'yarn`).

Also expanded the flags to make them more explicit.