### PR TITLE
Identify emulator values as such, clean up names

### DIFF
--- a/extract_endpoint/src/extract_endpoint/azure_utils.py
+++ b/extract_endpoint/src/extract_endpoint/azure_utils.py
@@ -10,6 +10,14 @@ class StorageCoordinates(typing.NamedTuple):
     domain: typing.Optional[str]
 
 
+AZURE_EMULATOR_COORDS = StorageCoordinates(
+    account='devstoreaccount1',
+    key='Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
+    container='test-container',
+    domain='http://127.0.0.1:10000/devstoreaccount1',
+)
+
+
 class EnvVariables(enum.Enum):
     account = 'EXTRACT_ENDPOINT_STORAGE_ACCOUNT'
     key = 'EXTRACT_ENDPOINT_STORAGE_KEY'
@@ -18,14 +26,14 @@ class EnvVariables(enum.Enum):
 
 
 class DefaultVariables(enum.Enum):
-    account = 'devstoreaccount1'
-    key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
-    container = 'endpoint'
+    account = AZURE_EMULATOR_COORDS.account
+    key = AZURE_EMULATOR_COORDS.key
+    container = AZURE_EMULATOR_COORDS.container
     domain = None
 
 
 def upload_stream_to_azure(coords: StorageCoordinates, stream: typing.IO[bytes], filename: str) -> bool:
-    block_blob_service = blob.BlockBlobService(account_name=coords.account, account_key=coords.key,
-                                               custom_domain=coords.domain)
-    block_blob_service.create_blob_from_stream(coords.container, filename, stream)
-    return filename in [blob.name for blob in block_blob_service.list_blobs(coords.container)]
+    azure_service = blob.BlockBlobService(account_name=coords.account, account_key=coords.key,
+                                          custom_domain=coords.domain)
+    azure_service.create_blob_from_stream(coords.container, filename, stream)
+    return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]

--- a/extract_endpoint/tests/test_azure_utils.py
+++ b/extract_endpoint/tests/test_azure_utils.py
@@ -5,24 +5,13 @@ from extract_endpoint import azure_utils
 
 
 @pytest.fixture
-def sample_storage_coordinates() -> azure_utils.StorageCoordinates:
-    return azure_utils.StorageCoordinates(account='devstoreaccount1',
-                                          key='Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uS'
-                                          + 'RZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==',
-                                          container='energuide-extracted-data',
-                                          domain='http://127.0.0.1:10000/devstoreaccount1')
-
-
-@pytest.fixture
-def sample_block_blob_service(sample_storage_coordinates: azure_utils.StorageCoordinates) -> blob.BlockBlobService:
-    block_blob_service = blob.BlockBlobService(account_name=sample_storage_coordinates.account,
-                                               account_key=sample_storage_coordinates.key,
-                                               custom_domain=sample_storage_coordinates.domain)
-    yield block_blob_service
-
-    container = sample_storage_coordinates.container
-    for filename in [blob.name for blob in block_blob_service.list_blobs(container)]:
-        block_blob_service.delete_blob(container, filename)
+def azure_service() -> blob.BlockBlobService:
+    azure_service = blob.BlockBlobService(account_name=azure_utils.AZURE_EMULATOR_COORDS.account,
+                                          account_key=azure_utils.AZURE_EMULATOR_COORDS.key,
+                                          custom_domain=azure_utils.AZURE_EMULATOR_COORDS.domain)
+    azure_service.create_container(azure_utils.AZURE_EMULATOR_COORDS.container)
+    yield azure_service
+    azure_service.delete_container(azure_utils.AZURE_EMULATOR_COORDS.container)
 
 
 @pytest.fixture
@@ -40,13 +29,13 @@ def sample_filename() -> str:
     return "sample_filename.txt"
 
 
-def test_upload_stream_to_azure(sample_storage_coordinates: azure_utils.StorageCoordinates,
-                                sample_block_blob_service: blob.BlockBlobService,
+def test_upload_stream_to_azure(azure_service: blob.BlockBlobService,
                                 sample_stream: io.BytesIO,
                                 sample_stream_content: str,
                                 sample_filename: str) -> None:
-    assert azure_utils.upload_stream_to_azure(sample_storage_coordinates, sample_stream, sample_filename)
-    container = sample_storage_coordinates.container
-    assert sample_filename in [blob.name for blob in sample_block_blob_service.list_blobs(container)]
-    actual_file_blob = sample_block_blob_service.get_blob_to_text(container, sample_filename)
+
+    assert azure_utils.upload_stream_to_azure(azure_utils.AZURE_EMULATOR_COORDS, sample_stream, sample_filename)
+    assert sample_filename in \
+           [blob.name for blob in azure_service.list_blobs(azure_utils.AZURE_EMULATOR_COORDS.container)]
+    actual_file_blob = azure_service.get_blob_to_text(azure_utils.AZURE_EMULATOR_COORDS.container, sample_filename)
     assert actual_file_blob.content == sample_stream_content


### PR DESCRIPTION
This way we'll just have one clearly labelled copy of the emulator values in the code base.