### PR TITLE
rename *Exception to *Error

### DIFF
--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -13,8 +13,8 @@ from energuide.embedded import window
 from energuide.embedded import ventilation
 from energuide.embedded import water_heating
 from energuide.embedded import heated_floor_area
-from energuide.exceptions import InvalidGroupSizeException
-from energuide.exceptions import InvalidInputDataException
+from energuide.exceptions import InvalidGroupSizeError
+from energuide.exceptions import InvalidInputDataError
 
 
 @enum.unique
@@ -29,7 +29,7 @@ class EvaluationType(enum.Enum):
         elif code == cls.POST_RETROFIT.value:
             return EvaluationType.POST_RETROFIT
         else:
-            raise InvalidInputDataException(f'Invalid code: {code}')
+            raise InvalidInputDataError(f'Invalid code: {code}')
 
 
 @enum.unique
@@ -127,7 +127,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True, ignore_none_values=True)
         if not checker.validate(row):
             error_keys = ', '.join(checker.errors.keys())
-            raise InvalidInputDataException(f'Validator failed on keys: {error_keys}')
+            raise InvalidInputDataError(f'Validator failed on keys: {error_keys}')
 
         parsed = checker.document
         codes = code.Codes.from_data(parsed['codes'])
@@ -296,7 +296,7 @@ class Dwelling:
                 evaluations=evaluations,
             )
         else:
-            raise InvalidGroupSizeException(f'Invalid group size "{len(data)}". Groups must be size 2')
+            raise InvalidGroupSizeError(f'Invalid group size "{len(data)}". Groups must be size 2')
 
     @classmethod
     def from_group(cls, data: typing.List[reader.InputData]) -> 'Dwelling':

--- a/etl/src/energuide/element.py
+++ b/etl/src/energuide/element.py
@@ -1,9 +1,9 @@
 import typing
 from lxml import etree
-from energuide.exceptions import EnerguideException
+from energuide.exceptions import EnerguideError
 
 
-class MalformedXmlError(EnerguideException):
+class MalformedXmlError(EnerguideError):
     pass
 
 

--- a/etl/src/energuide/embedded/ceiling.py
+++ b/etl/src/energuide/embedded/ceiling.py
@@ -4,7 +4,7 @@ from energuide import element
 from energuide.embedded import area
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _Ceiling(typing.NamedTuple):
@@ -35,7 +35,7 @@ class Ceiling(_Ceiling):
                 ceiling_length=distance.Distance(float(ceiling.xpath('Measurements/@length')[0])),
             )
         except (IndexError, ValueError, AssertionError) as exc:
-            raise InvalidEmbeddedDataTypeException(Ceiling) from exc
+            raise InvalidEmbeddedDataTypeError(Ceiling) from exc
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -1,7 +1,7 @@
 import typing
 from energuide import bilingual
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _WallCode(typing.NamedTuple):
@@ -29,7 +29,7 @@ class WallCode(_WallCode):
                 )
             )
         except (KeyError, AssertionError) as exc:
-            raise InvalidEmbeddedDataTypeException(WallCode) from exc
+            raise InvalidEmbeddedDataTypeError(WallCode) from exc
 
 
 class _WindowCode(typing.NamedTuple):
@@ -77,7 +77,7 @@ class WindowCode(_WindowCode):
                 )
             )
         except (KeyError, AssertionError) as exc:
-            raise InvalidEmbeddedDataTypeException(WindowCode) from exc
+            raise InvalidEmbeddedDataTypeError(WindowCode) from exc
 
 
 class _Codes(typing.NamedTuple):

--- a/etl/src/energuide/embedded/door.py
+++ b/etl/src/energuide/embedded/door.py
@@ -4,7 +4,7 @@ from energuide import element
 from energuide.embedded import distance
 from energuide.embedded import area
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _Door(typing.NamedTuple):
@@ -32,7 +32,7 @@ class Door(_Door):
                 width=distance.Distance(float(door.xpath('Measurements/@width')[0])),
             )
         except (IndexError, ValueError, AssertionError) as exc:
