### PR TITLE
Only deploy endpoint from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ workflows:
       - etl
       - extract_endpoint
       - python_integration
-      - deploy_endpoint
+      - deploy_endpoint:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,12 @@ workflows:
       - extract_endpoint
       - python_integration
       - deploy_endpoint
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - extract_endpoint
       -
         node_integration:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,9 @@ workflows:
                 - master
           requires:
             - extract_endpoint
+            - python_integration
+            - etl
+            - node
       -
         node_integration:
           requires:


### PR DESCRIPTION
The PR changes the CI configuration to only deploy_endpoint on master, and only if extact_endpoint job succeeded