### PR TITLE
Makefile for easy installation & running of azurite for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 **/.mypy_cache/
 etl/env
 extract_endpoint/env
+extract_endpoint/tests/azure_emulator
 .python-version
 .env
 .idea

--- a/extract_endpoint/Makefile
+++ b/extract_endpoint/Makefile
@@ -1,0 +1,32 @@
+SHELL ?= /usr/bin/bash
+VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/env || echo $$VIRTUAL_ENV)
+
+.PHONY: virtualenv
+virtualenv:
+	[ -z $$VIRTUAL_ENV ] && [ ! -d env ] && python3 -m venv env || true
+
+.PHONY: setup_python
+setup_python:  virtualenv requirements.txt
+	${VIRTUALENV_ROOT}/bin/pip install -q -r requirements.txt
+	${VIRTUALENV_ROOT}/bin/pip install -q -e .
+
+.PHONY: setup_project
+setup_project: setup_python
+	npm install -g azurite
+
+.PHONY: test_python
+test_python: virtualenv is_azurite_running
+	${VIRTUALENV_ROOT}/bin/pytest tests
+	${VIRTUALENV_ROOT}/bin/pylint src tests
+	${VIRTUALENV_ROOT}/bin/mypy src tests --ignore-missing-imports
+	rm -rf tests/azure_emulator
+
+.PHONY: start_azurite
+start_azurite:
+	mkdir -p tests/azure_emulator
+	azurite-blob -l tests/azure_emulator/data
+
+is_azurite_running:
+	(echo >/dev/tcp/localhost/10000) &>/dev/null && echo "Azurite is running" || ( echo "Please start Azurite before running tests (run make start_azurite in a new terminal window)" & exit 1 )
+
+.ONESHELL:

--- a/extract_endpoint/Makefile
+++ b/extract_endpoint/Makefile
@@ -19,7 +19,6 @@ test_python: virtualenv is_azurite_running
 	${VIRTUALENV_ROOT}/bin/pytest tests
 	${VIRTUALENV_ROOT}/bin/pylint src tests
 	${VIRTUALENV_ROOT}/bin/mypy src tests --ignore-missing-imports
-	rm -rf tests/azure_emulator
 
 .PHONY: start_azurite
 start_azurite:


### PR DESCRIPTION
This PR adds a Makefile to simplify installing & running the mac compatible Azure emulator Azurite for running tests. This Makefile borrows from the ETL Makefile and adds the following:

* a setup_project command that runs the setup_python step & installs azurite globally via NPM
* a start_azurite command that should be used in a separate terminal window to start the emulator
* a is_azurite_running command that is added to the test_python command. This checks to see if Azurite is running before starting the python tests and exits the script if it isn't

I played with running Azurite as a background process, but I think having it as a process in a separate window makes the most sense. There may be times having the output from the emulator will be useful for debugging issues. 

To do: create a proper readme for the extract_endpoint