-            raise InvalidEmbeddedDataTypeException(Door) from exc
+            raise InvalidEmbeddedDataTypeError(Door) from exc
 
     @property
     def u_factor(self) -> float:

--- a/etl/src/energuide/embedded/floor.py
+++ b/etl/src/energuide/embedded/floor.py
@@ -3,7 +3,7 @@ from energuide import element
 from energuide.embedded import area
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _Floor(typing.NamedTuple):
@@ -27,7 +27,7 @@ class Floor(_Floor):
                 floor_length=distance.Distance(float(floor.xpath('Measurements/@length')[0])),
             )
         except (AssertionError, ValueError, IndexError) as exc:
-            raise InvalidEmbeddedDataTypeException(Floor) from exc
+            raise InvalidEmbeddedDataTypeError(Floor) from exc
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {

--- a/etl/src/energuide/embedded/heated_floor_area.py
+++ b/etl/src/energuide/embedded/heated_floor_area.py
@@ -1,7 +1,7 @@
 import typing
 from energuide import element
 from energuide.embedded import area
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _HeatedFloorArea(typing.NamedTuple):
@@ -19,7 +19,7 @@ class HeatedFloorArea(_HeatedFloorArea):
                 area_below_grade=area.Area(float(heated_floor_area.attrib['belowGrade'])),
             )
         except (KeyError, ValueError) as exc:
-            raise InvalidEmbeddedDataTypeException(HeatedFloorArea) from exc
+            raise InvalidEmbeddedDataTypeError(HeatedFloorArea) from exc
 
     def to_dict(self) -> typing.Dict[str, typing.Optional[float]]:
         return {

--- a/etl/src/energuide/embedded/ventilation.py
+++ b/etl/src/energuide/embedded/ventilation.py
@@ -2,7 +2,7 @@ import enum
 import typing
 from energuide import element
 from energuide import bilingual
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class VentilationType(enum.Enum):
@@ -73,7 +73,7 @@ class Ventilation(_Ventilation):
                 efficiency=float(ventilation.attrib['efficiency1']),
             )
         except (KeyError, ValueError) as exc:
-            raise InvalidEmbeddedDataTypeException(Ventilation) from exc
+            raise InvalidEmbeddedDataTypeError(Ventilation) from exc
 
     @property
     def air_flow_rate_cmf(self):

--- a/etl/src/energuide/embedded/wall.py
+++ b/etl/src/energuide/embedded/wall.py
@@ -4,7 +4,7 @@ from energuide.embedded import code
 from energuide.embedded import insulation
 from energuide.embedded import distance
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class _Wall(typing.NamedTuple):
@@ -36,7 +36,7 @@ class Wall(_Wall):
                 height=distance.Distance(float(wall.xpath('Measurements/@height')[0])),
             )
         except (AssertionError, ValueError, IndexError) as exc:
-            raise InvalidEmbeddedDataTypeException(Wall) from exc
+            raise InvalidEmbeddedDataTypeError(Wall) from exc
 
     @property
     def _wall_area(self) -> area.Area:

--- a/etl/src/energuide/embedded/water_heating.py
+++ b/etl/src/energuide/embedded/water_heating.py
@@ -2,7 +2,7 @@ import enum
 import typing
 from energuide import bilingual
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 class WaterHeaterType(enum.Enum):
@@ -299,7 +299,7 @@ class WaterHeating(_WaterHeating):
                 efficiency=efficiency,
             )
         except (AssertionError, KeyError, ValueError, IndexError) as exc:
-            raise InvalidEmbeddedDataTypeException(WaterHeating) from exc
+            raise InvalidEmbeddedDataTypeError(WaterHeating) from exc
 
     @classmethod
     def from_data(cls, water_heating: element.Element) -> typing.List['WaterHeating']:

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -4,7 +4,7 @@ from energuide.embedded import code
 from energuide.embedded import insulation
 from energuide.embedded import distance
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 _MILLIMETRES_TO_METRES = 1000
@@ -37,7 +37,7 @@ class Window(_Window):
                 height=distance.Distance(float(window.xpath('Measurements/@height')[0]) / _MILLIMETRES_TO_METRES),
             )
         except (AssertionError, ValueError, IndexError) as exc:
