### PR TITLE
Cache control tags for types that didn't have them

### DIFF
--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -30,7 +30,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`An improvement that could improve the energy efficiency of the dwelling`}
-    type Upgrade {
+    type Upgrade @cacheControl(maxAge: 90) {
       # ${i18n.t`Part of the dwelling to be upgraded`}
       upgradeType: I18NString
       # ${i18n.t`Estimated cost of upgrade`}
@@ -88,7 +88,7 @@ const Schema = i18n => {
     }
 
     # ${i18n.t`A principal heating system is either the only source of heat for the house, or is used for at least 70% of the heating load`}
-    type Heating {
+    type Heating @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of heating system`}
       label: I18NString
       # ${i18n.t`Type of heating system (en)`}


### PR DESCRIPTION
From issue [#4](https://github.com/apollographql/apollo-cache-control-js/issues/4) in the github repo:

> If you don't see cache hits, that usually means there is a path in your response that has maxAge: 0 set. That happens for all objects that do not have an explicit @cacheControl defined, because caching is opt-in.

[Source](https://github.com/apollographql/apollo-cache-control-js/issues/4#issuecomment-341215307)