### PR TITLE
Add timestamp to endpoint

### DIFF
--- a/extract_endpoint/src/extract_endpoint/azure_utils.py
+++ b/extract_endpoint/src/extract_endpoint/azure_utils.py
@@ -25,16 +25,8 @@ def upload_bytes_to_azure(coords: StorageCoordinates, data: bytes, filename: str
     return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]
 
 
-def upload_string_to_azure(coords: StorageCoordinates, text: str, filename: str) -> bool:
+def download_bytes_from_azure(coords: StorageCoordinates, filename: str) -> str:
     azure_service = blob.BlockBlobService(account_name=coords.account,
                                           account_key=coords.key,
                                           custom_domain=coords.domain)
-    azure_service.create_blob_from_text(coords.container, filename, text)
-    return filename in [blob.name for blob in azure_service.list_blobs(coords.container)]
-
-
-def download_string_from_azure(coords: StorageCoordinates, filename: str) -> str:
-    azure_service = blob.BlockBlobService(account_name=coords.account,
-                                          account_key=coords.key,
-                                          custom_domain=coords.domain)
-    return azure_service.get_blob_to_text(coords.container, filename).content
+    return azure_service.get_blob_to_bytes(coords.container, filename).content

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -79,8 +79,7 @@ def upload_file() -> typing.Tuple[str, int]:
 
     timestamp = flask.request.form.get('timestamp', None)
     if timestamp:
-        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
-                                                 timestamp.encode(), TIMESTAMP_FILENAME):
+        if not azure_utils.upload_string_to_azure(App.config['AZURE_COORDINATES'], timestamp, TIMESTAMP_FILENAME):
             flask.abort(HTTPStatus.BAD_GATEWAY)
 
     return 'success', HTTPStatus.CREATED

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -4,6 +4,7 @@ import typing
 from http import HTTPStatus
 import flask
 from werkzeug import utils
+from azure.common import AzureMissingResourceHttpError
 from extract_endpoint import azure_utils
 from extract_endpoint import crypt_utils
 
@@ -41,6 +42,15 @@ def robots() -> None:
     flask.abort(HTTPStatus.NOT_FOUND)
 
 
+@App.route('/timestamp', methods=['GET'])
+def timestamp() -> str:
+    try:
+        timestamp = azure_utils.download_string_from_azure(App.config['AZURE_COORDINATES'], TIMESTAMP_FILENAME)
+    except AzureMissingResourceHttpError:
+        flask.abort(HTTPStatus.BAD_GATEWAY)
+    return timestamp
+
+
 @App.route('/upload_file', methods=['POST'])
 def upload_file() -> typing.Tuple[str, int]:
     if App.config['SECRET_KEY'] == DEFAULT_ENDPOINT_SECRET_KEY:
@@ -54,12 +64,6 @@ def upload_file() -> typing.Tuple[str, int]:
     if 'file' not in flask.request.files:
         flask.abort(HTTPStatus.BAD_REQUEST)
 
-    timestamp = flask.request.form.get('timestamp', None)
-    if timestamp:
-        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
-                                                 timestamp.encode(), TIMESTAMP_FILENAME):
-            flask.abort(HTTPStatus.BAD_REQUEST)
-
     file = flask.request.files['file']
     file_contents = file.read()
     file_as_string = base64.b64encode(file_contents).decode('utf-8')
@@ -70,9 +74,16 @@ def upload_file() -> typing.Tuple[str, int]:
 
     filename = utils.secure_filename(flask.request.form['filename'])
 
-    if azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], file_contents, filename):
-        return 'success', HTTPStatus.CREATED
-    return 'failure', HTTPStatus.BAD_REQUEST
+    if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], file_contents, filename):
+        flask.abort(HTTPStatus.BAD_GATEWAY)
+
+    timestamp = flask.request.form.get('timestamp', None)
+    if timestamp:
+        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
+                                                 timestamp.encode(), TIMESTAMP_FILENAME):
+            flask.abort(HTTPStatus.BAD_GATEWAY)
+
+    return 'success', HTTPStatus.CREATED
 
 
 if __name__ == "__main__":

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -45,7 +45,7 @@ def robots() -> None:
 @App.route('/timestamp', methods=['GET'])
 def timestamp() -> str:
     try:
