### PR TITLE
Refactor codes

### DIFF
--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -37,8 +37,8 @@ class _WindowCode(typing.NamedTuple):
     label: str
     glazing_type: bilingual.Bilingual
     coating_tint: bilingual.Bilingual
-    fill_type: bilingual.Bilingual
-    spacer_type: bilingual.Bilingual
+    fill_type: typing.Optional[bilingual.Bilingual]
+    spacer_type: typing.Optional[bilingual.Bilingual]
     window_code_type: bilingual.Bilingual
     frame_material: bilingual.Bilingual
 
@@ -47,6 +47,13 @@ class WindowCode(_WindowCode):
 
     @classmethod
     def from_data(cls, window_code: element.Element) -> 'WindowCode':
+
+        fill_type_english = window_code.findtext('Layers/FillType/English')
+        fill_type_french = window_code.findtext('Layers/FillType/French')
+
+        spacer_type_english = window_code.findtext('Layers/SpacerType/English')
+        spacer_type_french = window_code.findtext('Layers/SpacerType/French')
+
         try:
             return WindowCode(
                 identifier=window_code.attrib['id'],
@@ -60,13 +67,13 @@ class WindowCode(_WindowCode):
                     french=window_code.get_text('Layers/CoatingsTints/French'),
                 ),
                 fill_type=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/FillType/English'),
-                    french=window_code.get_text('Layers/FillType/French'),
-                ),
+                    english=fill_type_english,
+                    french=fill_type_french,
+                ) if fill_type_english and fill_type_french else None,
                 spacer_type=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/SpacerType/English'),
-                    french=window_code.get_text('Layers/SpacerType/French'),
-                ),
+                    english=spacer_type_english,
+                    french=spacer_type_french,
+                ) if spacer_type_english and spacer_type_french else None,
                 window_code_type=bilingual.Bilingual(
                     english=window_code.get_text('Layers/Type/English'),
                     french=window_code.get_text('Layers/Type/French'),

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -36,7 +36,7 @@ class _WindowCode(typing.NamedTuple):
     identifier: str
     label: str
     glazing_type: typing.Optional[bilingual.Bilingual]
-    coating_tint: bilingual.Bilingual
+    coating_tint: typing.Optional[bilingual.Bilingual]
     fill_type: typing.Optional[bilingual.Bilingual]
     spacer_type: typing.Optional[bilingual.Bilingual]
     window_code_type: bilingual.Bilingual
@@ -50,6 +50,9 @@ class WindowCode(_WindowCode):
 
         glazing_type_english = window_code.findtext('Layers/GlazingTypes/English')
         glazing_type_french = window_code.findtext('Layers/GlazingTypes/French')
+
+        coating_tint_english = window_code.findtext('Layers/CoatingsTints/English')
+        coating_tint_french = window_code.findtext('Layers/CoatingsTints/French')
 
         fill_type_english = window_code.findtext('Layers/FillType/English')
         fill_type_french = window_code.findtext('Layers/FillType/French')
@@ -66,9 +69,9 @@ class WindowCode(_WindowCode):
                     french=glazing_type_french,
                 ) if glazing_type_english and glazing_type_french else None,
                 coating_tint=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/CoatingsTints/English'),
-                    french=window_code.get_text('Layers/CoatingsTints/French'),
-                ),
+                    english=coating_tint_english,
+                    french=coating_tint_french,
+                ) if coating_tint_english and coating_tint_french else None,
                 fill_type=bilingual.Bilingual(
                     english=fill_type_english,
                     french=fill_type_french,

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -39,8 +39,8 @@ class _WindowCode(typing.NamedTuple):
     coating_tint: typing.Optional[bilingual.Bilingual]
     fill_type: typing.Optional[bilingual.Bilingual]
     spacer_type: typing.Optional[bilingual.Bilingual]
-    window_code_type: bilingual.Bilingual
-    frame_material: bilingual.Bilingual
+    window_code_type: typing.Optional[bilingual.Bilingual]
+    frame_material: typing.Optional[bilingual.Bilingual]
 
 
 class WindowCode(_WindowCode):
@@ -59,6 +59,12 @@ class WindowCode(_WindowCode):
 
         spacer_type_english = window_code.findtext('Layers/SpacerType/English')
         spacer_type_french = window_code.findtext('Layers/SpacerType/French')
+
+        window_code_type_english = window_code.findtext('Layers/Type/English')
+        window_code_type_french = window_code.findtext('Layers/Type/French')
+
+        frame_material_english = window_code.findtext('Layers/FrameMaterial/English')
+        frame_material_french = window_code.findtext('Layers/FrameMaterial/French')
 
         try:
             return WindowCode(
@@ -81,13 +87,13 @@ class WindowCode(_WindowCode):
                     french=spacer_type_french,
                 ) if spacer_type_english and spacer_type_french else None,
                 window_code_type=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/Type/English'),
-                    french=window_code.get_text('Layers/Type/French'),
-                ),
+                    english=window_code_type_english,
+                    french=window_code_type_french,
+                ) if window_code_type_english and window_code_type_french else None,
                 frame_material=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/FrameMaterial/English'),