-            raise InvalidEmbeddedDataTypeException(Window) from exc
+            raise InvalidEmbeddedDataTypeError(Window) from exc
 
     @property
     def _window_area(self) -> area.Area:

--- a/etl/src/energuide/exceptions.py
+++ b/etl/src/energuide/exceptions.py
@@ -1,19 +1,19 @@
 import typing
 
 
-class EnerguideException(Exception):
+class EnerguideError(Exception):
     pass
 
 
-class InvalidGroupSizeException(EnerguideException):
+class InvalidGroupSizeError(EnerguideError):
     pass
 
 
-class InvalidInputDataException(EnerguideException):
+class InvalidInputDataError(EnerguideError):
     pass
 
 
-class InvalidEmbeddedDataTypeException(EnerguideException):
+class InvalidEmbeddedDataTypeError(EnerguideError):
 
     def __init__(self, data_class: type, *args: typing.Tuple, **kwargs: typing.Dict) -> None:
         super().__init__(*args, **kwargs)

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -7,7 +7,7 @@ import cerberus
 from energuide import element
 from energuide import reader
 from energuide import snippets
-from energuide.exceptions import InvalidInputDataException
+from energuide.exceptions import InvalidInputDataError
 
 
 DROP_FIELDS = ['ENTRYBY',
@@ -44,7 +44,7 @@ def _validated(data: typing.Iterable[reader.InputData], validator) -> typing.Ite
     for row in data:
         if not validator.validate(row):
             error_keys = ', '.join(validator.errors.keys())
-            raise InvalidInputDataException(f'Validator failed on keys: {error_keys}')
+            raise InvalidInputDataError(f'Validator failed on keys: {error_keys}')
         yield row
 
 

--- a/etl/src/energuide/transform.py
+++ b/etl/src/energuide/transform.py
@@ -3,8 +3,8 @@ from energuide import database
 from energuide import reader
 from energuide import dwelling
 from energuide import logging
-from energuide.exceptions import InvalidEmbeddedDataTypeException
-from energuide.exceptions import EnerguideException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import EnerguideError
 
 
 LOGGER = logging.get_logger(__name__)
@@ -15,11 +15,11 @@ def _generate_dwellings(grouped: typing.Iterable[typing.List[reader.InputData]])
         try:
             dwell = dwelling.Dwelling.from_group(group)
             yield dwell
-        except InvalidEmbeddedDataTypeException as exc:
+        except InvalidEmbeddedDataTypeError as exc:
             files = [str(file.get('jsonFileName')) for file in group]
             failing_type = exc.data_class
             LOGGER.error(f'Files: "{", ".join(files)}": {failing_type.__name__}')
-        except EnerguideException as exc:
+        except EnerguideError as exc:
             files = [str(file.get('jsonFileName')) for file in group]
             LOGGER.error(f'Files: "{", ".join(files)}" - {exc}')
 

--- a/etl/tests/embedded/test_ceiling.py
+++ b/etl/tests/embedded/test_ceiling.py
@@ -5,7 +5,7 @@ from energuide.embedded import area
 from energuide.embedded import ceiling
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def test_from_data(sample_raw: element.Element, sample: ceiling.Ceiling) -> None
 @pytest.mark.parametrize("bad_xml", BAD_DATA_XML)
 def test_bad_data(bad_xml: str) -> None:
     ceiling_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         ceiling.Ceiling.from_data(ceiling_node)
 
     assert excinfo.value.data_class == ceiling.Ceiling

--- a/etl/tests/embedded/test_code.py
+++ b/etl/tests/embedded/test_code.py
@@ -3,7 +3,7 @@ import pytest
 from energuide import bilingual
 from energuide import element
 from energuide.embedded import code
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -195,7 +195,7 @@ def test_window_code_from_data(raw_window_code: element.Element, window_code: co
 @pytest.mark.parametrize("bad_xml", BAD_WALL_CODE_XML)
 def test_bad_wall_code(bad_xml: str) -> None:
     code_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         code.WallCode.from_data(code_node)
 
     assert excinfo.value.data_class == code.WallCode
@@ -204,7 +204,7 @@ def test_bad_wall_code(bad_xml: str) -> None:
 @pytest.mark.parametrize("bad_xml", BAD_WINDOW_CODE_XML)
 def test_bad_window_code(bad_xml: str) -> None:
     code_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         code.WindowCode.from_data(code_node)
 
     assert excinfo.value.data_class == code.WindowCode

--- a/etl/tests/embedded/test_door.py
+++ b/etl/tests/embedded/test_door.py
@@ -4,7 +4,7 @@ from energuide import element
 from energuide.embedded import door
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -84,7 +84,7 @@ def test_from_data(sample_raw: element.Element, sample: door.Door) -> None:
 @pytest.mark.parametrize("bad_xml", BAD_DATA_XML)
 def test_bad_data(bad_xml: str) -> None:
     door_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         door.Door.from_data(door_node)
 
     assert excinfo.value.data_class == door.Door

--- a/etl/tests/embedded/test_floor.py
+++ b/etl/tests/embedded/test_floor.py
@@ -4,7 +4,7 @@ from energuide.embedded import area
 from energuide.embedded import distance
 from energuide.embedded import floor
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -74,7 +74,7 @@ def test_from_data(sample_raw: element.Element, sample: floor.Floor) -> None:
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     floor_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         floor.Floor.from_data(floor_node)
 
     assert excinfo.value.data_class == floor.Floor

--- a/etl/tests/embedded/test_heated_floor_area.py
+++ b/etl/tests/embedded/test_heated_floor_area.py
@@ -1,7 +1,7 @@
 import pytest
 from energuide import element
 from energuide.embedded import heated_floor_area
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -34,7 +34,7 @@ def test_from_data(sample: element.Element) -> None:
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     floor_area_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         heated_floor_area.HeatedFloorArea.from_data(floor_area_node)
 
     assert excinfo.value.data_class == heated_floor_area.HeatedFloorArea

--- a/etl/tests/embedded/test_ventilation.py
+++ b/etl/tests/embedded/test_ventilation.py
@@ -1,7 +1,7 @@
 import pytest
 from energuide import element
 from energuide.embedded import ventilation
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -56,7 +56,7 @@ def test_from_data(sample: element.Element):
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     ventilation_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         ventilation.Ventilation.from_data(ventilation_node)
 
     assert excinfo.value.data_class == ventilation.Ventilation

--- a/etl/tests/embedded/test_wall.py
+++ b/etl/tests/embedded/test_wall.py
@@ -6,7 +6,7 @@ from energuide.embedded import code
 from energuide.embedded import distance
 from energuide.embedded import insulation
 from energuide.embedded import wall
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -111,7 +111,7 @@ def test_from_data_missing_codes() -> None:
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     wall_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         wall.Wall.from_data(wall_node, {})
 
     assert excinfo.value.data_class == wall.Wall

--- a/etl/tests/embedded/test_water_heating.py
+++ b/etl/tests/embedded/test_water_heating.py
@@ -1,7 +1,7 @@
 import pytest
 from energuide import element
 from energuide.embedded import water_heating
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -193,7 +193,7 @@ def test_from_data(sample: element.Element) -> None:
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     water_heating_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         water_heating.WaterHeating.from_data(water_heating_node)
 
     assert excinfo.value.data_class == water_heating.WaterHeating

--- a/etl/tests/embedded/test_window.py
+++ b/etl/tests/embedded/test_window.py
@@ -6,7 +6,7 @@ from energuide.embedded import code
 from energuide.embedded import distance
 from energuide.embedded import insulation
 from energuide.embedded import window
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 @pytest.fixture
@@ -96,7 +96,7 @@ def test_from_data(raw_sample: element.Element,
 @pytest.mark.parametrize("bad_xml", BAD_XML_DATA)
 def test_bad_data(bad_xml: str) -> None:
     window_node = element.Element.from_string(bad_xml)
-    with pytest.raises(InvalidEmbeddedDataTypeException) as excinfo:
+    with pytest.raises(InvalidEmbeddedDataTypeError) as excinfo:
         window.Window.from_data(window_node, {})
 
     assert excinfo.value.data_class == window.Window

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -17,8 +17,8 @@ from energuide.embedded import window
 from energuide.embedded import water_heating
 from energuide.embedded import ventilation
 from energuide.embedded import heated_floor_area
-from energuide.exceptions import InvalidInputDataException
-from energuide.exceptions import InvalidGroupSizeException
+from energuide.exceptions import InvalidInputDataError
+from energuide.exceptions import InvalidGroupSizeError
 
 
 # pylint: disable=no-self-use
@@ -579,14 +579,14 @@ class TestParsedDwellingDataRow:
 
     def test_bad_postal_code(self, sample_input_d: reader.InputData) -> None:
         sample_input_d['forwardSortationArea'] = 'K16'
-        with pytest.raises(InvalidInputDataException):
+        with pytest.raises(InvalidInputDataError):
             dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
 
     def test_from_bad_row(self) -> None:
         input_data = {
             'EVAL_ID': 123
         }
-        with pytest.raises(InvalidInputDataException) as ex:
+        with pytest.raises(InvalidInputDataError) as ex:
             dwelling.ParsedDwellingDataRow.from_row(input_data)
         assert 'EVAL_TYPE' in ex.exconly()
         assert 'EVAL_ID' not in ex.exconly()
@@ -644,7 +644,7 @@ class TestDwelling:
 
     def test_no_data(self) -> None:
         data: typing.List[typing.Any] = []
-        with pytest.raises(InvalidGroupSizeException):
+        with pytest.raises(InvalidGroupSizeError):
             dwelling.Dwelling.from_group(data)
 
     def test_to_dict(self, sample: typing.List[reader.InputData]) -> None:

--- a/etl/tests/test_extractor.py
+++ b/etl/tests/test_extractor.py
@@ -7,7 +7,7 @@ import py._path.local
 import pytest
 from energuide import extractor
 from energuide import reader
-from energuide.exceptions import InvalidInputDataException
+from energuide.exceptions import InvalidInputDataError
 
 
 def data1() -> typing.Dict[str, typing.Optional[str]]:
@@ -83,7 +83,7 @@ def test_extract_valid(valid_filepath: str) -> None:
 
 
 def test_extract_missing(invalid_filepath: str) -> None:
-    with pytest.raises(InvalidInputDataException) as ex:
+    with pytest.raises(InvalidInputDataError) as ex:
         output = extractor.extract_data(invalid_filepath)
         _ = dict(next(output))
 

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -3,7 +3,7 @@ import pymongo
 from energuide import database
 from energuide import transform
 from energuide.embedded import ceiling
-from energuide.exceptions import InvalidEmbeddedDataTypeException
+from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
 def test_run(database_coordinates: database.DatabaseCoordinates,
@@ -25,7 +25,7 @@ def test_bad_data(database_coordinates: database.DatabaseCoordinates,
                   capsys: _pytest.capture.CaptureFixture) -> None:
 
     def raise_error(*args) -> None: #pylint: disable=unused-argument
-        raise InvalidEmbeddedDataTypeException(ceiling.Ceiling)
+        raise InvalidEmbeddedDataTypeError(ceiling.Ceiling)
 
     monkeypatch.setattr(ceiling.Ceiling, 'from_data', raise_error)
 


### PR DESCRIPTION
See: https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions

> Most exceptions are defined with names that end in “Error,” similar to the naming of the standard exceptions.