### PR TITLE
Add Apollo Engine request caching

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -11,6 +11,17 @@ const engine = new Engine({
     logging: {
       level: 'ERROR',
     },
+    stores: [
+      {
+        name: 'publicResponseCache',
+        inMemory: {
+          cacheSize: 10485760,
+        },
+      },
+    ],
+    queryCache: {
+      publicFullQueryStore: 'publicResponseCache',
+    },
   },
   graphqlPort: 3000,
   endpoint: '/graphql',

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -30,7 +30,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Ventilation systems draw exterior air into the house, exhaust interior air to the exterior, or both`}
-    type Ventilation {
+    type Ventilation @cacheControl(maxAge: 90) {
       # ${i18n.t`Ventilation type installed (en)`}
       typeEnglish: I18NString
       # ${i18n.t`Ventilation type installed (fr)`}
@@ -42,7 +42,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Floors represents the usable area of the house`}
-    type Floor {
+    type Floor @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of floor location`}
       label: I18NString
       # ${i18n.t`Floor insulation nominal RSI (R-value Systeme International)`}
@@ -64,7 +64,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Water heaters heat the domestic hot water in a house`}
-    type WaterHeater {
+    type WaterHeater @cacheControl(maxAge: 90) {
       # ${i18n.t`Type of tank being used to heat the domestic hot water in the house (en)`}
       typeEnglish: I18NString
       # ${i18n.t`Type of tank being used to heat the domestic hot water in the house (fr)`}
@@ -78,7 +78,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`One page of results`}
-    type PaginatedResultSet {
+    type PaginatedResultSet @cacheControl(maxAge: 90) {
       # ${i18n.t`If true, a further page of results can be returned`}
       hasNext: I18NBoolean
       # ${i18n.t`If true, a previous page of results can be returned`}
@@ -92,7 +92,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Heated floor areas represents the usable areas of a house that is conditioned to a specified temperature during the whole heating season`}
-    type HeatedFloorArea {
+    type HeatedFloorArea @cacheControl(maxAge: 90) {
       # ${i18n.t`Above-grade heated area of the house in square metres (m2), i.e. the ground floor`}
       areaAboveGradeMetres: I18NFloat
       # ${i18n.t`Above-grade heated area of the house in square feet (ft2), i.e. the ground floor`}
@@ -104,7 +104,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Walls separate the interior heated space from the outside (interior partition walls are not considered walls)`}
-    type Wall {
+    type Wall @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of wall location`}
       label: I18NString
       # ${i18n.t`Wall construction being used (en)`}
@@ -138,7 +138,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Doors are on outside walls, separating the interior heated space from the outside`}
-    type Door {
+    type Door @cacheControl(maxAge: 90) {
       # ${i18n.t`Describes the construction of the door (en)`}
       typeEnglish: I18NString
       # ${i18n.t`Describes the construction of the door (fr)`}
@@ -158,7 +158,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Windows separate the interior heated space from the outside`}
-    type Window {
+    type Window @cacheControl(maxAge: 90) {
       # ${i18n.t`Used to identify the window component in the house`}
       label: I18NString
       # ${i18n.t`Window RSI (R-value Systeme International)`}
@@ -204,7 +204,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Ceilings are the upper interior surface of a room`}
-    type Ceiling {
+    type Ceiling @cacheControl(maxAge: 90) {
       # ${i18n.t`Used to identify the ceiling in the house`}
       label: I18NString
       # ${i18n.t`Describes the construction of the ceiling (en)`}
@@ -230,7 +230,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`Detailed information about specific features of a given dwelling`}
-    type Evaluation {
+    type Evaluation @cacheControl(maxAge: 90) {
       # ${i18n.t`Evaluation type codes are used to define the type of evaluation performed and to distinguish the house type (i.e. newly built or existing)`}
       evaluationType: I18NString
       # ${i18n.t`Date the evaluation was made`}
@@ -259,7 +259,7 @@ const Schema = i18n => {
 
 
     # ${i18n.t`A residential building evaluted under the Energuide program`}
-    type Dwelling {
+    type Dwelling @cacheControl(maxAge: 90) {
       # ${i18n.t`Unique identification number for a dwelling`}
       houseId: I18NInt
       # ${i18n.t`Year of construction`}
@@ -275,7 +275,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`The root query type`}
-    type Query {
+    type Query @cacheControl(maxAge: 90) {
       # ${i18n.t`Details for a specific dwelling`}
       dwelling(houseId: I18NInt!): Dwelling
       # ${i18n.t`Details for all dwellings, optionally filtered by one or more values`}

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -3,10 +3,10 @@ import bodyParser from 'body-parser'
 import cors from 'cors'
 import { graphqlExpress, graphiqlExpress } from 'apollo-server-express'
 import Schema from './schema'
-import { i18n , unpackCatalog } from 'lingui-i18n'
+import { i18n, unpackCatalog } from 'lingui-i18n'
 import requestLanguage from 'express-request-language'
 
-i18n.load({ 
+i18n.load({
   fr: unpackCatalog(require('./locale/fr/messages.js')),
   en: unpackCatalog(require('./locale/en/messages.js')),
 })
@@ -15,25 +15,25 @@ function Server(context = {}, ...middlewares) {
   const server = express()
   middlewares.forEach(middleware => server.use(middleware))
   server
-  .use(
-    requestLanguage({
-      languages: i18n.availableLanguages.sort(),
-    }),
-  )
-  .use(cors())
-  .use(
-    '/graphql',
-    bodyParser.json(),
-    graphqlExpress(request => {
-      i18n.activate(request.language)
-      return {
-        schema: new Schema(i18n),
-        context,
-        tracing: true,
-        cacheControl: true,
-      }
-    }),
-  )
+    .use(
+      requestLanguage({
+        languages: i18n.availableLanguages.sort(),
+      }),
+    )
+    .use(cors())
+    .use(
+      '/graphql',
+      bodyParser.json(),
+      graphqlExpress(request => {
+        i18n.activate(request.language)
+        return {
+          schema: new Schema(i18n),
+          context,
+          tracing: true,
+          cacheControl: true,
+        }
+      }),
+    )
   server.get('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }))
   server.get('/', function (req, res) {
     res.redirect('/graphiql');


### PR DESCRIPTION
Apollo engine caching defaults to the lowest-defined caching setting per query (default is 0). This means that we have to set an explicit caching setting on each of our `type`s if we want a generic caching behaviour. (ie, if we didn't set it on "walls", any query which included walls would never be cached.)

I've set the time to 90 seconds but that's pretty arbitrary.

Evidence of caching can be seen
- when running locally by removing the 'cacheControl' from `strip: ['cacheControl', ... ] [in the Apollo Engine setup](https://github.com/cds-snc/nrcan_api/blob/master/api/src/index.js#L19)
- by logging into Apollo Engine itself, which gives a visual timeline of requests, and shows how many were returned from the cache

'stores' config was [pinched from the Request Caching docs](https://www.apollographql.com/docs/engine/caching.html#engine-cache-config).