-                    french=window_code.get_text('Layers/FrameMaterial/French'),
-                )
+                    english=frame_material_english,
+                    french=frame_material_french,
+                ) if frame_material_english and frame_material_french else None,
             )
         except (KeyError, ElementGetValueError) as exc:
             raise InvalidEmbeddedDataTypeError(WindowCode) from exc

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -1,46 +1,63 @@
+import enum
 import typing
 from energuide import bilingual
 from energuide import element
 from energuide.exceptions import InvalidEmbeddedDataTypeError, ElementGetValueError
 
 
+class WallCodeTag(enum.Enum):
+    STRUCTURE_TYPE = enum.auto()
+    COMPONENT_TYPE_SIZE = enum.auto()
+
+
 class _WallCode(typing.NamedTuple):
     identifier: str
     label: str
-    structure_type: bilingual.Bilingual
-    component_type_size: bilingual.Bilingual
+    tags: typing.Dict[WallCodeTag, typing.Optional[bilingual.Bilingual]]
 
 
 class WallCode(_WallCode):
 
     @classmethod
     def from_data(cls, wall_code: element.Element) -> 'WallCode':
+        structure_type_english = wall_code.findtext('Layers/StructureType/English')
+        structure_type_french = wall_code.findtext('Layers/StructureType/French')
+
+        component_type_size_english = wall_code.findtext('Layers/ComponentTypeSize/English')
+        component_type_size_french = wall_code.findtext('Layers/ComponentTypeSize/French')
+
         try:
             return WallCode(
-                identifier=wall_code.attrib['id'],
+                identifier=wall_code.get('@id', str),
                 label=wall_code.get_text('Label'),
-                structure_type=bilingual.Bilingual(
-                    english=wall_code.get_text('Layers/StructureType/English'),
-                    french=wall_code.get_text('Layers/StructureType/French'),
-                ),
-                component_type_size=bilingual.Bilingual(
-                    english=wall_code.get_text('Layers/ComponentTypeSize/English'),
-                    french=wall_code.get_text('Layers/ComponentTypeSize/French'),
-                )
+                tags={
+                    WallCodeTag.STRUCTURE_TYPE: bilingual.Bilingual(
+                        english=structure_type_english,
+                        french=structure_type_french,
+                    ) if structure_type_english and structure_type_french else None,
+                    WallCodeTag.COMPONENT_TYPE_SIZE: bilingual.Bilingual(
+                        english=component_type_size_english,
+                        french=component_type_size_french,
+                    ) if component_type_size_english and component_type_size_french else None,
+                }
             )
-        except (KeyError, ElementGetValueError) as exc:
-            raise InvalidEmbeddedDataTypeError(WallCode) from exc
+        except ElementGetValueError as exc:
+            raise InvalidEmbeddedDataTypeError(WallCode, 'Unable to get identifier attributes') from exc
+
+
+class WindowCodeTag(enum.Enum):
+    GLAZING_TYPE = enum.auto()
+    COATING_TINTS = enum.auto()
+    FILL_TYPE = enum.auto()
+    SPACER_TYPE = enum.auto()
+    CODE_TYPE = enum.auto()
+    FRAME_MATERIAL = enum.auto()
 
 
 class _WindowCode(typing.NamedTuple):
     identifier: str
     label: str
-    glazing_type: typing.Optional[bilingual.Bilingual]
-    coating_tint: typing.Optional[bilingual.Bilingual]
-    fill_type: typing.Optional[bilingual.Bilingual]
-    spacer_type: typing.Optional[bilingual.Bilingual]
-    window_code_type: typing.Optional[bilingual.Bilingual]
-    frame_material: typing.Optional[bilingual.Bilingual]
+    tags: typing.Dict[WindowCodeTag, typing.Optional[bilingual.Bilingual]]
 
 
 class WindowCode(_WindowCode):
