### PR TITLE
Add timestamp to post endpoint

### DIFF
--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -63,7 +63,7 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_REQUEST)
     if 'file' not in flask.request.files:
         flask.abort(HTTPStatus.BAD_REQUEST)
-    if flask.request.form.get('timestamp', None) is None:
+    if 'timestamp' not in flask.request.form:
         flask.abort(HTTPStatus.BAD_REQUEST)
 
     file = flask.request.files['file']
@@ -79,7 +79,7 @@ def upload_file() -> typing.Tuple[str, int]:
     if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], file_contents, filename):
         flask.abort(HTTPStatus.BAD_GATEWAY)
 
-    timestamp = flask.request.form.get('timestamp', None)
+    timestamp = flask.request.form['timestamp']
 
     if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], timestamp.encode(), TIMESTAMP_FILENAME):
         flask.abort(HTTPStatus.BAD_GATEWAY)

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -63,6 +63,8 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_REQUEST)
     if 'file' not in flask.request.files:
         flask.abort(HTTPStatus.BAD_REQUEST)
+    if flask.request.form.get('timestamp', None) == '':
+        flask.abort(HTTPStatus.BAD_REQUEST)
 
     file = flask.request.files['file']
     file_contents = file.read()
@@ -78,11 +80,9 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_GATEWAY)
 
     timestamp = flask.request.form.get('timestamp', None)
-    if timestamp:
-        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'],
-                                                 timestamp.encode(),
-                                                 TIMESTAMP_FILENAME):
-            flask.abort(HTTPStatus.BAD_GATEWAY)
+
+    if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], timestamp.encode(), TIMESTAMP_FILENAME):
+        flask.abort(HTTPStatus.BAD_GATEWAY)
 
     return 'success', HTTPStatus.CREATED
 

--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -63,7 +63,7 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_REQUEST)
     if 'file' not in flask.request.files:
         flask.abort(HTTPStatus.BAD_REQUEST)
-    if flask.request.form.get('timestamp', None) == '':
+    if flask.request.form.get('timestamp', None) is None:
         flask.abort(HTTPStatus.BAD_REQUEST)
 
     file = flask.request.files['file']

--- a/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
@@ -16,7 +16,10 @@ def main() -> None:
     pass
 
 
-def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: str, timestamp: str) -> requests.models.Response:
+def post_stream(stream: typing.IO[bytes],
+                filename: typing.Optional[str],
+                url: str,
+                timestamp: str) -> requests.models.Response:
     if filename is None and stream.name == '<stdin>':
         raise ValueError("Must supply a filename if reading from stdin")
     if filename is None:

--- a/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
@@ -4,6 +4,7 @@ import secrets
 import typing
 import requests
 import click
+import datetime
 from extract_endpoint import crypt_utils
 
 
@@ -26,9 +27,11 @@ def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: s
     signature = crypt_utils.sign_string(salt=salt,
                                         key=os.environ.get('ENDPOINT_SECRET_KEY', DEFAULT_ENDPOINT_SECRET_KEY),
                                         data=base64.b64encode(data).decode('utf-8'))
+    timestamp = datetime.datetime.now()
+
     return requests.post(url=url,
                          files={'file': data},
-                         data={'salt': salt, 'signature': signature, 'filename': filename})
+                         data={'salt': salt, 'signature': signature, 'filename': filename, 'timestamp': timestamp})
 
 
 @main.command()

--- a/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
@@ -2,9 +2,9 @@ import os
 import base64
 import secrets
 import typing
+import datetime
 import requests
 import click
-import datetime
 from extract_endpoint import crypt_utils
 
 
@@ -16,7 +16,7 @@ def main() -> None:
     pass
 
 
-def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: str) -> requests.models.Response:
+def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: str, timestamp: str) -> requests.models.Response:
     if filename is None and stream.name == '<stdin>':
         raise ValueError("Must supply a filename if reading from stdin")
     if filename is None:
@@ -27,7 +27,6 @@ def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: s
     signature = crypt_utils.sign_string(salt=salt,
                                         key=os.environ.get('ENDPOINT_SECRET_KEY', DEFAULT_ENDPOINT_SECRET_KEY),
                                         data=base64.b64encode(data).decode('utf-8'))
