### PR TITLE
Accept btu/h unit

### DIFF
--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -82,7 +82,7 @@ class Heating(_Heating):
         capacity: typing.Optional[float]
         if units == 'kW':
             capacity = capacity_value
-        elif units == 'btu/hr':
+        elif units == 'btu/hr' or units == 'btu/h':
             capacity = capacity_value / cls._KWH_TO_BTU
         else:
             raise InvalidEmbeddedDataTypeError(

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -105,8 +105,9 @@ def test_from_data(sample_raw: element.Element, sample: heating.Heating) -> None
     assert output == sample
 
 
-def test_converts_btu() -> None:
-    specification_node = sample_specifications(capacity=1000.0, capacity_units='btu/hr')
+@pytest.mark.parametrize("unit", ['btu/hr', 'btu/h'])
+def test_converts_btu(unit: str) -> None:
+    specification_node = sample_specifications(capacity=1000.0, capacity_units=unit)
     node = sample_node(specification_node=specification_node)
     output = heating.Heating.from_data(node)
     assert output.output_size == 0.2930710386613453


### PR DESCRIPTION
This PR adds a check to `heating` to accept `btu/h` as a valid unit.

Logs have shown that both are present in the data.