### PR TITLE
typed get function for Element

### DIFF
--- a/etl/src/energuide/element.py
+++ b/etl/src/energuide/element.py
@@ -1,6 +1,6 @@
 import typing
 from lxml import etree
-from energuide.exceptions import EnerguideError
+from energuide.exceptions import EnerguideError, ElementGetValueError
 
 
 class MalformedXmlError(EnerguideError):
@@ -71,10 +71,10 @@ class Element:
         try:
             value = self.__node.xpath(xpath)[0]
         except IndexError as ex:
-            raise EnerguideError(f"Couldn't find element at {xpath} in {self.tag}", ex)
+            raise ElementGetValueError(f"Couldn't find element at {xpath} in {self.tag}", ex)
 
         try:
             result = type_(value)
         except ValueError as ex:
-            raise EnerguideError(f"Unable to cast {value} to {type_} in {self.tag}", ex)
+            raise ElementGetValueError(f"Unable to cast {value} to {type_} in {self.tag}", ex)
         return typing.cast(T, result)

--- a/etl/src/energuide/element.py
+++ b/etl/src/energuide/element.py
@@ -7,6 +7,9 @@ class MalformedXmlError(EnerguideError):
     pass
 
 
+T = typing.TypeVar('T', int, float, str)
+
+
 class Element:
 
     _PARSER = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
@@ -63,3 +66,15 @@ class Element:
 
     def insert(self, index: int, element: 'Element') -> None:
         self.__node.insert(index, element.__node)
+
+    def get(self, xpath: str, type_: typing.Type[T]) -> T:
+        try:
+            value = self.__node.xpath(xpath)[0]
+        except IndexError as ex:
+            raise EnerguideError(f"Couldn't find element at {xpath} in {self.tag}", ex)
+
+        try:
+            result = type_(value)
+        except ValueError as ex:
+            raise EnerguideError(f"Unable to cast {value} to {type_} in {self.tag}", ex)
+        return typing.cast(T, result)

--- a/etl/src/energuide/exceptions.py
+++ b/etl/src/energuide/exceptions.py
@@ -18,3 +18,7 @@ class InvalidEmbeddedDataTypeError(EnerguideError):
     def __init__(self, data_class: type, msg: typing.Optional[str] = None) -> None:
         self.data_class = data_class
         super().__init__(msg)
+
+
+class ElementGetValueError(EnerguideError):
+    pass

--- a/etl/tests/test_element.py
+++ b/etl/tests/test_element.py
@@ -1,7 +1,7 @@
 import py._path.local
 import pytest
 from energuide import element
-from energuide.exceptions import EnerguideError
+from energuide.exceptions import ElementGetValueError
 
 
 @pytest.fixture
@@ -128,10 +128,10 @@ def test_get_str(fragment_node: element.Element) -> None:
 
 
 def test_get_raises_when_not_found(fragment_node: element.Element) -> None:
-    with pytest.raises(EnerguideError):
+    with pytest.raises(ElementGetValueError):
         fragment_node.get('Bar/@foo', int)
 
 
 def test_get_raises_when_cant_cast(fragment_node: element.Element) -> None:
-    with pytest.raises(EnerguideError):
+    with pytest.raises(ElementGetValueError):
         fragment_node.get('Bar/text()', int)

--- a/etl/tests/test_element.py
+++ b/etl/tests/test_element.py
@@ -1,11 +1,12 @@
 import py._path.local
 import pytest
 from energuide import element
+from energuide.exceptions import EnerguideError
 
 
 @pytest.fixture
 def fragment() -> str:
-    return "<Foo><Bar id='1'>baz</Bar><Bar id='1'>qux</Bar></Foo>"
+    return "<Foo><Bar id='1'>baz</Bar><Bar id='2'>qux</Bar></Foo>"
 
 
 @pytest.fixture
@@ -106,3 +107,25 @@ def test_insert_node() -> None:
     root.insert(0, child1)
     root.insert(0, child2)
     assert len(root.xpath('*')) == 2
+
+
+def test_get_int(fragment_node: element.Element) -> None:
+    assert fragment_node.get('Bar/@id', int) == 1
+
+
+def test_get_float(fragment_node: element.Element) -> None:
+    assert fragment_node.get('Bar/@id', float) == 1.0
+
+
+def test_get_str(fragment_node: element.Element) -> None:
+    assert fragment_node.get('Bar/@id', str) == '1'
+
+
+def test_get_raises_when_not_found(fragment_node: element.Element) -> None:
+    with pytest.raises(EnerguideError):
+        fragment_node.get('Bar/@foo', int)
+
+
+def test_get_raises_when_cant_cast(fragment_node: element.Element) -> None:
+    with pytest.raises(EnerguideError):
+        fragment_node.get('Bar/text()', int)

--- a/etl/tests/test_element.py
+++ b/etl/tests/test_element.py
@@ -110,15 +110,21 @@ def test_insert_node() -> None:
 
 
 def test_get_int(fragment_node: element.Element) -> None:
-    assert fragment_node.get('Bar/@id', int) == 1
+    result = fragment_node.get('Bar/@id', int)
+    assert result == 1
+    assert isinstance(result, int)
 
 
 def test_get_float(fragment_node: element.Element) -> None:
-    assert fragment_node.get('Bar/@id', float) == 1.0
+    result = fragment_node.get('Bar/@id', float)
+    assert result == 1.0
+    assert isinstance(result, float)
 
 
 def test_get_str(fragment_node: element.Element) -> None:
-    assert fragment_node.get('Bar/@id', str) == '1'
+    result = fragment_node.get('Bar/@id', str)
+    assert result == '1'
+    assert isinstance(result, str)
 
 
 def test_get_raises_when_not_found(fragment_node: element.Element) -> None:


### PR DESCRIPTION
This PR adds a dynamically-typed `get` function to `Element`. `mypy` is able to determine that if you call `result = my_element.get('/path/to/@attribute', int)`, it is supposed to return an `int`.

This should make it possible to simplify some of the exception handling in #249 