### PR TITLE
Add floor fields to filter field enum

### DIFF
--- a/api/src/schema/enums.js
+++ b/api/src/schema/enums.js
@@ -35,7 +35,9 @@ const ventilationFields = [
 
 ventilationFields.forEach(attr => {
   // eslint-disable-next-line no-new-func
-  let fn = new Function('matcher', `
+  let fn = new Function(
+    'matcher',
+    `
   return {
     evaluations: {
       $elemMatch: {
@@ -45,6 +47,39 @@ ventilationFields.forEach(attr => {
       },
     },
   }
-  `)
+  `,
+  )
   module.exports[generateName('ventilation', attr)] = attachToString(fn)
+})
+
+// The fields on the ventilation type
+const floorFields = [
+  'label',
+  'insulationNominalRsi',
+  'insulationNominalR',
+  'insulationEffectiveRsi',
+  'insulationEffectiveR',
+  'areaMetres',
+  'areaFeet',
+  'lengthMetres',
+  'lengthFeet',
+]
+
+floorFields.forEach(attr => {
+  // eslint-disable-next-line no-new-func
+  let fn = new Function(
+    'matcher',
+    `
+  return {
+    evaluations: {
+      $elemMatch: {
+        floors: {
+          $elemMatch:{ ${attr}: matcher },
+        },
+      },
+    },
+  }
+  `,
+  )
+  module.exports[generateName('floor', attr)] = attachToString(fn)
 })

--- a/api/src/schema/enums.js
+++ b/api/src/schema/enums.js
@@ -52,7 +52,7 @@ ventilationFields.forEach(attr => {
   module.exports[generateName('ventilation', attr)] = attachToString(fn)
 })
 
-// The fields on the ventilation type
+// The fields on the floor type
 const floorFields = [
   'label',
   'insulationNominalRsi',

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -172,6 +172,15 @@ const Schema = i18n => {
       ventilationAirFlowRateLps
       ventilationAirFlowRateCfm
       ventilationEfficiency
+      floorLabel
+      floorInsulationNominalRsi
+      floorInsulationNominalR
+      floorInsulationEffectiveRsi
+      floorInsulationEffectiveR
+      floorAreaMetres
+      floorAreaFeet
+      floorLengthMetres
+      floorLengthFeet
     }
   `
 

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -12,6 +12,15 @@ import {
   ventilationAirFlowRateLps,
   ventilationAirFlowRateCfm,
   ventilationEfficiency,
+  floorLabel,
+  floorInsulationNominalRsi,
+  floorInsulationNominalR,
+  floorInsulationEffectiveRsi,
+  floorInsulationEffectiveR,
+  floorAreaMetres,
+  floorAreaFeet,
+  floorLengthMetres,
+  floorLengthFeet,
 } from './enums'
 /* eslint-enable import/named */
 
@@ -83,6 +92,15 @@ const resolvers = {
     ventilationAirFlowRateLps: ventilationAirFlowRateLps.toString(),
     ventilationAirFlowRateCfm: ventilationAirFlowRateCfm.toString(),
     ventilationEfficiency: ventilationEfficiency.toString(),
+    floorLabel: floorLabel.toString(),
+    floorInsulationNominalRsi: floorInsulationNominalRsi.toString(),
+    floorInsulationNominalR: floorInsulationNominalR.toString(),
+    floorInsulationEffectiveRsi: floorInsulationEffectiveRsi.toString(),
+    floorInsulationEffectiveR: floorInsulationEffectiveR.toString(),
+    floorAreaMetres: floorAreaMetres.toString(),
+    floorAreaFeet: floorAreaFeet.toString(),
+    floorLengthMetres: floorLengthMetres.toString(),
+    floorLengthFeet: floorLengthFeet.toString(),
   },
   Comparator: {
     gt: '$gt',

--- a/api/test/enum.test.js
+++ b/api/test/enum.test.js
@@ -1,18 +1,7 @@
 import { MongoClient } from 'mongodb'
 
 /* eslint-disable import/named */
-import {
-  dwellingHouseId,
-  dwellingYearBuilt,
-  dwellingCity,
-  dwellingRegion,
-  dwellingForwardSortationArea,
-  ventilationTypeEnglish,
-  ventilationTypeFrench,
-  ventilationAirFlowRateLps,
-  ventilationAirFlowRateCfm,
-  ventilationEfficiency,
-} from '../src/schema/enums'
+import * as enumFunctions from '../src/schema/enums' // eslint-disable-line
 /* eslint-enable import/named */
 
 let client, db, collection
@@ -34,251 +23,74 @@ describe('Enum values', () => {
     client.close()
   })
 
-  describe('dwellingHouseId', () => {
-    it('returns a query object', () => {
-      expect(dwellingHouseId({ $eq: 189250 })).toEqual({
-        houseId: { $eq: 189250 },
+  const testData = {
+    dwellingHouseId: {
+      testValue: 189250,
+    },
+    dwellingYearBuilt: {
+      testValue: 1900,
+    },
+    dwellingCity: {
+      testValue: 'Charlottetown',
+    },
+    dwellingRegion: {
+      testValue: 'PE',
+    },
+    dwellingForwardSortationArea: {
+      testValue: 'C1A',
+    },
+    ventilationTypeEnglish: {
+      testValue: 'Heat recovery ventilator',
+    },
+    ventilationTypeFrench: {
+      testValue: 'Ventilateur-récupérateur de chaleur',
+    },
+    ventilationAirFlowRateLps: {
+      testValue: 220,
+    },
+    ventilationAirFlowRateCfm: {
+      testValue: 466.1536,
+    },
+    ventilationEfficiency: {
+      testValue: 55,
+    },
+    floorLabel: {
+      testValue: 'Rm over garage',
+    },
+    floorInsulationNominalRsi: {
+      testValue: 2.11,
+    },
+    floorInsulationNominalR: {
+      testValue: 11.981135641069999,
+    },
+    floorInsulationEffectiveRsi: {
+      testValue: 2.61,
+    },
+    floorInsulationEffectiveR: {
+      testValue: 14.82026730957,
+    },
+    floorAreaMetres: {
+      testValue: 9.2903,
+    },
+    floorAreaFeet: {
+      testValue: 99.99996334435568,
+    },
+    floorLengthMetres: {
+      testValue: 3.048,
+    },
+    floorLengthFeet: {
+      testValue: 10.00000032,
+    },
+  }
+
+  Object.keys(testData).forEach(functionName => {
+    describe(functionName, () => {
+      it('returns a query object capable of returning data', async () => {
+        let { testValue } = testData[functionName] // eslint-disable-line
+        let query = enumFunctions[functionName](testValue) //eslint-disable-line
+        let result = await collection.findOne(query)
+        expect(result).not.toBe(null)
       })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = dwellingHouseId.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object which returns a value from the test data', async () => {
-      let query = dwellingHouseId(189250)
-      let result = await collection.findOne(query)
-      expect(result.houseId).toEqual(189250)
-    })
-  })
-
-  describe('dwellingYearBuilt', () => {
-    it('returns a query object', () => {
-      expect(dwellingYearBuilt(1900)).toEqual({ yearBuilt: 1900 })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = dwellingYearBuilt.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object which returns a value from the test data', async () => {
-      let query = dwellingYearBuilt(1900)
-      let result = await collection.findOne(query)
-      expect(result.yearBuilt).toEqual(1900)
-    })
-  })
-
-  describe('dwellingCity', () => {
-    //  "city": "Charlottetown",
-
-    it('returns a query object', () => {
-      expect(dwellingCity('Charlottetown')).toEqual({ city: 'Charlottetown' })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = dwellingYearBuilt.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object which returns a value from the test data', async () => {
-      let query = dwellingCity('Charlottetown')
-      let result = await collection.findOne(query)
-      expect(result.city).toEqual('Charlottetown')
-    })
-  })
-
-  describe('dwellingRegion', () => {
-    //  "region": "PE",
-
-    it('returns a query object', () => {
-      expect(dwellingRegion('PE')).toEqual({ region: 'PE' })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = dwellingRegion.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object which returns a value from the test data', async () => {
-      let query = dwellingRegion('PE')
-      let result = await collection.findOne(query)
-      expect(result.region).toEqual('PE')
-    })
-  })
-
-  describe('dwellingForwardSortationArea', () => {
-    it('returns a query object', () => {
-      expect(dwellingForwardSortationArea('C1A')).toEqual({
-        forwardSortationArea: 'C1A',
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = dwellingForwardSortationArea.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = dwellingForwardSortationArea('C1A')
-      let result = await collection.findOne(query)
-      expect(result.forwardSortationArea).toEqual('C1A')
-    })
-  })
-
-  describe('ventilationTypeEnglish', () => {
-    it('returns a query object', () => {
-      expect(ventilationTypeEnglish('foo')).toEqual({
-        evaluations: {
-          $elemMatch: {
-            ventilations: {
-              $elemMatch: {
-                typeEnglish: 'foo',
-              },
-            },
-          },
-        },
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = ventilationTypeEnglish.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = ventilationTypeEnglish('Heat recovery ventilator')
-      let result = await collection.findOne(query)
-      expect(result).toBeTruthy()
-    })
-  })
-
-  describe('ventilationTypeFrench', () => {
-    it('returns a query object', () => {
-      expect(ventilationTypeFrench('fou')).toEqual({
-        evaluations: {
-          $elemMatch: {
-            ventilations: {
-              $elemMatch: {
-                typeFrench: 'fou',
-              },
-            },
-          },
-        },
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = ventilationTypeFrench.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = ventilationTypeFrench('Ventilateur-récupérateur de chaleur')
-      let result = await collection.findOne(query)
-      expect(result).toBeTruthy()
-    })
-  })
-
-  describe('ventilationAirFlowRateLps', () => {
-    it('returns a query object', () => {
-      expect(ventilationAirFlowRateLps(200)).toEqual({
-        evaluations: {
-          $elemMatch: {
-            ventilations: {
-              $elemMatch: {
-                airFlowRateLps: 200,
-              },
-            },
-          },
-        },
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = ventilationAirFlowRateLps.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = ventilationAirFlowRateLps(220)
-      let result = await collection.findOne(query)
-      expect(result).toBeTruthy()
-    })
-  })
-
-  describe('ventilationAirFlowRateCfm', () => {
-    it('returns a query object', () => {
-      expect(ventilationAirFlowRateCfm(200)).toEqual({
-        evaluations: {
-          $elemMatch: {
-            ventilations: {
-              $elemMatch: {
-                airFlowRateCfm: 200,
-              },
-            },
-          },
-        },
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = ventilationAirFlowRateLps.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = ventilationAirFlowRateCfm(466.1536)
-      let result = await collection.findOne(query)
-      expect(result).toBeTruthy()
-    })
-  })
-
-  describe('ventilationEfficiency', () => {
-    it('returns a query object', () => {
-      expect(ventilationEfficiency(200)).toEqual({
-        evaluations: {
-          $elemMatch: {
-            ventilations: {
-              $elemMatch: {
-                efficiency: 200,
-              },
-            },
-          },
-        },
-      })
-    })
-
-    it('has a toString function that produces an eval friendly expression', () => {
-      let str = ventilationEfficiency.toString()
-      let characters = [...str]
-      expect(characters[0]).toEqual('(')
-      expect(characters[characters.length - 1]).toEqual(')')
-    })
-
-    it('returns a query object capable of returning data', async () => {
-      let query = ventilationEfficiency(55)
-      let result = await collection.findOne(query)
-      expect(result).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
This allows users to filter results based on values on floor type.
Additionally, the tests have been rethought and refactored so they can just be generated.