@@ -68,35 +85,37 @@ class WindowCode(_WindowCode):
 
         try:
             return WindowCode(
-                identifier=window_code.attrib['id'],
+                identifier=window_code.get('@id', str),
                 label=window_code.get_text('Label'),
-                glazing_type=bilingual.Bilingual(
-                    english=glazing_type_english,
-                    french=glazing_type_french,
-                ) if glazing_type_english and glazing_type_french else None,
-                coating_tint=bilingual.Bilingual(
-                    english=coating_tint_english,
-                    french=coating_tint_french,
-                ) if coating_tint_english and coating_tint_french else None,
-                fill_type=bilingual.Bilingual(
-                    english=fill_type_english,
-                    french=fill_type_french,
-                ) if fill_type_english and fill_type_french else None,
-                spacer_type=bilingual.Bilingual(
-                    english=spacer_type_english,
-                    french=spacer_type_french,
-                ) if spacer_type_english and spacer_type_french else None,
-                window_code_type=bilingual.Bilingual(
-                    english=window_code_type_english,
-                    french=window_code_type_french,
-                ) if window_code_type_english and window_code_type_french else None,
-                frame_material=bilingual.Bilingual(
-                    english=frame_material_english,
-                    french=frame_material_french,
-                ) if frame_material_english and frame_material_french else None,
+                tags={
+                    WindowCodeTag.GLAZING_TYPE: bilingual.Bilingual(
+                        english=glazing_type_english,
+                        french=glazing_type_french,
+                    ) if glazing_type_english and glazing_type_french else None,
+                    WindowCodeTag.COATING_TINTS: bilingual.Bilingual(
+                        english=coating_tint_english,
+                        french=coating_tint_french,
+                    ) if coating_tint_english and coating_tint_french else None,
+                    WindowCodeTag.FILL_TYPE: bilingual.Bilingual(
+                        english=fill_type_english,
+                        french=fill_type_french,
+                    ) if fill_type_english and fill_type_french else None,
+                    WindowCodeTag.SPACER_TYPE: bilingual.Bilingual(
+                        english=spacer_type_english,
+                        french=spacer_type_french,
+                    ) if spacer_type_english and spacer_type_french else None,
+                    WindowCodeTag.CODE_TYPE: bilingual.Bilingual(
+                        english=window_code_type_english,
+                        french=window_code_type_french,
+                    ) if window_code_type_english and window_code_type_french else None,
+                    WindowCodeTag.FRAME_MATERIAL: bilingual.Bilingual(
+                        english=frame_material_english,
+                        french=frame_material_french,
+                    ) if frame_material_english and frame_material_french else None,
+                }
             )
-        except (KeyError, ElementGetValueError) as exc:
-            raise InvalidEmbeddedDataTypeError(WindowCode) from exc
+        except ElementGetValueError as exc:
+            raise InvalidEmbeddedDataTypeError(WindowCode, 'Unable to get identifier attributes') from exc
 
 
 class _Codes(typing.NamedTuple):

--- a/etl/src/energuide/embedded/code.py
+++ b/etl/src/energuide/embedded/code.py
@@ -35,7 +35,7 @@ class WallCode(_WallCode):
 class _WindowCode(typing.NamedTuple):
     identifier: str
     label: str
-    glazing_type: bilingual.Bilingual
+    glazing_type: typing.Optional[bilingual.Bilingual]
     coating_tint: bilingual.Bilingual
     fill_type: typing.Optional[bilingual.Bilingual]
     spacer_type: typing.Optional[bilingual.Bilingual]
@@ -48,6 +48,9 @@ class WindowCode(_WindowCode):
     @classmethod
     def from_data(cls, window_code: element.Element) -> 'WindowCode':
 
+        glazing_type_english = window_code.findtext('Layers/GlazingTypes/English')
+        glazing_type_french = window_code.findtext('Layers/GlazingTypes/French')
+
         fill_type_english = window_code.findtext('Layers/FillType/English')
         fill_type_french = window_code.findtext('Layers/FillType/French')
 