-    timestamp = datetime.datetime.now()
 
     return requests.post(url=url,
                          files={'file': data},
@@ -38,5 +37,6 @@ def post_stream(stream: typing.IO[bytes], filename: typing.Optional[str], url: s
 @click.argument('stream', type=click.File('rb'))
 @click.option('--filename')
 @click.option('--url', default='http://127.0.0.1:5000/upload_file')
-def upload(stream: typing.IO[bytes], filename: typing.Optional[str], url: str) -> None:
-    click.echo(str(post_stream(stream=stream, filename=filename, url=url)))
+@click.option('--timestamp', default=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+def upload(stream: typing.IO[bytes], filename: typing.Optional[str], url: str, timestamp: str) -> None:
+    click.echo(str(post_stream(stream=stream, filename=filename, url=url, timestamp=timestamp)))

--- a/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
@@ -2,7 +2,6 @@ import os
 import base64
 import secrets
 import typing
-import datetime
 import requests
 import click
 from extract_endpoint import crypt_utils
@@ -17,9 +16,9 @@ def main() -> None:
 
 
 def post_stream(stream: typing.IO[bytes],
+                timestamp: str,
                 filename: typing.Optional[str],
-                url: str,
-                timestamp: str) -> requests.models.Response:
+                url: str) -> requests.models.Response:
     if filename is None and stream.name == '<stdin>':
         raise ValueError("Must supply a filename if reading from stdin")
     if filename is None:
@@ -38,8 +37,8 @@ def post_stream(stream: typing.IO[bytes],
 
 @main.command()
 @click.argument('stream', type=click.File('rb'))
+@click.argument('timestamp')
 @click.option('--filename')
 @click.option('--url', default='http://127.0.0.1:5000/upload_file')
-@click.option('--timestamp', default=datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-def upload(stream: typing.IO[bytes], filename: typing.Optional[str], url: str, timestamp: str) -> None:
-    click.echo(str(post_stream(stream=stream, filename=filename, url=url, timestamp=timestamp)))
+def upload(stream: typing.IO[bytes], timestamp: str, filename: typing.Optional[str], url: str) -> None:
+    click.echo(str(post_stream(stream=stream, timestamp=timestamp, filename=filename, url=url)))

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -1,5 +1,6 @@
 import io
 import base64
+import datetime
 from http import HTTPStatus
 import typing
 import pytest
@@ -36,7 +37,7 @@ def sample_secret_key() -> typing.Generator:
 
 @pytest.fixture
 def sample_timestamp() -> str:
-    return "Tue 27 Feb 2018 11:19:17 EST"
+    return datetime.datetime(2018, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")
 
 
 @pytest.fixture

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -77,7 +77,7 @@ def sample_filename() -> str:
 
 @pytest.fixture
 def sample_timestamp() -> str:
-    return datetime.datetime(2018, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")
+    return datetime.datetime(2013, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def check_file_in_azure(azure_service: blob.BlockBlobService,
@@ -148,3 +148,12 @@ def test_post_stream_stdin_no_filename(upload_url: str,
                                      filename=None,
                                      url=upload_url,
                                      timestamp=sample_timestamp)
+
+
+@pytest.mark.usefixtures('run_endpoint')
+def test_post_stream_empty_timestamp(upload_url: str, sample_stream: NamedStream, sample_filename: str) -> None:
+    post_return = post_to_endpoint.post_stream(stream=sample_stream,
+                                               filename=sample_filename,
+                                               url=upload_url,
+                                               timestamp='')
+    assert post_return.status_code == HTTPStatus.BAD_REQUEST

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -80,6 +80,11 @@ def sample_timestamp() -> str:
     return datetime.datetime(2013, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")
 
 
+@pytest.fixture
+def sample_timestamp_filename() -> str:
+    return "timestamp.txt"
+
+
 def check_file_in_azure(azure_service: blob.BlockBlobService,
                         azure_emulator_coords: azure_utils.StorageCoordinates,
                         filename: str,
@@ -97,7 +102,8 @@ def test_post_stream(azure_service: blob.BlockBlobService,
                      sample_stream: NamedStream,
                      sample_stream_content: str,
                      sample_filename: str,
-                     sample_timestamp: str) -> None:
+                     sample_timestamp: str,
+                     sample_timestamp_filename: str) -> None:
 
     post_return = post_to_endpoint.post_stream(stream=sample_stream,
                                                filename=sample_filename,
@@ -105,6 +111,7 @@ def test_post_stream(azure_service: blob.BlockBlobService,
                                                timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
+    check_file_in_azure(azure_service, azure_emulator_coords, sample_timestamp_filename, sample_timestamp)
 
 
 @pytest.mark.usefixtures('run_endpoint')
@@ -114,13 +121,15 @@ def test_post_stream_stdin(azure_service: blob.BlockBlobService,
                            sample_stream_stdin: NamedStream,
                            sample_stream_content: str,
                            sample_filename: str,
-                           sample_timestamp: str) -> None:
+                           sample_timestamp: str,
+                           sample_timestamp_filename: str) -> None:
     post_return = post_to_endpoint.post_stream(stream=sample_stream_stdin,
                                                filename=sample_filename,
                                                url=upload_url,
                                                timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
+    check_file_in_azure(azure_service, azure_emulator_coords, sample_timestamp_filename, sample_timestamp)
 
 
 @pytest.mark.usefixtures('run_endpoint')
@@ -130,13 +139,15 @@ def test_post_stream_no_filename(azure_service: blob.BlockBlobService,
                                  sample_stream: NamedStream,
                                  sample_stream_content: str,
                                  sample_filename: str,
-                                 sample_timestamp: str) -> None:
+                                 sample_timestamp: str,
+                                 sample_timestamp_filename: str) -> None:
     post_return = post_to_endpoint.post_stream(stream=sample_stream,
                                                filename=None,
                                                url=upload_url,
                                                timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
+    check_file_in_azure(azure_service, azure_emulator_coords, sample_timestamp_filename, sample_timestamp)
 
 
 @pytest.mark.usefixtures('run_endpoint')
@@ -155,5 +166,5 @@ def test_post_stream_empty_timestamp(upload_url: str, sample_stream: NamedStream
     post_return = post_to_endpoint.post_stream(stream=sample_stream,
                                                filename=sample_filename,
                                                url=upload_url,
-                                               timestamp='')
+                                               timestamp=None)
     assert post_return.status_code == HTTPStatus.BAD_REQUEST

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -8,7 +8,7 @@ import pytest
 import _pytest
 import requests
 from azure.storage import blob
-from extract_endpoint import post_to_endpoint, azure_utils
+from extract_endpoint import post_to_endpoint, azure_utils, endpoint
 
 
 class NamedStream(io.BytesIO):
@@ -82,7 +82,7 @@ def sample_timestamp() -> str:
 
 @pytest.fixture
 def sample_timestamp_filename() -> str:
-    return "timestamp.txt"
+    return endpoint.TIMESTAMP_FILENAME
 
 
 def check_file_in_azure(azure_service: blob.BlockBlobService,
@@ -159,12 +159,3 @@ def test_post_stream_stdin_no_filename(upload_url: str,
                                      filename=None,
                                      url=upload_url,
                                      timestamp=sample_timestamp)
-
-
-@pytest.mark.usefixtures('run_endpoint')
-def test_post_stream_empty_timestamp(upload_url: str, sample_stream: NamedStream, sample_filename: str) -> None:
-    post_return = post_to_endpoint.post_stream(stream=sample_stream,
-                                               filename=sample_filename,
-                                               url=upload_url,
-                                               timestamp=None)
-    assert post_return.status_code == HTTPStatus.BAD_REQUEST

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -1,6 +1,7 @@
 import io
 import subprocess
 import typing
+import datetime
 from http import HTTPStatus
 import psutil
 import pytest
@@ -74,6 +75,11 @@ def sample_filename() -> str:
     return "sample_filename.txt"
 
 
+@pytest.fixture
+def sample_timestamp() -> str:
+    return datetime.datetime(2018, 1, 1, 0, 0, 0).strftime("%Y-%m-%d %H:%M:%S")
+
+
 def check_file_in_azure(azure_service: blob.BlockBlobService,
                         azure_emulator_coords: azure_utils.StorageCoordinates,
                         filename: str,
@@ -90,9 +96,13 @@ def test_post_stream(azure_service: blob.BlockBlobService,
                      upload_url: str,
                      sample_stream: NamedStream,
                      sample_stream_content: str,
-                     sample_filename: str) -> None:
+                     sample_filename: str,
+                     sample_timestamp: str) -> None:
 
-    post_return = post_to_endpoint.post_stream(stream=sample_stream, filename=sample_filename, url=upload_url)
+    post_return = post_to_endpoint.post_stream(stream=sample_stream,
+                                               filename=sample_filename,
+                                               url=upload_url,
+                                               timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
@@ -103,8 +113,12 @@ def test_post_stream_stdin(azure_service: blob.BlockBlobService,
                            upload_url: str,
                            sample_stream_stdin: NamedStream,
                            sample_stream_content: str,
-                           sample_filename: str) -> None:
-    post_return = post_to_endpoint.post_stream(stream=sample_stream_stdin, filename=sample_filename, url=upload_url)
+                           sample_filename: str,
+                           sample_timestamp: str) -> None:
+    post_return = post_to_endpoint.post_stream(stream=sample_stream_stdin,
+                                               filename=sample_filename,
+                                               url=upload_url,
+                                               timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
@@ -115,13 +129,22 @@ def test_post_stream_no_filename(azure_service: blob.BlockBlobService,
                                  upload_url: str,
                                  sample_stream: NamedStream,
                                  sample_stream_content: str,
-                                 sample_filename: str) -> None:
-    post_return = post_to_endpoint.post_stream(stream=sample_stream, filename=None, url=upload_url)
+                                 sample_filename: str,
+                                 sample_timestamp: str) -> None:
+    post_return = post_to_endpoint.post_stream(stream=sample_stream,
+                                               filename=None,
+                                               url=upload_url,
+                                               timestamp=sample_timestamp)
     assert post_return.status_code == HTTPStatus.CREATED
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
 
 @pytest.mark.usefixtures('run_endpoint')
-def test_post_stream_stdin_no_filename(upload_url: str, sample_stream_stdin: NamedStream) -> None:
+def test_post_stream_stdin_no_filename(upload_url: str,
+                                       sample_stream_stdin: NamedStream,
+                                       sample_timestamp: str) -> None:
     with pytest.raises(ValueError):
-        post_to_endpoint.post_stream(stream=sample_stream_stdin, filename=None, url=upload_url)
+        post_to_endpoint.post_stream(stream=sample_stream_stdin,
+                                     filename=None,
+                                     url=upload_url,
+                                     timestamp=sample_timestamp)


### PR DESCRIPTION
This PR intends to add timestamp as a click option with the default being datetime.now(), which is then passed to post_stream and ultimately the end point to upload a timestamp.txt file with the passed timestamp.

Opinions please!