### PR TITLE
require all CI tests to pass before building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,9 @@ workflows:
             - python_integration
       - yarn_build:
           requires:
+            - node
+            - etl
+            - extract_endpoint
             - node_integration
           filters:
             branches:


### PR DESCRIPTION
If I'm reading this correctly, we would currently build & deploy even if the ETL, Node, or Extract Endpoint test steps would fail.