### PR TITLE
Rename workflow job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,6 +345,6 @@ workflows:
             - extract_endpoint
             - node_integration
       -
-        deploy:
+        deploy_api:
           requires:
             - yarn_build


### PR DESCRIPTION
This PR changes the name of the job to run in the `node_and+python` workflow from `deploy` to `deploy_api`, what it was renamed to in https://github.com/cds-snc/nrcan_api/pull/266