### PR TITLE
Start modularizing the schema

### DIFF
--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -78,6 +78,7 @@ describe('configuration', () => {
       let response = await makeRequest({ typeName: 'Evaluation', lang: 'fr' })
 
       let { __type: { description } } = response.body.data
+
       expect(description).toEqual(
         "Informations détaillées sur les caractéristiques spécifiques d'un logement donné",
       )

--- a/api/src/schema/Header.js
+++ b/api/src/schema/Header.js
@@ -1,0 +1,27 @@
+export const createHeader = i18n => {
+  const Header = `
+    type Header {
+      # ${i18n.t`Header insulation nominal RSI (R-value Systeme International)`}
+      insulationNominalRsi: I18NFloat
+      # ${i18n.t`Header insulation nominal R-value`}
+      insulationNominalR: I18NFloat
+      # ${i18n.t`Header insulation effective RSI (R-value Systeme International)`}
+      insulationEffectiveRsi: I18NFloat
+      # ${i18n.t`Header insulation effective R-value`}
+      insulationEffectiveR: I18NFloat
+      # ${i18n.t`Header area in square metres (m2)`}
+      areaMetres: I18NFloat
+      # ${i18n.t`Header area in square feet (ft2)`}
+      areaFeet: I18NFloat
+      # ${i18n.t`Header perimeter of the house in metres (m)`}
+      perimeterMetres: I18NFloat
+      # ${i18n.t`Header perimeter of the house in feet (ft)`}
+      perimeterFeet: I18NFloat
+      # ${i18n.t`Header height in metres (m)`}
+      heightMetres: I18NFloat
+      # ${i18n.t`Header height in feet (ft)`}
+      heightFeet: I18NFloat
+    }
+  `
+  return Header
+}

--- a/api/src/schema/Header.js
+++ b/api/src/schema/Header.js
@@ -1,6 +1,6 @@
 export const createHeader = i18n => {
   const Header = `
-    type Header {
+    type Header @cacheControl(maxAge: 90) {
       # ${i18n.t`Header insulation nominal RSI (R-value Systeme International)`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`Header insulation nominal R-value`}

--- a/api/src/schema/__tests__/Header.test.js
+++ b/api/src/schema/__tests__/Header.test.js
@@ -1,0 +1,42 @@
+import { createHeader } from '../Header'
+import { createI18NFloat } from '../types/I18NFloat'
+import { i18n, unpackCatalog } from 'lingui-i18n'
+import { makeExecutableSchema } from 'graphql-tools'
+
+i18n.load({
+  fr: unpackCatalog(require('../../locale/fr/messages.js')),
+  en: unpackCatalog(require('../../locale/en/messages.js')),
+})
+let schema
+describe('Schema', () => {
+  describe('Header', () => {
+    beforeEach(() => {
+      const Header = createHeader(i18n)
+      schema = makeExecutableSchema({
+        typeDefs: [Header, `scalar I18NFloat`],
+        resolvers: [{I18NFloat: createI18NFloat(i18n)}],
+      })
+    })
+
+    it('is parsable', () => {
+      expect(schema.getTypeMap()).toHaveProperty('Header')
+    })
+
+    it('has the expected fields', () => {
+      const { Header } = schema.getTypeMap()
+      const fields = Object.keys(Header.getFields())
+      expect(fields).toEqual([
+        'insulationNominalRsi',
+        'insulationNominalR',
+        'insulationEffectiveRsi',
+        'insulationEffectiveR',
+        'areaMetres',
+        'areaFeet',
+        'perimeterMetres',
+        'perimeterFeet',
+        'heightMetres',
+        'heightFeet',
+      ])
+    })
+  })
+})

--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -277,6 +277,7 @@ describe('Schema', () => {
       ])
     })
   })
+
   describe('Upgrade', () => {
     it('is defined', () => {
       expect(typeMap).toHaveProperty('Upgrade')
@@ -288,4 +289,5 @@ describe('Schema', () => {
       expect(fields).toEqual(['upgradeType', 'cost', 'priority'])
     })
   })
+
 })

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -2,8 +2,8 @@ import { Resolvers } from './resolvers'
 import { makeExecutableSchema } from 'graphql-tools'
 
 const Schema = i18n => {
-  const typeDefs = `
-
+  const typeDefs = [
+    `
     scalar I18NInt
     scalar I18NFloat
     scalar I18NString
@@ -18,6 +18,7 @@ const Schema = i18n => {
       # ${i18n.t`Equal to: returns true for results equal to the comparison value`}
       eq
     }
+
 
     # ${i18n.t`Filters will return results only if they satisfy a condition`}
     input Filter {
@@ -456,7 +457,8 @@ const Schema = i18n => {
       # ${i18n.t`Filter results by the dwellings containing at least one ceiling with a specific length in feet (ft)`}
       ceilingLengthFeet
     }
-  `
+  `,
+  ]
 
   return makeExecutableSchema({ typeDefs, resolvers: new Resolvers(i18n) })
 }

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -1,11 +1,4 @@
 import MongoPaging from 'mongo-cursor-pagination'
-import {
-  GraphQLInt,
-  GraphQLFloat,
-  GraphQLString,
-  GraphQLBoolean,
-} from 'graphql'
-
 /* eslint-disable import/named */
 import {
   dwellingHouseId,
@@ -76,38 +69,17 @@ import {
 } from './enums'
 /* eslint-enable import/named */
 
-const I18NInt = Object.create(GraphQLInt)
-const I18NFloat = Object.create(GraphQLFloat)
-const I18NString = Object.create(GraphQLString)
-const I18NBoolean = Object.create(GraphQLBoolean)
+import { createI18NFloat } from './types/I18NFloat'
+import { createI18NInt } from './types/I18NInt'
+import { createI18NString } from './types/I18NString'
+import { createI18NBoolean } from './types/I18NBoolean'
 
 const Resolvers = i18n => {
-  I18NInt.description = i18n.t`
-    The 'Int' scalar type represents non-fractional signed whole numeric
-    values. Int can represent values between -(2^31) and 2^31 - 1.
-  `
-
-  I18NFloat.description = i18n.t`
-    The 'Float' scalar type represents signed double-precision fractional
-    values as specified by
-    [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
-  `
-
-  I18NString.description = i18n.t`
-    The 'String' scalar type represents textual data, represented as UTF-8
-    character sequences. The String type is most often used by GraphQL to
-    represent free-form human-readable text.
-  `
-
-  I18NBoolean.description = i18n.t`
-    The 'Boolean' scalar type represents 'true' or 'false'.
-  `
-
   return {
-    I18NInt,
-    I18NString,
-    I18NFloat,
-    I18NBoolean,
+    I18NInt: createI18NInt(i18n),
+    I18NString: createI18NString(i18n),
+    I18NFloat: createI18NFloat(i18n),
+    I18NBoolean: createI18NBoolean(i18n),
     Query: {
       dwelling: async (root, { houseId }, { client }) => {
         let query = {

--- a/api/src/schema/types/I18NBoolean.js
+++ b/api/src/schema/types/I18NBoolean.js
@@ -1,0 +1,9 @@
+import { GraphQLBoolean } from 'graphql'
+
+export const createI18NBoolean = i18n => {
+  const I18NBoolean = Object.create(GraphQLBoolean)
+  I18NBoolean.description = i18n.t`
+    The 'Boolean' scalar type represents 'true' or 'false'.
+  `
+  return I18NBoolean
+}

--- a/api/src/schema/types/I18NFloat.js
+++ b/api/src/schema/types/I18NFloat.js
@@ -1,0 +1,11 @@
+import { GraphQLFloat } from 'graphql'
+
+export const createI18NFloat = i18n => {
+  const I18NFloat = Object.create(GraphQLFloat)
+  I18NFloat.description = i18n.t`
+    The 'Float' scalar type represents signed double-precision fractional
+    values as specified by
+    [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
+  `
+  return I18NFloat
+}

--- a/api/src/schema/types/I18NInt.js
+++ b/api/src/schema/types/I18NInt.js
@@ -1,0 +1,10 @@
+import { GraphQLInt } from 'graphql'
+
+export const createI18NInt = i18n => {
+  const I18NInt = Object.create(GraphQLInt)
+  I18NInt.description = i18n.t`
+    The 'Int' scalar type represents non-fractional signed whole numeric
+    values. Int can represent values between -(2^31) and 2^31 - 1.
+  `
+  return I18NInt
+}

--- a/api/src/schema/types/I18NString.js
+++ b/api/src/schema/types/I18NString.js
@@ -1,0 +1,11 @@
+import { GraphQLString } from 'graphql'
+
+export const createI18NString = i18n => {
+  const I18NString = Object.create(GraphQLString)
+  I18NString.description = i18n.t`
+    The 'String' scalar type represents textual data, represented as UTF-8
+    character sequences. The String type is most often used by GraphQL to
+    represent free-form human-readable text.
+  `
+  return I18NString
+}


### PR DESCRIPTION
This commit is the beginning of the process of splitting this schema up
into smaller pieces. The Header type (needed for foundations) is
included here as it's the type that touched off this little refactoring
operation, but it's not used or visible anywhere.