@@ -59,9 +62,9 @@ class WindowCode(_WindowCode):
                 identifier=window_code.attrib['id'],
                 label=window_code.get_text('Label'),
                 glazing_type=bilingual.Bilingual(
-                    english=window_code.get_text('Layers/GlazingTypes/English'),
-                    french=window_code.get_text('Layers/GlazingTypes/French'),
-                ),
+                    english=glazing_type_english,
+                    french=glazing_type_french,
+                ) if glazing_type_english and glazing_type_french else None,
                 coating_tint=bilingual.Bilingual(
                     english=window_code.get_text('Layers/CoatingsTints/English'),
                     french=window_code.get_text('Layers/CoatingsTints/French'),

--- a/etl/src/energuide/embedded/wall.py
+++ b/etl/src/energuide/embedded/wall.py
@@ -51,10 +51,10 @@ class Wall(_Wall):
         code_tags: typing.Dict[str, typing.Optional[str]] = dict(
             item
             for _, tag_name in self._CODE_TAG_TRANSLATIONS
-            for item in {
-                f'{tag_name}English': None,
-                f'{tag_name}French': None,
-            }.items()
+            for item in [
+                (f'{tag_name}English', None),
+                (f'{tag_name}French', None),
+            ]
         )
 
         if self.wall_code:

--- a/etl/src/energuide/embedded/wall.py
+++ b/etl/src/energuide/embedded/wall.py
@@ -18,10 +18,10 @@ class _Wall(typing.NamedTuple):
 
 class Wall(_Wall):
 
-    _CODE_TAG_TRANSLATIONS = {
-        code.WallCodeTag.STRUCTURE_TYPE: 'structureType',
-        code.WallCodeTag.COMPONENT_TYPE_SIZE: 'componentTypeSize',
-    }
+    _CODE_TAG_TRANSLATIONS = [
+        (code.WallCodeTag.STRUCTURE_TYPE, 'structureType'),
+        (code.WallCodeTag.COMPONENT_TYPE_SIZE, 'componentTypeSize')
+    ]
 
     @classmethod
     def from_data(cls,
@@ -50,7 +50,7 @@ class Wall(_Wall):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         code_tags: typing.Dict[str, typing.Optional[str]] = dict(
             item
-            for tag_name in self._CODE_TAG_TRANSLATIONS.values()
+            for _, tag_name in self._CODE_TAG_TRANSLATIONS
             for item in {
                 f'{tag_name}English': None,
                 f'{tag_name}French': None,
@@ -58,7 +58,7 @@ class Wall(_Wall):
         )
 
         if self.wall_code:
-            for tag_type, tag_name in self._CODE_TAG_TRANSLATIONS.items():
+            for tag_type, tag_name in self._CODE_TAG_TRANSLATIONS:
                 tag_value = self.wall_code.tags.get(tag_type)
                 code_tags.update(
                     **{

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -48,8 +48,13 @@ class Window(_Window):
             'label': self.label,
             'insulationRsi': self.window_insulation.rsi,
             'insulationR': self.window_insulation.r_value,
-            'glazingTypesEnglish': self.window_code.glazing_type.english if self.window_code else None,
-            'glazingTypesFrench': self.window_code.glazing_type.french if self.window_code else None,
+
+            'glazingTypesEnglish': self.window_code.glazing_type.english
+            if self.window_code and self.window_code.glazing_type else None,
+
+            'glazingTypesFrench': self.window_code.glazing_type.french
+            if self.window_code and self.window_code.glazing_type else None,
+
             'coatingsTintsEnglish': self.window_code.coating_tint.english if self.window_code else None,
             'coatingsTintsFrench': self.window_code.coating_tint.french if self.window_code else None,
 

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -55,8 +55,11 @@ class Window(_Window):
             'glazingTypesFrench': self.window_code.glazing_type.french
             if self.window_code and self.window_code.glazing_type else None,
 
-            'coatingsTintsEnglish': self.window_code.coating_tint.english if self.window_code else None,
-            'coatingsTintsFrench': self.window_code.coating_tint.french if self.window_code else None,
+            'coatingsTintsEnglish': self.window_code.coating_tint.english
+            if self.window_code and self.window_code.coating_tint else None,
+
+            'coatingsTintsFrench': self.window_code.coating_tint.french
+            if self.window_code and self.window_code.coating_tint else None,
 
             'fillTypeEnglish': self.window_code.fill_type.english
             if self.window_code and self.window_code.fill_type else None,

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -56,10 +56,10 @@ class Window(_Window):
         code_tags: typing.Dict[str, typing.Optional[str]] = dict(
             item
             for _, tag_name in self._CODE_TAG_TRANSLATIONS
-            for item in {
-                f'{tag_name}English': None,
-                f'{tag_name}French': None,
-            }.items()
+            for item in [
+                (f'{tag_name}English', None),
+                (f'{tag_name}French', None),
+            ]
         )
 
         if self.window_code:

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -52,10 +52,19 @@ class Window(_Window):
             'glazingTypesFrench': self.window_code.glazing_type.french if self.window_code else None,
             'coatingsTintsEnglish': self.window_code.coating_tint.english if self.window_code else None,
             'coatingsTintsFrench': self.window_code.coating_tint.french if self.window_code else None,
-            'fillTypeEnglish': self.window_code.fill_type.english if self.window_code else None,
-            'fillTypeFrench': self.window_code.fill_type.french if self.window_code else None,
-            'spacerTypeEnglish': self.window_code.spacer_type.english if self.window_code else None,
-            'spacerTypeFrench': self.window_code.spacer_type.french if self.window_code else None,
+
+            'fillTypeEnglish': self.window_code.fill_type.english
+            if self.window_code and self.window_code.fill_type else None,
+
+            'fillTypeFrench': self.window_code.fill_type.french
+            if self.window_code and self.window_code.fill_type else None,
+
+            'spacerTypeEnglish': self.window_code.spacer_type.english
+            if self.window_code and self.window_code.spacer_type else None,
+
+            'spacerTypeFrench': self.window_code.spacer_type.french
+            if self.window_code and self.window_code.spacer_type else None,
+
             'typeEnglish': self.window_code.window_code_type.english if self.window_code else None,
             'typeFrench': self.window_code.window_code_type.french if self.window_code else None,
             'frameMaterialEnglish': self.window_code.frame_material.english if self.window_code else None,

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -20,6 +20,15 @@ class _Window(typing.NamedTuple):
 
 class Window(_Window):
 
+    _CODE_TAG_TRANSLATIONS = {
+        code.WindowCodeTag.GLAZING_TYPE: 'glazingTypes',
+        code.WindowCodeTag.COATING_TINTS: 'coatingsTints',
+        code.WindowCodeTag.FILL_TYPE: 'fillType',
+        code.WindowCodeTag.SPACER_TYPE: 'spacerType',
+        code.WindowCodeTag.CODE_TYPE: 'type',
+        code.WindowCodeTag.FRAME_MATERIAL: 'frameMaterial',
+    }
+
     @classmethod
     def from_data(cls,
                   window: element.Element,
@@ -44,47 +53,30 @@ class Window(_Window):
         return area.Area(self.width.metres * self.height.metres)
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
+        code_tags: typing.Dict[str, typing.Optional[str]] = dict(
+            item
+            for tag_name in self._CODE_TAG_TRANSLATIONS.values()
+            for item in {
+                f'{tag_name}English': None,
+                f'{tag_name}French': None,
+            }.items()
+        )
+
+        if self.window_code:
+            for tag_type, tag_name in self._CODE_TAG_TRANSLATIONS.items():
+                tag_value = self.window_code.tags.get(tag_type)
+                code_tags.update(
+                    **{
+                        f'{tag_name}English': tag_value.english if tag_value else None,
+                        f'{tag_name}French': tag_value.french if tag_value else None,
+                    }
+                )
+
         return {
             'label': self.label,
             'insulationRsi': self.window_insulation.rsi,
             'insulationR': self.window_insulation.r_value,
-
-            'glazingTypesEnglish': self.window_code.glazing_type.english
-            if self.window_code and self.window_code.glazing_type else None,
-
-            'glazingTypesFrench': self.window_code.glazing_type.french
-            if self.window_code and self.window_code.glazing_type else None,
-
-            'coatingsTintsEnglish': self.window_code.coating_tint.english
-            if self.window_code and self.window_code.coating_tint else None,
-
-            'coatingsTintsFrench': self.window_code.coating_tint.french
-            if self.window_code and self.window_code.coating_tint else None,
-
-            'fillTypeEnglish': self.window_code.fill_type.english
-            if self.window_code and self.window_code.fill_type else None,
-
-            'fillTypeFrench': self.window_code.fill_type.french
-            if self.window_code and self.window_code.fill_type else None,
-
-            'spacerTypeEnglish': self.window_code.spacer_type.english
-            if self.window_code and self.window_code.spacer_type else None,
-
-            'spacerTypeFrench': self.window_code.spacer_type.french
-            if self.window_code and self.window_code.spacer_type else None,
-
-            'typeEnglish': self.window_code.window_code_type.english
-            if self.window_code and self.window_code.window_code_type else None,
-
-            'typeFrench': self.window_code.window_code_type.french
-            if self.window_code and self.window_code.window_code_type else None,
-
-            'frameMaterialEnglish': self.window_code.frame_material.english
-            if self.window_code and self.window_code.frame_material else None,
-
-            'frameMaterialFrench': self.window_code.frame_material.french
-            if self.window_code and self.window_code.frame_material else None,
-
+            **code_tags,
             'areaMetres': self._window_area.square_metres,
             'areaFeet': self._window_area.square_feet,
             'widthMetres': self.width.metres,

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -20,14 +20,14 @@ class _Window(typing.NamedTuple):
 
 class Window(_Window):
 
-    _CODE_TAG_TRANSLATIONS = {
-        code.WindowCodeTag.GLAZING_TYPE: 'glazingTypes',
-        code.WindowCodeTag.COATING_TINTS: 'coatingsTints',
-        code.WindowCodeTag.FILL_TYPE: 'fillType',
-        code.WindowCodeTag.SPACER_TYPE: 'spacerType',
-        code.WindowCodeTag.CODE_TYPE: 'type',
-        code.WindowCodeTag.FRAME_MATERIAL: 'frameMaterial',
-    }
+    _CODE_TAG_TRANSLATIONS = [
+        (code.WindowCodeTag.GLAZING_TYPE, 'glazingTypes'),
+        (code.WindowCodeTag.COATING_TINTS, 'coatingsTints'),
+        (code.WindowCodeTag.FILL_TYPE, 'fillType'),
+        (code.WindowCodeTag.SPACER_TYPE, 'spacerType'),
+        (code.WindowCodeTag.CODE_TYPE, 'type'),
+        (code.WindowCodeTag.FRAME_MATERIAL, 'frameMaterial'),
+    ]
 
     @classmethod
     def from_data(cls,
@@ -55,7 +55,7 @@ class Window(_Window):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         code_tags: typing.Dict[str, typing.Optional[str]] = dict(
             item
-            for tag_name in self._CODE_TAG_TRANSLATIONS.values()
+            for _, tag_name in self._CODE_TAG_TRANSLATIONS
             for item in {
                 f'{tag_name}English': None,
                 f'{tag_name}French': None,
@@ -63,7 +63,7 @@ class Window(_Window):
         )
 
         if self.window_code:
-            for tag_type, tag_name in self._CODE_TAG_TRANSLATIONS.items():
+            for tag_type, tag_name in self._CODE_TAG_TRANSLATIONS:
                 tag_value = self.window_code.tags.get(tag_type)
                 code_tags.update(
                     **{

--- a/etl/src/energuide/embedded/window.py
+++ b/etl/src/energuide/embedded/window.py
@@ -73,10 +73,18 @@ class Window(_Window):
             'spacerTypeFrench': self.window_code.spacer_type.french
             if self.window_code and self.window_code.spacer_type else None,
 
-            'typeEnglish': self.window_code.window_code_type.english if self.window_code else None,
-            'typeFrench': self.window_code.window_code_type.french if self.window_code else None,
-            'frameMaterialEnglish': self.window_code.frame_material.english if self.window_code else None,
-            'frameMaterialFrench': self.window_code.frame_material.french if self.window_code else None,
+            'typeEnglish': self.window_code.window_code_type.english
+            if self.window_code and self.window_code.window_code_type else None,
+
+            'typeFrench': self.window_code.window_code_type.french
+            if self.window_code and self.window_code.window_code_type else None,
+
+            'frameMaterialEnglish': self.window_code.frame_material.english
+            if self.window_code and self.window_code.frame_material else None,
+
+            'frameMaterialFrench': self.window_code.frame_material.french
+            if self.window_code and self.window_code.frame_material else None,
+
             'areaMetres': self._window_area.square_metres,
             'areaFeet': self._window_area.square_feet,
             'widthMetres': self.width.metres,

--- a/etl/tests/embedded/test_code.py
+++ b/etl/tests/embedded/test_code.py
@@ -91,16 +91,7 @@ BAD_WINDOW_CODE_XML = [
         </FrameMaterial>
     </Layers>
 </Code>
-    """,
-
-    # This XML block is missing all the tags under <Layers>
     """
-<Code id='Code 11'>
-    <Label>202002</Label>
-    <Layers>
-    </Layers>
-</Code>
-    """,
 ]
 
 

--- a/etl/tests/embedded/test_code.py
+++ b/etl/tests/embedded/test_code.py
@@ -43,19 +43,6 @@ BAD_WALL_CODE_XML = [
     </Layers>
 </Code>
     """,
-
-    # This XML block is missing the <StructureType> tag
-    """
-<Code id='Code 1'>
-    <Label>1201101121</Label>
-    <Layers>
-        <ComponentTypeSize>
-            <English>38x89 mm (2x4 in)</English>
-            <French>38x89 (2x4)</French>
-        </ComponentTypeSize>
-    </Layers>
-</Code>
-    """,
 ]
 
 
@@ -100,14 +87,16 @@ def wall_code() -> code.WallCode:
     return code.WallCode(
         identifier='Code 1',
         label='1201101121',
-        structure_type=bilingual.Bilingual(
-            english='Wood frame',
-            french='Ossature de bois',
-        ),
-        component_type_size=bilingual.Bilingual(
-            english='38x89 mm (2x4 in)',
-            french='38x89 (2x4)',
-        )
+        tags={
+            code.WallCodeTag.STRUCTURE_TYPE: bilingual.Bilingual(
+                english='Wood frame',
+                french='Ossature de bois',
+            ),
+            code.WallCodeTag.COMPONENT_TYPE_SIZE: bilingual.Bilingual(
+                english='38x89 mm (2x4 in)',
+                french='38x89 (2x4)',
+            )
+        },
     )
 
 
@@ -152,15 +141,17 @@ def window_code() -> code.WindowCode:
     return code.WindowCode(
         identifier='Code 11',
         label='202002',
-        glazing_type=bilingual.Bilingual(
-            english='Double/double with 1 coat',
-            french='Double/double, 1 couche',
-        ),
-        coating_tint=bilingual.Bilingual(english='Clear', french='Transparent'),
-        fill_type=bilingual.Bilingual(english='6 mm Air', french="6 mm d'air"),
-        spacer_type=bilingual.Bilingual(english='Metal', french='Métal'),
-        window_code_type=bilingual.Bilingual(english='Picture', french='Fixe'),
-        frame_material=bilingual.Bilingual(english='Wood', french='Bois'),
+        tags={
+            code.WindowCodeTag.GLAZING_TYPE: bilingual.Bilingual(
+                english='Double/double with 1 coat',
+                french='Double/double, 1 couche',
+            ),
+            code.WindowCodeTag.COATING_TINTS: bilingual.Bilingual(english='Clear', french='Transparent'),
+            code.WindowCodeTag.FILL_TYPE: bilingual.Bilingual(english='6 mm Air', french="6 mm d'air"),
+            code.WindowCodeTag.SPACER_TYPE: bilingual.Bilingual(english='Metal', french='Métal'),
+            code.WindowCodeTag.CODE_TYPE: bilingual.Bilingual(english='Picture', french='Fixe'),
+            code.WindowCodeTag.FRAME_MATERIAL: bilingual.Bilingual(english='Wood', french='Bois'),
+        }
     )
 
 

--- a/etl/tests/embedded/test_wall.py
+++ b/etl/tests/embedded/test_wall.py
@@ -61,14 +61,16 @@ def sample_wall_code() -> typing.Dict[str, code.WallCode]:
     return {'Code 1': code.WallCode(
         identifier='Code 1',
         label='1201101121',
-        structure_type=bilingual.Bilingual(
-            english='Wood frame',
-            french='Ossature de bois',
-        ),
-        component_type_size=bilingual.Bilingual(
-            english='38x89 mm (2x4 in)',
-            french='38x89 (2x4)',
-        )
+        tags={
+            code.WallCodeTag.STRUCTURE_TYPE: bilingual.Bilingual(
+                english='Wood frame',
+                french='Ossature de bois',
+            ),
+            code.WallCodeTag.COMPONENT_TYPE_SIZE: bilingual.Bilingual(
+                english='38x89 mm (2x4 in)',
+                french='38x89 (2x4)',
+            )
+        },
     )}
 
 

--- a/etl/tests/embedded/test_window.py
+++ b/etl/tests/embedded/test_window.py
@@ -63,15 +63,17 @@ def sample_window_code() -> typing.Dict[str, code.WindowCode]:
     return {'Code 11': code.WindowCode(
         identifier='Code 11',
         label='202002',
-        glazing_type=bilingual.Bilingual(
-            english='Double/double with 1 coat',
-            french='Double/double, 1 couche',
-        ),
-        coating_tint=bilingual.Bilingual(english='Clear', french='Transparent'),
-        fill_type=bilingual.Bilingual(english='6 mm Air', french="6 mm d'air"),
-        spacer_type=bilingual.Bilingual(english='Metal', french='Métal'),
-        window_code_type=bilingual.Bilingual(english='Picture', french='Fixe'),
-        frame_material=bilingual.Bilingual(english='Wood', french='Bois'),
+        tags={
+            code.WindowCodeTag.GLAZING_TYPE: bilingual.Bilingual(
+                english='Double/double with 1 coat',
+                french='Double/double, 1 couche',
+            ),
+            code.WindowCodeTag.COATING_TINTS: bilingual.Bilingual(english='Clear', french='Transparent'),
+            code.WindowCodeTag.FILL_TYPE: bilingual.Bilingual(english='6 mm Air', french="6 mm d'air"),
+            code.WindowCodeTag.SPACER_TYPE: bilingual.Bilingual(english='Metal', french='Métal'),
+            code.WindowCodeTag.CODE_TYPE: bilingual.Bilingual(english='Picture', french='Fixe'),
+            code.WindowCodeTag.FRAME_MATERIAL: bilingual.Bilingual(english='Wood', french='Bois'),
+        }
     )}
 
 

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -588,28 +588,35 @@ class TestParsedDwellingDataRow:
         wall_code = code.WallCode(
             identifier='Code 1',
             label='1201101121',
-            structure_type=bilingual.Bilingual(
-                english='Wood frame',
-                french='Ossature de bois',
-            ),
-            component_type_size=bilingual.Bilingual(
-                english='38x89 mm (2x4 in)',
-                french='38x89 (2x4)',
-            )
+            tags={
+                code.WallCodeTag.STRUCTURE_TYPE: bilingual.Bilingual(
+                    english='Wood frame',
+                    french='Ossature de bois',
+                ),
+                code.WallCodeTag.COMPONENT_TYPE_SIZE: bilingual.Bilingual(
+                    english='38x89 mm (2x4 in)',
+                    french='38x89 (2x4)',
+                )
+            },
         )
 
         window_code = code.WindowCode(
             identifier='Code 12',
             label='234002',
-            glazing_type=bilingual.Bilingual(
-                english='Double/double with 1 coat',
-                french='Double/double, 1 couche',
-            ),
-            coating_tint=bilingual.Bilingual(english='Low-E .20 (hard1)', french='Faible E .20 (Dur 1)'),
-            fill_type=bilingual.Bilingual(english='9 mm Argon', french="9 mm d'argon"),
-            spacer_type=bilingual.Bilingual(english='Metal', french='Métal'),
-            window_code_type=bilingual.Bilingual(english='Picture', french='Fixe'),
-            frame_material=bilingual.Bilingual(english='Wood', french='Bois'),
+            tags={
+                code.WindowCodeTag.GLAZING_TYPE: bilingual.Bilingual(
+                    english='Double/double with 1 coat',
+                    french='Double/double, 1 couche',
+                ),
+                code.WindowCodeTag.COATING_TINTS: bilingual.Bilingual(
+                    english='Low-E .20 (hard1)',
+                    french='Faible E .20 (Dur 1)'
+                ),
+                code.WindowCodeTag.FILL_TYPE: bilingual.Bilingual(english='9 mm Argon', french="9 mm d'argon"),
+                code.WindowCodeTag.SPACER_TYPE: bilingual.Bilingual(english='Metal', french='Métal'),
+                code.WindowCodeTag.CODE_TYPE: bilingual.Bilingual(english='Picture', french='Fixe'),
+                code.WindowCodeTag.FRAME_MATERIAL: bilingual.Bilingual(english='Wood', french='Bois'),
+            }
         )
 
         assert output == dwelling.ParsedDwellingDataRow(


### PR DESCRIPTION
This PR changes the various information tags in Window and Wall codes to be optional (as it seems from our recent data dump that any of them can be missing).

This change also prompted a general refactor of window and wall codes to make it easier to serialize `Window` and `Wall` objects in their `to_dict` methods to not need to do an explicit check each tag type, getting the english and french text if it exists and using `None` if not.