### PR TITLE
add heating element

### DIFF
--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -1,0 +1,151 @@
+import enum
+import typing
+from energuide import bilingual
+from energuide import element
+from energuide.exceptions import InvalidEmbeddedDataTypeError
+
+
+class HeatingType(enum.Enum):
+    BASEBOARD = enum.auto()
+    FURNACE = enum.auto()
+    BOILER = enum.auto()
+    COMBO_HEAT_DHW = enum.auto()
+    P911 = enum.auto()
+
+
+class EnergySource(enum.Enum):
+    ELECTRIC = enum.auto()
+    NATURAL_GAS = enum.auto()
+    OIL = enum.auto()
+    PROPANE = enum.auto()
+    WOOD = enum.auto()
+
+
+class _Heating(typing.NamedTuple):
+    heating_type: HeatingType
+    energy_source: EnergySource
+    equipment_type: bilingual.Bilingual
+    label: str
+    output_size: float
+    efficiency: float
+    steady_state: str
+
+
+class Heating(_Heating):
+
+    _KWH_TO_BTU = 3412.142
+
+    _HEATING_TYPE_NODE_NAMES = {
+        'Baseboards': HeatingType.BASEBOARD,
+        'Furnace': HeatingType.FURNACE,
+        'Boiler': HeatingType.BOILER,
+    }
+
+    _HEATING_TYPE_TRANSLATIONS = {
+        HeatingType.BASEBOARD: bilingual.Bilingual(english='Electric baseboard',
+                                                   french='Plinthe électrique'),
+        HeatingType.FURNACE: bilingual.Bilingual(english='Furnace', french='Fournaise'),
+        HeatingType.BOILER: bilingual.Bilingual(english='Boiler', french='Chaudière'),
+        HeatingType.COMBO_HEAT_DHW: bilingual.Bilingual(english='Combo Heat/DHW',
+                                                        french='Combinaison chaleur/ Eau Chaude Domestique'),
+        HeatingType.P911: bilingual.Bilingual(english='Certified combo system, space and domestic water heating',
+                                              french='Système combiné certifié pour le chauffage '
+                                                     'des locaux et de l’eau'),
+    }
+
+    _ENERGY_SOURCE_CODES = {
+        2: EnergySource.NATURAL_GAS,
+        3: EnergySource.OIL,
+        4: EnergySource.PROPANE,
+        5: EnergySource.WOOD,
+    }
+
+    _ENERGY_SOURCE_TRANSLATIONS = {
+        EnergySource.ELECTRIC: bilingual.Bilingual(english='Electric Space Heating',
+                                                   french='Chauffage électrique'),
+        EnergySource.NATURAL_GAS: bilingual.Bilingual(english='Natural Gas', french='Chauffage au gaz naturel'),
+        EnergySource.OIL: bilingual.Bilingual(english='Oil Space Heating', french='Chauffage au mazout'),
+        EnergySource.PROPANE: bilingual.Bilingual(english='Propane Space Heating', french='Chauffage au propane'),
+        EnergySource.WOOD: bilingual.Bilingual(english='Wood Space Heating (Mixed Wood, Hardwood, '
+                                                       'Soft Wood or Wood Pellets)',
+                                               french='Chauffage au bois(Bois mélangé, Bois dur, Bois mou, '
+                                                      'Granules de bois)'),
+    }
+
+    @classmethod
+    def _get_output_size(cls, node: element.Element) -> float:
+        capacity_node = node.find('Type1/*/Specifications/OutputCapacity')
+        assert capacity_node is not None
+
+        units = capacity_node.attrib['uiUnits']
+        capacity_value = float(capacity_node.attrib['value'])
+        capacity: typing.Optional[float]
+        if units == 'kW':
+            capacity = capacity_value
+        elif units == 'btu/h':
+            capacity = capacity_value / cls._KWH_TO_BTU
+        else:
+            raise InvalidEmbeddedDataTypeError(
+                Heating, f'Unknown capacity units: f{units}')
+        assert capacity is not None
+        return capacity
+
+    @classmethod
+    def _get_heating_type(cls, node: element.Element) -> HeatingType:
+        candidates = [candidate.tag for candidate in node.xpath('Type1/*')]
+        heating_type: typing.Optional[HeatingType] = None
+        for candidate in candidates:
+            if candidate in cls._HEATING_TYPE_NODE_NAMES:
+                heating_type = cls._HEATING_TYPE_NODE_NAMES[candidate]
+                break
+        if heating_type is None:
+            raise InvalidEmbeddedDataTypeError(
+                Heating, f'Could not identify HeatingType, candidate node names = {[candidates]}')
+        return heating_type
+
+    @classmethod
+    def _get_energy_source(cls, node: element.Element) -> EnergySource:
+        code = int(node.xpath('Type1/*/Equipment/EnergySource/@code')[0])
+        energy_source = cls._ENERGY_SOURCE_CODES.get(code)
+        if energy_source is None:
+            raise InvalidEmbeddedDataTypeError(
+                Heating, f'Unknown energy source: {energy_source}')
+        return energy_source
+
+    @classmethod
+    def _get_equipment_type(cls, node: element.Element) -> bilingual.Bilingual:
+        english_text = node.get_text('Type1/*/Equipment/EquipmentType/English')
+        french_text = node.get_text('Type1/*/Equipment/EquipmentType/French')
+        return bilingual.Bilingual(english=english_text, french=french_text)
+
+    @staticmethod
+    def _get_steady_state(node: element.Element) -> str:
+        steady_state_value = node.xpath('Type1/*/Specifications/@isSteadyState')[0]
+        return 'Steady State' if steady_state_value == 'true' else 'AFUE'
+
+    @classmethod
+    def from_data(cls, node: element.Element) -> 'Heating':
+        return Heating(
+            label=node.get_text('Label'),
+            output_size=float(Heating._get_output_size(node)),
+            efficiency=float(node.xpath('Type1/*/Specifications/@efficiency')[0]),
+            steady_state=cls._get_steady_state(node),
+            heating_type=cls._get_heating_type(node),
+            energy_source=cls._get_energy_source(node),
+            equipment_type=cls._get_equipment_type(node),
+        )
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'label': self.label,
+            'heatingTypeEnglish': self._HEATING_TYPE_TRANSLATIONS[self.heating_type].english,
+            'heatingTypeFrench': self._HEATING_TYPE_TRANSLATIONS[self.heating_type].french,
+            'energySourceEnglish': self._ENERGY_SOURCE_TRANSLATIONS[self.energy_source].english,
+            'energySourceFrench': self._ENERGY_SOURCE_TRANSLATIONS[self.energy_source].french,
+            'equipmentTypeEnglish': self.equipment_type.english,
+            'equipmentTypeFrench': self.equipment_type.french,
+            'outputSizeKW': self.output_size,
+            'outputSizeBtu': self.output_size * self._KWH_TO_BTU,
+            'efficiency': self.efficiency,
+            'steadyState': self.steady_state,
+        }

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -1,0 +1,174 @@
+import typing
+import pytest
+from energuide import bilingual
+from energuide import element
+from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.embedded import heating
+
+
+def sample_node(heating_type: str = 'Furnace',
+                equipment_node: typing.Optional[element.Element] = None,
+                specification_node: typing.Optional[element.Element] = None) -> element.Element:
+    specification_node = sample_specifications() if not specification_node else specification_node
+    equipment_node = sample_equipment() if not equipment_node else equipment_node
+
+    data = """
+<HeatingCooling id="18">
+    <Label>Heating/Cooling System</Label>
+    <CoolingSeason>
+        <Start code="1">January</Start>
+        <End code="12">December</End>
+        <Design code="7">July</Design>
+    </CoolingSeason>
+    <Type1>
+        <FansAndPump hasEnergyEfficientMotor="false">
+            <Mode code="1">
+                <English>Auto</English>
+                <French>Auto</French>
+            </Mode>
+            <Power isCalculated="true" low="0" high="145.5" />
+        </FansAndPump>
+    </Type1>
+    <Type2 shadingInF280Cooling="AccountedFor" />
+</HeatingCooling>
+    """
+    node = element.Element.from_string(data)
+    type1_node: element.Element = node.xpath('Type1')[0]
+    heating_node = sample_heating_node(heating_type)
+    type1_node.insert(1, heating_node)
+
+    heating_node.insert(1, specification_node)
+    heating_node.insert(2, equipment_node)
+    return node
+
+
+def sample_heating_node(node_name: str) -> element.Element:
+    node = element.Element.new(node_name)
+
+    equip_info_str = """
+<EquipmentInformation energystar="false">
+    <Manufacturer>Wizard SPH man</Manufacturer>
+</EquipmentInformation>
+    """
+    equip_info_node = element.Element.from_string(equip_info_str)
+    node.insert(0, equip_info_node)
+    return node
+
+
+def sample_specifications(efficiency: float = 95.0,
+                          is_steady_state: bool = False,
+                          capacity: float = 26.5,
+                          capacity_units: str = 'kW') -> element.Element:
+    data = f"""
+<Specifications sizingFactor="1.1" efficiency="{efficiency}" isSteadyState="{'true' if is_steady_state else 'false'}" pilotLight="0" flueDiameter="0">
+    <OutputCapacity code="2" value="{capacity}" uiUnits="{capacity_units}" />
+</Specifications>
+    """
+    return element.Element.from_string(data)
+
+
+def sample_equipment(energy_source_code: int = 2,
+                     equipment_type_english: str = 'English Type',
+                     equipment_type_french: str = 'French Type') -> element.Element:
+    data = f"""
+<Equipment isBiEnergy="false" switchoverTemperature="0">
+    <EnergySource code="{energy_source_code}" />
+    <EquipmentType>
+        <English>{equipment_type_english}</English>
+        <French>{equipment_type_french}</French>
+    </EquipmentType>
+</Equipment>
+    """
+    return element.Element.from_string(data)
+
+
+@pytest.fixture
+def sample_raw() -> element.Element:
+    return sample_node()
+
+
+@pytest.fixture
+def sample() -> heating.Heating:
+    return heating.Heating(
+        heating_type=heating.HeatingType.FURNACE,
+        energy_source=heating.EnergySource.NATURAL_GAS,
+        equipment_type=bilingual.Bilingual(english='English Type', french='French Type'),
+        label='Heating/Cooling System',
+        output_size=26.5,
+        efficiency=95.0,
+        steady_state='AFUE'
+    )
+
+
+def test_from_data(sample_raw: element.Element, sample: heating.Heating) -> None:
+    output = heating.Heating.from_data(sample_raw)
+    assert output == sample
+
+
+def test_converts_btu() -> None:
+    specification_node = sample_specifications(capacity=1000.0, capacity_units='btu/h')
+    node = sample_node(specification_node=specification_node)
+    output = heating.Heating.from_data(node)
+    assert output.output_size == 0.2930710386613453
+
+
+def test_output_size_unknown_units() -> None:
+    specification_node = sample_specifications(capacity_units='foo')
+    node = sample_node(specification_node=specification_node)
+
+    with pytest.raises(InvalidEmbeddedDataTypeError) as ex:
+        heating.Heating.from_data(node)
+    assert ex.value.data_class == heating.Heating
+
+
+def test_unknown_heating_type() -> None:
+    node = sample_node(heating_type='Foo')
+
+    with pytest.raises(InvalidEmbeddedDataTypeError) as ex:
+        heating.Heating.from_data(node)
+    assert ex.value.data_class == heating.Heating
+
+
+def test_boiler() -> None:
+    node = sample_node(heating_type='Boiler')
+    output = heating.Heating.from_data(node)
+    assert output.heating_type == heating.HeatingType.BOILER
+
+
+def test_wood_energy_source() -> None:
+    equipment_node = sample_equipment(energy_source_code=5)
+    node = sample_node(equipment_node=equipment_node)
+    output = heating.Heating.from_data(node)
+    assert output.energy_source == heating.EnergySource.WOOD
+
+
+def test_unknown_energy_source_code() -> None:
+    equipment_node = sample_equipment(energy_source_code=6)
+    node = sample_node(equipment_node=equipment_node)
+
+    with pytest.raises(InvalidEmbeddedDataTypeError) as ex:
+        heating.Heating.from_data(node)
+    assert ex.value.data_class == heating.Heating
+
+
+def test_steady_state() -> None:
+    specification_node = sample_specifications(is_steady_state=True)
+    node = sample_node(specification_node=specification_node)
+    output = heating.Heating.from_data(node)
+    assert output.steady_state == 'Steady State'
+
+
+def test_to_dict(sample: heating.Heating) -> None:
+    assert sample.to_dict() == {
+        'label': 'Heating/Cooling System',
+        'heatingTypeEnglish': 'Furnace',
+        'heatingTypeFrench': 'Fournaise',
+        'energySourceEnglish': 'Natural Gas',
+        'energySourceFrench': 'Chauffage au gaz naturel',
+        'equipmentTypeEnglish': 'English Type',
+        'equipmentTypeFrench': 'French Type',
+        'outputSizeKW': 26.5,
+        'outputSizeBtu': 90421.76299999999,
+        'efficiency': 95.0,
+        'steadyState': 'AFUE',
+    }

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -11,6 +11,7 @@ def sample_node(heating_type: str = 'Furnace',
                 specification_node: typing.Optional[element.Element] = None) -> element.Element:
     specification_node = sample_specifications() if not specification_node else specification_node
     equipment_node = sample_equipment() if not equipment_node else equipment_node
+    heating_node = sample_heating_node(heating_type)
 
     data = """
 <HeatingCooling id="18">
@@ -34,7 +35,6 @@ def sample_node(heating_type: str = 'Furnace',
     """
     node = element.Element.from_string(data)
     type1_node: element.Element = node.xpath('Type1')[0]
-    heating_node = sample_heating_node(heating_type)
     type1_node.insert(1, heating_node)
 
     heating_node.insert(1, specification_node)


### PR DESCRIPTION
This PR adds the long-awaited Heating element. It isn't yet included in the actual transform operation, merely the ability to parse it from xml and serialize it with `to_dict`.

There are some known holes that I was not able to yet figure out - no known examples of electric baseboards, P9-11 efficiency heaters, or combo heating/water heater systems. The parsing logic should fail loudly with explicit error messages in these cases.