-        timestamp = azure_utils.download_string_from_azure(App.config['AZURE_COORDINATES'], TIMESTAMP_FILENAME)
+        timestamp = azure_utils.download_bytes_from_azure(App.config['AZURE_COORDINATES'], TIMESTAMP_FILENAME)
     except AzureMissingResourceHttpError:
         flask.abort(HTTPStatus.BAD_GATEWAY)
     return timestamp
@@ -79,7 +79,9 @@ def upload_file() -> typing.Tuple[str, int]:
 
     timestamp = flask.request.form.get('timestamp', None)
     if timestamp:
-        if not azure_utils.upload_string_to_azure(App.config['AZURE_COORDINATES'], timestamp, TIMESTAMP_FILENAME):
+        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
+                                                 timestamp.encode(),
+                                                 TIMESTAMP_FILENAME):
             flask.abort(HTTPStatus.BAD_GATEWAY)
 
     return 'success', HTTPStatus.CREATED

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -11,6 +11,9 @@ from extract_endpoint import crypt_utils
 DEFAULT_ENDPOINT_SECRET_KEY = 'no key'
 
 
+TIMESTAMP_FILENAME = 'timestamp.txt'
+
+
 App = flask.Flask(__name__)
 App.config.update(dict(
     SECRET_KEY=os.environ.get('ENDPOINT_SECRET_KEY', DEFAULT_ENDPOINT_SECRET_KEY),
@@ -50,6 +53,12 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_REQUEST)
     if 'file' not in flask.request.files:
         flask.abort(HTTPStatus.BAD_REQUEST)
+
+    timestamp = flask.request.form.get('timestamp', None)
+    if timestamp:
+        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
+                                                 timestamp.encode(), TIMESTAMP_FILENAME):
+            flask.abort(HTTPStatus.BAD_REQUEST)
 
     file = flask.request.files['file']
     file_contents = file.read()

--- a/extract_endpoint/tests/test_azure_utils.py
+++ b/extract_endpoint/tests/test_azure_utils.py
@@ -51,24 +51,15 @@ def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
 
-def test_upload_string(azure_emulator_coords: azure_utils.StorageCoordinates,
-                       azure_service: blob.BlockBlobService,
-                       sample_stream_content: str,
-                       sample_filename: str) -> None:
+def test_download_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
+                        put_file_in_azure: str,
+                        sample_stream_content: str) -> None:
 
-    assert azure_utils.upload_string_to_azure(azure_emulator_coords, sample_stream_content, sample_filename)
-    check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
-
-
-def test_download_string(azure_emulator_coords: azure_utils.StorageCoordinates,
-                         put_file_in_azure: str,
-                         sample_stream_content: str) -> None:
-
-    actual_contents = azure_utils.download_string_from_azure(azure_emulator_coords, put_file_in_azure)
-    assert actual_contents == sample_stream_content
+    actual_contents = azure_utils.download_bytes_from_azure(azure_emulator_coords, put_file_in_azure)
+    assert actual_contents == sample_stream_content.encode()
 
 
 @pytest.mark.usefixtures('put_file_in_azure')
-def test_download_string_bad_filename(azure_emulator_coords: azure_utils.StorageCoordinates) -> None:
+def test_download_bytes_bad_filename(azure_emulator_coords: azure_utils.StorageCoordinates) -> None:
     with pytest.raises(AzureMissingResourceHttpError):
-        azure_utils.download_string_from_azure(azure_emulator_coords, 'bad_filename')
+        azure_utils.download_bytes_from_azure(azure_emulator_coords, 'bad_filename')

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -92,6 +92,11 @@ def test_timestamp(test_client: testing.FlaskClient, sample_timestamp: str) -> N
     assert get_return.data == sample_timestamp.encode()
 
 
+def test_timestamp_no_file(test_client: testing.FlaskClient) -> None:
+    get_return = test_client.get('/timestamp')
+    assert get_return.status_code == HTTPStatus.BAD_GATEWAY
+
+
 def check_file_in_azure(azure_service: blob.BlockBlobService,
                         azure_emulator_coords: azure_utils.StorageCoordinates,
                         filename: str,


### PR DESCRIPTION
Let the endpoint accept an optional timestamp along with the file. This timestamp is written to its own file in Azure.