### PR TITLE
Fix Mike's typo

### DIFF
--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -173,11 +173,6 @@ const Resolvers = i18n => {
         return result
       },
     },
-    Evaluation: {
-      energyUpgrades: async root => {
-        return root.energyUgrades
-      },
-    },
     Field: {
       dwellingHouseId: dwellingHouseId.toString(),
       dwellingYearBuilt: dwellingYearBuilt.toString(),

--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -334,7 +334,7 @@ class Evaluation:
             'waterHeatings': [water_heating.to_dict() for water_heating in self.water_heatings],
             'foundations': [foundation.to_dict() for foundation in self.foundations],
             'ersRating': self.ers_rating,
-            'energyUgrades': [upgrade.to_dict() for upgrade in self.energy_upgrades],
+            'energyUpgrades': [upgrade.to_dict() for upgrade in self.energy_upgrades],
             'heating': self.heating_system.to_dict(),
             'fileId': self.file_id,
         }


### PR DESCRIPTION
This PR fixes the typo in the serialization of evaluation of `energyUgrades` to `energyUpgrades`