### PR TITLE
Add backwards paging to the API results

### DIFF
--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -322,7 +322,7 @@ const Schema = i18n => {
       # ${i18n.t`Details for a specific dwelling`}
       dwelling(houseId: I18NInt!): Dwelling
       # ${i18n.t`Details for all dwellings, optionally filtered by one or more values`}
-      dwellings(filters: [Filter!] limit: I18NInt, next: I18NString): PaginatedResultSet
+      dwellings(filters: [Filter!] limit: I18NInt next: I18NString previous: I18NString): PaginatedResultSet
     }
 
     enum Field {

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -94,7 +94,7 @@ const Resolvers = i18n => {
         // and is passed directly into library code to be decoded and used while
         // talking to the database.
         // ಠ_ಠ
-        const { filters, limit, next } = args
+        const { filters, limit, next, previous } = args
 
         let query = {
           $and: [{}],
@@ -127,6 +127,7 @@ const Resolvers = i18n => {
         let result = await MongoPaging.find(client, {
           query,
           next,
+          previous,
           limit,
         })
 

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -1,4 +1,6 @@
 import MongoPaging from 'mongo-cursor-pagination'
+import { GraphQLError } from 'graphql'
+
 /* eslint-disable import/named */
 import {
   dwellingHouseId,
@@ -95,6 +97,14 @@ const Resolvers = i18n => {
         // talking to the database.
         // ಠ_ಠ
         const { filters, limit, next, previous } = args
+
+        if (next && previous) {
+          throw new GraphQLError(
+            i18n.t`
+              Cannot submit values for both 'next' and 'previous'.
+            `,
+          )
+        }
 
         let query = {
           $and: [{}],

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -35,8 +35,8 @@ function Server(context = {}, ...middlewares) {
       }),
     )
   server.get('/graphiql', graphiqlExpress({ endpointURL: '/graphql' }))
-  server.get('/', function (req, res) {
-    res.redirect('/graphiql');
+  server.get('/', function(req, res) {
+    res.redirect('/graphiql')
   })
   return server
 }

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -598,7 +598,7 @@ describe('queries', () => {
       it('uses limit and next to paginate results', async () => {
         let response = await makeRequestForOnePage()
 
-        // use the value of "next" to fetch the next result
+        // use the value of "next" to fetch the next results
         let response2 = await makeRequestForOnePage({
           next: `next: "${response.body.data.dwellings.next}"`,
         })
@@ -608,18 +608,18 @@ describe('queries', () => {
         expect(first.results[0].yearBuilt).toEqual(3000)
         expect(second.results[0].yearBuilt).toEqual(1900)
 
-        expect(first.hasNext).toEqual(true)
-        expect(second.hasNext).toEqual(false)
+        expect(first.hasNext).toBe(true)
+        expect(second.hasNext).toBe(false)
       })
 
       it('uses limit and previous to paginate results', async () => {
         let response = await makeRequestForOnePage()
 
-        // use the value of "next" to fetch the next result
         let response2 = await makeRequestForOnePage({
           next: `next: "${response.body.data.dwellings.next}"`,
         })
 
+        // use the value of "previous" to fetch the previous results
         let response3 = await makeRequestForOnePage({
           previous: `previous: "${response2.body.data.dwellings.previous}"`,
         })
@@ -630,9 +630,29 @@ describe('queries', () => {
         expect(first).toEqual(third)
         expect(second.results[0].yearBuilt).toEqual(1900)
 
-        expect(first.hasPrevious).toEqual(false)
-        expect(second.hasPrevious).toEqual(true)
-        expect(third.hasPrevious).toEqual(false)
+        expect(first.hasPrevious).toBe(false)
+        expect(second.hasPrevious).toBe(true)
+        expect(third.hasPrevious).toBe(false)
+      })
+
+      it('Returns error key if values exist for both next and previous', async () => {
+        let response = await makeRequestForOnePage()
+
+        let response2 = await makeRequestForOnePage({
+          next: `next: "${response.body.data.dwellings.next}"`,
+          previous: `previous: "${response.body.data.dwellings.previous}"`,
+        })
+
+        let { dwellings: first } = response.body.data
+        expect(first.results[0].yearBuilt).toEqual(3000)
+
+        expect(response2.body.data.dwellings).toBe(null)
+        expect(response2.body.errors).not.toBe(null)
+        expect(response2.body.errors[0].message).toEqual(
+          "Cannot submit values for both 'next' and 'previous'.",
+        )
+        // returned status code is still 200
+        expect(response2.status).toBe(200)
       })
     })
 


### PR DESCRIPTION
Add a `previous` input parameter to allow paging backwards through our results.

Up until this point, we were able to get the next page of results but could never return to the previous page(s).

Also, if both `next` and `previous` are passed in, we throw an error because this a nonsensical thing to do. For more details see commit message.