### PR TITLE
Get text raises custom error

### DIFF
--- a/etl/src/energuide/element.py
+++ b/etl/src/energuide/element.py
@@ -38,7 +38,13 @@ class Element:
 
     def get_text(self, *args, **kwargs) -> str:
         result: typing.Optional[str] = self.__node.findtext(*args, **kwargs)
-        assert result is not None
+        if result is None:
+            error_message = (
+                f"Couldn't find text at path {args[0]} in tag {self.tag}"
+                if len(args) > 0
+                else "Couldn't find text in {self.tag}"
+            )
+            raise ElementGetValueError(error_message)
         return result
 
     @property

--- a/etl/src/energuide/element.py
+++ b/etl/src/energuide/element.py
@@ -41,7 +41,7 @@ class Element:
         if result is None:
             error_message = (
                 f"Couldn't find text at path {args[0]} in tag {self.tag}"
-                if len(args) > 0
+                if args
                 else "Couldn't find text in {self.tag}"
             )
             raise ElementGetValueError(error_message)

--- a/etl/src/energuide/embedded/ceiling.py
+++ b/etl/src/energuide/embedded/ceiling.py
@@ -4,7 +4,7 @@ from energuide import element
 from energuide.embedded import area
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class _Ceiling(typing.NamedTuple):
@@ -34,7 +34,7 @@ class Ceiling(_Ceiling):
                 ceiling_area=area.Area(float(ceiling.xpath('Measurements/@area')[0])),
                 ceiling_length=distance.Distance(float(ceiling.xpath('Measurements/@length')[0])),
             )
-        except (IndexError, ValueError, AssertionError) as exc:
+        except (IndexError, ValueError, ElementGetValueError) as exc:
             raise InvalidEmbeddedDataTypeError(Ceiling) from exc
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -1,7 +1,7 @@
 import typing
 from energuide import bilingual
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class _WallCode(typing.NamedTuple):
@@ -28,7 +28,7 @@ class WallCode(_WallCode):
                     french=wall_code.get_text('Layers/ComponentTypeSize/French'),
                 )
             )
-        except (KeyError, AssertionError) as exc:
+        except (KeyError, ElementGetValueError) as exc:
             raise InvalidEmbeddedDataTypeError(WallCode) from exc
 
 
@@ -76,7 +76,7 @@ class WindowCode(_WindowCode):
                     french=window_code.get_text('Layers/FrameMaterial/French'),
                 )
             )
-        except (KeyError, AssertionError) as exc:
+        except (KeyError, ElementGetValueError) as exc:
             raise InvalidEmbeddedDataTypeError(WindowCode) from exc
 
 

--- a/etl/src/energuide/embedded/door.py
+++ b/etl/src/energuide/embedded/door.py
@@ -4,7 +4,7 @@ from energuide import element
 from energuide.embedded import distance
 from energuide.embedded import area
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class _Door(typing.NamedTuple):
@@ -31,7 +31,7 @@ class Door(_Door):
                 height=distance.Distance(float(door.xpath('Measurements/@height')[0])),
                 width=distance.Distance(float(door.xpath('Measurements/@width')[0])),
             )
-        except (IndexError, ValueError, AssertionError) as exc:
+        except (IndexError, ValueError, ElementGetValueError) as exc:
             raise InvalidEmbeddedDataTypeError(Door) from exc
 
     @property

--- a/etl/src/energuide/embedded/floor.py
+++ b/etl/src/energuide/embedded/floor.py
@@ -3,7 +3,7 @@ from energuide import element
 from energuide.embedded import area
 from energuide.embedded import distance
 from energuide.embedded import insulation
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class _Floor(typing.NamedTuple):
@@ -26,7 +26,7 @@ class Floor(_Floor):
                 floor_area=area.Area(float(floor.xpath('Measurements/@area')[0])),
                 floor_length=distance.Distance(float(floor.xpath('Measurements/@length')[0])),
             )
-        except (AssertionError, ValueError, IndexError) as exc:
+        except (ElementGetValueError, ValueError, IndexError) as exc:
             raise InvalidEmbeddedDataTypeError(Floor) from exc
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:

--- a/etl/src/energuide/embedded/wall.py
+++ b/etl/src/energuide/embedded/wall.py
@@ -4,7 +4,7 @@ from energuide.embedded import code
 from energuide.embedded import insulation
 from energuide.embedded import distance
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class _Wall(typing.NamedTuple):
@@ -35,7 +35,7 @@ class Wall(_Wall):
                 perimeter=distance.Distance(float(wall.xpath('Measurements/@perimeter')[0])),
                 height=distance.Distance(float(wall.xpath('Measurements/@height')[0])),
             )
-        except (AssertionError, ValueError, IndexError) as exc:
+        except (ElementGetValueError, ValueError, IndexError) as exc:
             raise InvalidEmbeddedDataTypeError(Wall) from exc
 
     @property

--- a/etl/src/energuide/embedded/water_heating.py
+++ b/etl/src/energuide/embedded/water_heating.py
@@ -2,7 +2,7 @@ import enum
 import typing
 from energuide import bilingual
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 class WaterHeaterType(enum.Enum):
@@ -298,7 +298,7 @@ class WaterHeating(_WaterHeating):
                 tank_volume=volume,
                 efficiency=efficiency,
             )
-        except (AssertionError, KeyError, ValueError, IndexError) as exc:
+        except (ElementGetValueError, AssertionError, KeyError, ValueError, IndexError) as exc:
             raise InvalidEmbeddedDataTypeError(WaterHeating) from exc
 
     @classmethod

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -4,7 +4,7 @@ from energuide.embedded import code
 from energuide.embedded import insulation
 from energuide.embedded import distance
 from energuide import element
-from energuide.exceptions import InvalidEmbeddedDataTypeError
+from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
 _MILLIMETRES_TO_METRES = 1000
@@ -36,7 +36,7 @@ class Window(_Window):
                 width=distance.Distance(float(window.xpath('Measurements/@width')[0]) / _MILLIMETRES_TO_METRES),
                 height=distance.Distance(float(window.xpath('Measurements/@height')[0]) / _MILLIMETRES_TO_METRES),
             )
-        except (AssertionError, ValueError, IndexError) as exc:
+        except (ElementGetValueError, ValueError, IndexError) as exc:
             raise InvalidEmbeddedDataTypeError(Window) from exc
 
     @property

--- a/etl/tests/test_element.py
+++ b/etl/tests/test_element.py
@@ -38,7 +38,7 @@ def test_get_text(fragment_node: element.Element) -> None:
 
 
 def test_get_text_raises_when_not_found(fragment_node: element.Element) -> None:
-    with pytest.raises(AssertionError):
+    with pytest.raises(ElementGetValueError):
         fragment_node.get_text('Baz')
 
 


### PR DESCRIPTION
Further to my comment in #260, this PR changes the `assert` call in `element#get_text` to instead raise the custom `ElementGetValueError` exception for easier exception handling.