### PR TITLE
Check that things are returned

### DIFF
--- a/api/test/enum.test.js
+++ b/api/test/enum.test.js
@@ -130,7 +130,7 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = dwellingForwardSortationArea('C1A')
       let result = await collection.findOne(query)
       expect(result.forwardSortationArea).toEqual('C1A')
@@ -159,10 +159,10 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = ventilationTypeEnglish('Heat recovery ventilator')
       let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(12149)
+      expect(result).toBeTruthy()
     })
   })
 
@@ -188,10 +188,10 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = ventilationTypeFrench('Ventilateur-récupérateur de chaleur')
       let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(12149)
+      expect(result).toBeTruthy()
     })
   })
 
@@ -217,10 +217,10 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = ventilationAirFlowRateLps(220)
       let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(12149)
+      expect(result).toBeTruthy()
     })
   })
 
@@ -246,10 +246,10 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = ventilationAirFlowRateCfm(466.1536)
       let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(12149)
+      expect(result).toBeTruthy()
     })
   })
 
@@ -275,10 +275,10 @@ describe('Enum values', () => {
       expect(characters[characters.length - 1]).toEqual(')')
     })
 
-    it('returns a query object which returns a value from the test data', async () => {
+    it('returns a query object capable of returning data', async () => {
       let query = ventilationEfficiency(55)
       let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(12149)
+      expect(result).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
Previously these tests baked the houseId into the expectations. This
wasn't a core part of the tests (given that they are just testing that
the query object is usable by mongo), and assumes an order that appears
not to hold... sometimes...