### PR TITLE
Add Azure utils for string upload / download

### DIFF
--- a/extract_endpoint/src/extract_endpoint/azure_utils.py
+++ b/extract_endpoint/src/extract_endpoint/azure_utils.py
@@ -25,6 +25,14 @@ def upload_bytes_to_azure(coords: StorageCoordinates, data: bytes, filename: str
     return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]
 
 
+def upload_string_to_azure(coords: StorageCoordinates, text: str, filename: str) -> bool:
+    azure_service = blob.BlockBlobService(account_name=coords.account,
+                                          account_key=coords.key,
+                                          custom_domain=coords.domain)
+    azure_service.create_blob_from_text(coords.container, filename, text)
+    return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]
+
+
 def download_string_from_azure(coords: StorageCoordinates, filename: str) -> str:
     azure_service = blob.BlockBlobService(account_name=coords.account,
                                           account_key=coords.key,

--- a/extract_endpoint/src/extract_endpoint/azure_utils.py
+++ b/extract_endpoint/src/extract_endpoint/azure_utils.py
@@ -23,3 +23,10 @@ def upload_bytes_to_azure(coords: StorageCoordinates, data: bytes, filename: str
                                           custom_domain=coords.domain)
     azure_service.create_blob_from_bytes(coords.container, filename, data)
     return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]
+
+
+def download_string_from_azure(coords: StorageCoordinates, filename: str) -> str:
+    azure_service = blob.BlockBlobService(account_name=coords.account,
+                                          account_key=coords.key,
+                                          custom_domain=coords.domain)
+    return azure_service.get_blob_to_text(coords.container, filename).content

--- a/extract_endpoint/tests/test_azure_utils.py
+++ b/extract_endpoint/tests/test_azure_utils.py
@@ -31,6 +31,16 @@ def put_file_in_azure(azure_emulator_coords: azure_utils.StorageCoordinates,
     azure_service.delete_blob(azure_emulator_coords.container, filename)
 
 
+def check_file_in_azure(azure_service: blob.BlockBlobService,
+                        azure_emulator_coords: azure_utils.StorageCoordinates,
+                        filename: str,
+                        contents: str) -> None:
+
+    assert filename in [blob.name for blob in azure_service.list_blobs(azure_emulator_coords.container)]
+    actual_blob = azure_service.get_blob_to_text(azure_emulator_coords.container, filename)
+    assert actual_blob.content == contents
+
+
 def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
                       azure_service: blob.BlockBlobService,
                       sample_data: bytes,
@@ -38,10 +48,16 @@ def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
                       sample_filename: str) -> None:
 
     assert azure_utils.upload_bytes_to_azure(azure_emulator_coords, sample_data, sample_filename)
-    assert sample_filename in \
-           [blob.name for blob in azure_service.list_blobs(azure_emulator_coords.container)]
-    actual_file_blob = azure_service.get_blob_to_text(azure_emulator_coords.container, sample_filename)
-    assert actual_file_blob.content == sample_stream_content
+    check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
+
+
+def test_upload_string(azure_emulator_coords: azure_utils.StorageCoordinates,
+                       azure_service: blob.BlockBlobService,
+                       sample_stream_content: str,
+                       sample_filename: str) -> None:
+
+    assert azure_utils.upload_string_to_azure(azure_emulator_coords, sample_stream_content, sample_filename)
+    check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
 
 def test_download_string(azure_emulator_coords: azure_utils.StorageCoordinates,
@@ -50,6 +66,7 @@ def test_download_string(azure_emulator_coords: azure_utils.StorageCoordinates,
 
     actual_contents = azure_utils.download_string_from_azure(azure_emulator_coords, put_file_in_azure)
     assert actual_contents == sample_stream_content
+
 
 @pytest.mark.usefixtures('put_file_in_azure')
 def test_download_string_bad_filename(azure_emulator_coords: azure_utils.StorageCoordinates) -> None:

--- a/extract_endpoint/tests/test_azure_utils.py
+++ b/extract_endpoint/tests/test_azure_utils.py
@@ -1,5 +1,7 @@
+import typing
 import pytest
 from azure.storage import blob
+from azure.common import AzureMissingResourceHttpError
 from extract_endpoint import azure_utils
 
 
@@ -18,14 +20,38 @@ def sample_filename() -> str:
     return "sample_filename.txt"
 
 
-def test_upload_bytes_to_azure(azure_emulator_coords: azure_utils.StorageCoordinates,
-                               azure_service: blob.BlockBlobService,
-                               sample_data: bytes,
-                               sample_stream_content: str,
-                               sample_filename: str) -> None:
+@pytest.fixture
+def put_file_in_azure(azure_emulator_coords: azure_utils.StorageCoordinates,
+                      azure_service: blob.BlockBlobService,
+                      sample_stream_content: str) -> typing.Generator:
+
+    filename = 'test_put_file.txt'
+    azure_service.create_blob_from_text(azure_emulator_coords.container, filename, sample_stream_content)
+    yield filename
+    azure_service.delete_blob(azure_emulator_coords.container, filename)
+
+
+def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
+                      azure_service: blob.BlockBlobService,
+                      sample_data: bytes,
+                      sample_stream_content: str,
+                      sample_filename: str) -> None:
 
     assert azure_utils.upload_bytes_to_azure(azure_emulator_coords, sample_data, sample_filename)
     assert sample_filename in \
            [blob.name for blob in azure_service.list_blobs(azure_emulator_coords.container)]
     actual_file_blob = azure_service.get_blob_to_text(azure_emulator_coords.container, sample_filename)
     assert actual_file_blob.content == sample_stream_content
+
+
+def test_download_string(azure_emulator_coords: azure_utils.StorageCoordinates,
+                         put_file_in_azure: str,
+                         sample_stream_content: str) -> None:
+
+    actual_contents = azure_utils.download_string_from_azure(azure_emulator_coords, put_file_in_azure)
+    assert actual_contents == sample_stream_content
+
+@pytest.mark.usefixtures('put_file_in_azure')
+def test_download_string_bad_filename(azure_emulator_coords: azure_utils.StorageCoordinates) -> None:
+    with pytest.raises(AzureMissingResourceHttpError):
+        azure_utils.download_string_from_azure(azure_emulator_coords, 'bad_filename')


### PR DESCRIPTION
Add utility functions to upload and download strings to/from Azure. Will be used by the Endpoint to save and retrieve timestamps.