### PR TITLE
Fix regex to handle integers and floats

### DIFF
--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -57,7 +57,7 @@ const resolvers = {
           // - optionally starting with a minus sign
           // - containing zero or one decimal places
           // convert it to a float instead of a string
-          if (filter.value.match(/^-?\d+\.?\d+$/)) {
+          if (filter.value.match(/^-?\d+$|^-?\d+\.\d+$/)) {
             value = parseFloat(filter.value)
           }
           // We are evaling our own code here, not user input.

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -555,11 +555,11 @@ describe('queries', () => {
               query: `{
                 dwellingsInFSA(
                   forwardSortationArea: "C1A"
-                  filter: {
+                  filters: [{
                     field: dwellingYearBuilt
                     comparator: gt
                     value: "1"
-                  }) {
+                  }]) {
                   results {
                     yearBuilt
                   }

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -542,8 +542,34 @@ describe('queries', () => {
                  }
                }`,
             })
+
           let { dwellings: { results: [first] } } = response.body.data
           expect(first.city).toEqual('Charlottetown')
+        })
+
+        it('correctly handles integer values', async () => {
+          let response = await request(server)
+            .post('/graphql')
+            .set('Content-Type', 'application/json; charset=utf-8')
+            .send({
+              query: `{
+                dwellingsInFSA(
+                  forwardSortationArea: "C1A"
+                  filter: {
+                    field: dwellingYearBuilt
+                    comparator: gt
+                    value: "1"
+                  }) {
+                  results {
+                    yearBuilt
+                  }
+                }
+               }`,
+            })
+
+          let { data } = response.body
+          let { dwellingsInFSA } = data
+          expect(dwellingsInFSA.results.length).toBeGreaterThan(0)
         })
       })
 


### PR DESCRIPTION
This regex is responsible for converting strings containing numbers into
actual numbers so that values passed to mongo will have the correct
type. As the number of types you can search by expand, it turns out that
this regex doesn't handle integers. This changes that.