### PR TITLE
Windows compatibility changes

### DIFF
--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -49,11 +49,10 @@ def _validated(data: typing.Iterable[reader.InputData], validator) -> typing.Ite
 
 
 def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
-    if sys.platform == 'win32':
-        # Windows C long is 32 bits, so using sys.maxsize may throw an error on windows
-        csv.field_size_limit(2**31-1)
-    else:
+    try:
         csv.field_size_limit(sys.maxsize)
+    except OverflowError:
+        csv.field_size_limit(2**31-1)
 
     with open(filepath, 'r') as file:
         csv_reader = csv.DictReader(file)

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -55,7 +55,7 @@ def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
     except OverflowError:
         csv.field_size_limit(_WINDOWS_LONG_SIZE)
 
-    with open(filepath, 'r') as file:
+    with open(filepath, 'r', encoding='utf-8', newline='') as file:
         csv_reader = csv.DictReader(file)
         for row in csv_reader:
             yield row

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -38,6 +38,7 @@ REQUIRED_FIELDS = DROP_FIELDS + [
 ]
 
 _SCHEMA = {field: {'type': 'string', 'required': True} for field in REQUIRED_FIELDS}
+_WINDOWS_LONG_SIZE = (2 ** 31) - 1
 
 
 def _validated(data: typing.Iterable[reader.InputData], validator) -> typing.Iterator[reader.InputData]:
@@ -52,7 +53,7 @@ def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
     try:
         csv.field_size_limit(sys.maxsize)
     except OverflowError:
-        csv.field_size_limit(2**31-1)
+        csv.field_size_limit(_WINDOWS_LONG_SIZE)
 
     with open(filepath, 'r') as file:
         csv_reader = csv.DictReader(file)

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -49,7 +49,12 @@ def _validated(data: typing.Iterable[reader.InputData], validator) -> typing.Ite
 
 
 def _read_csv(filepath: str) -> typing.Iterator[reader.InputData]:
-    csv.field_size_limit(sys.maxsize)
+    if sys.platform == 'win32':
+        # Windows C long is 32 bits, so using sys.maxsize may throw an error on windows
+        csv.field_size_limit(2**31-1)
+    else:
+        csv.field_size_limit(sys.maxsize)
+
     with open(filepath, 'r') as file:
         csv_reader = csv.DictReader(file)
         for row in csv_reader:

--- a/etl/tests/sample.h2k
+++ b/etl/tests/sample.h2k
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <HouseFile xml:lang="en" uiUnits="Imperial">
     <Version major="1" minor="3">
         <Labels>


### PR DESCRIPTION
This PR introduces small refactoring/changes to the ETL code to make it compatible with development on a Windows machine.

1. If an `OverflowError` occurs when setting the max field size, fall back to the size of a `long` in C in windows
2. Open the csv file with UTF-8 encoding explicitly (instead of relying on locale default)
3. Delete invisible characters at the beginning of `sample.h2k`

ping @pcraig3 and @vadjr to let you know I believe this resolves all the currently known incompatibilities with Windows and Unix.