### PR TITLE
New heating source codes

### DIFF
--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -73,7 +73,7 @@ class Heating(_Heating):
                                                        'Soft Wood or Wood Pellets)',
                                                french='Chauffage au bois(Bois mélangé, Bois dur, Bois mou, '
                                                       'Granules de bois)'),
-        EnergySource.HARDWOOD: bilingual.Bilingual(englis='Hardwood',
+        EnergySource.HARDWOOD: bilingual.Bilingual(english='Hardwood',
                                                    french='Bois dur'),
     }
 

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -71,7 +71,7 @@ class Heating(_Heating):
         EnergySource.WOOD: bilingual.Bilingual(english='Wood Space Heating (Mixed Wood, Hardwood, '
                                                        'Soft Wood or Wood Pellets)',
                                                french='Chauffage au bois(Bois mélangé, Bois dur, Bois mou, '
-                                                      'Granules de bois)')
+                                                      'Granules de bois)'),
     }
 
     @classmethod

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -19,6 +19,7 @@ class EnergySource(enum.Enum):
     OIL = enum.auto()
     PROPANE = enum.auto()
     WOOD = enum.auto()
+    HARDWOOD = enum.auto()
 
 
 class _Heating(typing.NamedTuple):
@@ -54,11 +55,12 @@ class Heating(_Heating):
     }
 
     _ENERGY_SOURCE_CODES = {
-        1: EnergySource.ELECTRIC
+        1: EnergySource.ELECTRIC,
         2: EnergySource.NATURAL_GAS,
         3: EnergySource.OIL,
         4: EnergySource.PROPANE,
         5: EnergySource.WOOD,
+        6: EnergySource.HARDWOOD,
     }
 
     _ENERGY_SOURCE_TRANSLATIONS = {
@@ -71,6 +73,8 @@ class Heating(_Heating):
                                                        'Soft Wood or Wood Pellets)',
                                                french='Chauffage au bois(Bois mélangé, Bois dur, Bois mou, '
                                                       'Granules de bois)'),
+        EnergySource.HARDWOOD: bilingual.Bilingual(englis='Hardwood',
+                                                   french='Bois dur'),
     }
 
     @classmethod

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -60,7 +60,7 @@ class Heating(_Heating):
         3: EnergySource.OIL,
         4: EnergySource.PROPANE,
         5: EnergySource.WOOD,
-        6: EnergySource.HARDWOOD,
+        6: EnergySource.WOOD,
     }
 
     _ENERGY_SOURCE_TRANSLATIONS = {
@@ -72,9 +72,7 @@ class Heating(_Heating):
         EnergySource.WOOD: bilingual.Bilingual(english='Wood Space Heating (Mixed Wood, Hardwood, '
                                                        'Soft Wood or Wood Pellets)',
                                                french='Chauffage au bois(Bois mélangé, Bois dur, Bois mou, '
-                                                      'Granules de bois)'),
-        EnergySource.HARDWOOD: bilingual.Bilingual(english='Hardwood',
-                                                   french='Bois dur'),
+                                                      'Granules de bois)')
     }
 
     @classmethod

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -54,6 +54,7 @@ class Heating(_Heating):
     }
 
     _ENERGY_SOURCE_CODES = {
+        1: EnergySource.ELECTRIC
         2: EnergySource.NATURAL_GAS,
         3: EnergySource.OIL,
         4: EnergySource.PROPANE,

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -19,7 +19,6 @@ class EnergySource(enum.Enum):
     OIL = enum.auto()
     PROPANE = enum.auto()
     WOOD = enum.auto()
-    HARDWOOD = enum.auto()
 
 
 class _Heating(typing.NamedTuple):

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -135,15 +135,16 @@ def test_boiler() -> None:
     assert output.heating_type == heating.HeatingType.BOILER
 
 
-def test_wood_energy_source() -> None:
-    equipment_node = sample_equipment(energy_source_code=5)
+@pytest.mark.parametrize("energy_code", [5, 6])
+def test_wood_energy_source(energy_code: int) -> None:
+    equipment_node = sample_equipment(energy_source_code=energy_code)
     node = sample_node(equipment_node=equipment_node)
     output = heating.Heating.from_data(node)
     assert output.energy_source == heating.EnergySource.WOOD
 
 
 def test_unknown_energy_source_code() -> None:
-    equipment_node = sample_equipment(energy_source_code=6)
+    equipment_node = sample_equipment(energy_source_code=7)
     node = sample_node(equipment_node=equipment_node)
 
     with pytest.raises(InvalidEmbeddedDataTypeError) as ex:


### PR DESCRIPTION
This PR adds 2 new entries to the `_ENERGY_SOURCE_CODES` dictionary now that we have data that has revealed which code goes to which energy source.