### PR TITLE
Always generate floors

### DIFF
--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -132,7 +132,6 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
     def from_row(cls, row: reader.InputData) -> 'ParsedDwellingDataRow':
         checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True, ignore_none_values=True)
         if not checker.validate(row):
-            # import pdb; pdb.set_trace()
             error_keys = ', '.join(checker.errors.keys())
             raise InvalidInputDataError(f'Validator failed on keys: {error_keys}')
 

--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -132,6 +132,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
     def from_row(cls, row: reader.InputData) -> 'ParsedDwellingDataRow':
         checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True, ignore_none_values=True)
         if not checker.validate(row):
+            # import pdb; pdb.set_trace()
             error_keys = ', '.join(checker.errors.keys())
             raise InvalidInputDataError(f'Validator failed on keys: {error_keys}')
 

--- a/etl/src/energuide/embedded/basement.py
+++ b/etl/src/energuide/embedded/basement.py
@@ -166,13 +166,13 @@ class BasementFloor(_BasementFloor):
 
     @classmethod
     def from_crawlspace(cls, floor: typing.Optional[element.Element]) -> typing.List['BasementFloor']:
-        return [
-            cls._from_data(floor, 'AddedToSlab', FloorType.SLAB)
-            if floor is not None else cls._empty_floor(FloorType.SLAB),
-
-            cls._from_data(floor, 'FloorsAbove', FloorType.FLOOR_ABOVE_CRAWLSPACE)
-            if floor is not None else cls._empty_floor(FloorType.FLOOR_ABOVE_CRAWLSPACE),
-        ]
+        if floor is None:
+            return [cls._empty_floor(FloorType.SLAB), cls._empty_floor(FloorType.FLOOR_ABOVE_CRAWLSPACE)]
+        else:
+            return [
+                cls._from_data(floor, 'AddedToSlab', FloorType.SLAB),
+                cls._from_data(floor, 'FloorsAbove', FloorType.FLOOR_ABOVE_CRAWLSPACE),
+            ]
 
     @classmethod
     def from_slab(cls, floor: typing.Optional[element.Element]) -> typing.List['BasementFloor']:

--- a/etl/src/energuide/embedded/basement.py
+++ b/etl/src/energuide/embedded/basement.py
@@ -168,11 +168,10 @@ class BasementFloor(_BasementFloor):
     def from_crawlspace(cls, floor: typing.Optional[element.Element]) -> typing.List['BasementFloor']:
         if floor is None:
             return [cls._empty_floor(FloorType.SLAB), cls._empty_floor(FloorType.FLOOR_ABOVE_CRAWLSPACE)]
-        else:
-            return [
-                cls._from_data(floor, 'AddedToSlab', FloorType.SLAB),
-                cls._from_data(floor, 'FloorsAbove', FloorType.FLOOR_ABOVE_CRAWLSPACE),
-            ]
+        return [
+            cls._from_data(floor, 'AddedToSlab', FloorType.SLAB),
+            cls._from_data(floor, 'FloorsAbove', FloorType.FLOOR_ABOVE_CRAWLSPACE),
+        ]
 
     @classmethod
     def from_slab(cls, floor: typing.Optional[element.Element]) -> typing.List['BasementFloor']:

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -339,19 +339,6 @@ def crawlspace_input() -> typing.List[str]:
             <Measurements height="1.0668" depth="0.4572" />
             <RValues skirt="0" thermalBreak="0" />
         </Wall>
-        <Components>
-            <FloorHeader adjacentEnclosedSpace="false" id="6">
-                <Label>BW hdr-01</Label>
-                <Construction>
-                    <Type idref="Code 21" rValue="4.0777" nominalInsulation="3.87">1800400220</Type>
-                </Construction>
-                <Measurements height="0.23" perimeter="39.9288" />
-                <FacingDirection code="1">
-                    <English>N/A</English>
-                    <French>S/O</French>
-                </FacingDirection>
-            </FloorHeader>
-        </Components>
     </Crawlspace>
     """
     return [doc]
@@ -763,12 +750,7 @@ class TestParsedDwellingDataRow:
                             floor_area=area.Area(24.993000130000002)
                         )
                     ],
-                    header=basement.BasementHeader(
-                        nominal_insulation=insulation.Insulation(rsi=3.87),
-                        effective_insulation=insulation.Insulation(rsi=4.0777),
-                        height=distance.Distance(distance_metres=0.23),
-                        perimeter=distance.Distance(distance_metres=39.9288)
-                    ),
+                    header=None,
                 ),
                 basement.Basement(
                     foundation_type=basement.FoundationType.SLAB,


### PR DESCRIPTION
This PR addresses an issue that I noticed regarding how foundation parsing should deal with missing elements.

Report Generator always generates floor rows, even if floor tag is missing, whereas the lack of walls and headers will result in no rows. This PR now emulates that behavior 