### PR TITLE
Extract "other data"

### DIFF
--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -101,7 +101,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
 
 
 def _cast_nullable_string(value: str) -> typing.Optional[int]:
-    if value == '':
+    if not value:
         return None
     return int(value)
 
@@ -121,7 +121,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'CLIENTCITY': {'type': 'string', 'required': True},
         'forwardSortationArea': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z]'},
         'HOUSEREGION': {'type': 'string', 'required': True},
-        'ERSRATING': {'type': 'integer', 'nullable': True, 'coerce': _cast_nullable_string},
+        'ersRating': {'type': 'integer', 'nullable': True, 'coerce': _cast_nullable_string},
         'BUILDER': {'type': 'string', 'required': True},
 
         'ceilings': _XML_LIST_SCHEMA,
@@ -183,7 +183,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
                           for ventilation_node in parsed['ventilations']],
             heating_system=heating.Heating.from_data(parsed['heating_cooling']),
             foundations=foundations,
-            ers_rating=parsed['ERSRATING'],
+            ers_rating=parsed['ersRating'],
             energy_upgrades=[upgrade.Upgrade.from_data(upgrade_node) for upgrade_node in parsed['upgrades']],
             file_id=parsed['BUILDER'],
         )

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -86,7 +86,7 @@ def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterato
             energy_snippets = snippets.snip_energy_upgrades(upgrades_node[0])
             row = _safe_merge(row, energy_snippets.to_dict())
 
-        tsv_fields = snippets.snip_tsv(doc)
+        tsv_fields = snippets.snip_other_data(doc)
         row = _safe_merge(row, tsv_fields.to_dict())
         yield row
 

--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -14,19 +14,16 @@ REQUIRED_FIELDS = [
     'EVAL_ID',
     'EVAL_TYPE',
     'BUILDER',
-    'DHWHPCOP',
-    'ERSRATING',
     'ENTRYDATE',
     'CREATIONDATE',
     'MODIFICATIONDATE',
     'YEARBUILT',
     'CLIENTCITY',
     'HOUSEREGION',
-    'CLIENTPCODE',
     'RAW_XML',
 ]
 
-NULLABLE_FIELDS = ['MODIFICATIONDATE', 'ERSRATING']
+NULLABLE_FIELDS = ['MODIFICATIONDATE']
 
 INPUT_SCHEMA = {field: {'type': 'string', 'required': True} for field in REQUIRED_FIELDS}
 for field in NULLABLE_FIELDS:
@@ -73,8 +70,6 @@ def _safe_merge(data: reader.InputData, extra: reader.InputData) -> reader.Input
 
 def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterator[reader.InputData]:
     for row in data:
-        row['forwardSortationArea'] = row['CLIENTPCODE'][:3]
-
         doc = element.Element.from_string(row['RAW_XML'])
         house_node = doc.xpath('House')
         if house_node:
@@ -91,6 +86,8 @@ def _extract_snippets(data: typing.Iterable[reader.InputData]) -> typing.Iterato
             energy_snippets = snippets.snip_energy_upgrades(upgrades_node[0])
             row = _safe_merge(row, energy_snippets.to_dict())
 
+        tsv_fields = snippets.snip_tsv(doc)
+        row = _safe_merge(row, tsv_fields.to_dict())
         yield row
 
 

--- a/etl/src/energuide/snippets.py
+++ b/etl/src/energuide/snippets.py
@@ -65,12 +65,12 @@ class EnergyUpgradesSnippet(_EnergyUpgradesSnippet):
         }
 
 
-class _TsvSnippet(typing.NamedTuple):
+class _OtherDataSnippet(typing.NamedTuple):
     forward_sortation_area: typing.Optional[str]
     ers_rating: typing.Optional[str]
 
 
-class TsvSnippet(_TsvSnippet):
+class OtherDataSnippet(_OtherDataSnippet):
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
@@ -92,11 +92,11 @@ def _get_nullable_fields(root: element.Element, path: str) -> typing.Optional[st
     return data
 
 
-def snip_tsv(root: element.Element) -> TsvSnippet:
+def snip_other_data(root: element.Element) -> OtherDataSnippet:
     postal_code = _get_nullable_fields(root, 'ProgramInformation/Client/StreetAddress/PostalCode/text()')
-    return TsvSnippet(
+    return OtherDataSnippet(
         forward_sortation_area=postal_code[0:3] if postal_code else None,
-        ers_rating=_get_nullable_fields(root, 'AllResults/Results/Tsv/ERSRATING/text()'),
+        ers_rating=_get_nullable_fields(root, 'Program/Results/Tsv/ERSRating/@value'),
     )
 
 

--- a/etl/src/energuide/snippets.py
+++ b/etl/src/energuide/snippets.py
@@ -1,5 +1,6 @@
 import typing
 from energuide import element
+from energuide.exceptions import ElementGetValueError
 
 
 class _Codes(typing.NamedTuple):
@@ -64,8 +65,39 @@ class EnergyUpgradesSnippet(_EnergyUpgradesSnippet):
         }
 
 
+class _TsvSnippet(typing.NamedTuple):
+    forward_sortation_area: typing.Optional[str]
+    ers_rating: typing.Optional[str]
+
+
+class TsvSnippet(_TsvSnippet):
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'forwardSortationArea': self.forward_sortation_area,
+            'ersRating': self.ers_rating,
+        }
+
+
 def _extract_nodes(node: element.Element, path: str) -> typing.List[element.Element]:
     return node.xpath(path)
+
+
+def _get_nullable_fields(root: element.Element, path: str) -> typing.Optional[str]:
+    data: typing.Optional[str]
+    try:
+        data = root.get(path, str)
+    except ElementGetValueError:
+        data = None
+    return data
+
+
+def snip_tsv(root: element.Element) -> TsvSnippet:
+    postal_code = _get_nullable_fields(root, 'ProgramInformation/Client/StreetAddress/PostalCode/text()')
+    return TsvSnippet(
+        forward_sortation_area=postal_code[0:3] if postal_code else None,
+        ers_rating=_get_nullable_fields(root, 'AllResults/Results/Tsv/ERSRATING/text()'),
+    )
 
 
 def snip_house(house: element.Element) -> HouseSnippet:

--- a/etl/tests/randomized_energuide_data.csv
+++ b/etl/tests/randomized_energuide_data.csv
@@ -30907,7 +30907,7 @@ EVAL_ID,IDNUMBER,PARTNER,EVALUATOR,PREVIOUSFILEID,STATUS,CREATIONDATE,MODIFICATI
                 <Street>98SSD00812 Test Street</Street>
                 <City>Calgary</City>
                 <Province>ALBERTA</Province>
-                <PostalCode>T1L 1C1</PostalCode>
+                <PostalCode>C1A 1C1</PostalCode>
             </StreetAddress>
             <MailingAddress>
                 <Name />
@@ -33258,7 +33258,7 @@ EVAL_ID,IDNUMBER,PARTNER,EVALUATOR,PREVIOUSFILEID,STATUS,CREATIONDATE,MODIFICATI
                 <NUMSOLSYS value=""1"" />
                 <TOTCSIA value=""0"" />
                 <LARGESTCSIA value=""0"" />
-                <ERSRating value=""295"" />
+                <ERSRating value=""120"" />
                 <UGRERSRating value=""295"" />
                 <ERSEnergyIntensity value=""0.25"" />
                 <UGRERSEnergyIntensity value=""0.25"" />

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -514,7 +514,7 @@ def sample_input_d(ceiling_input: typing.List[str],
         'crawlspaces': crawlspace_input,
         'slabs': slab_input,
         'codes': raw_codes,
-        'ERSRATING': '567',
+        'ersRating': '567',
         'upgrades': upgrades_input,
     }
 
@@ -829,7 +829,7 @@ class TestParsedDwellingDataRow:
         assert 'EVAL_ID' not in ex.exconly()
 
     def test_missing_ers(self, sample_input_d: reader.InputData) -> None:
-        sample_input_d['ERSRATING'] = ''
+        sample_input_d['ersRating'] = ''
         output = dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
         assert output.ers_rating is None
 

--- a/etl/tests/test_extractor.py
+++ b/etl/tests/test_extractor.py
@@ -146,13 +146,13 @@ def test_extract_with_tsv_snippets(tmpdir: py._path.local.LocalPath, base_data: 
             </StreetAddress>
         </Client>
     </ProgramInformation>
-    <AllResults>
+    <Program>
         <Results>
             <Tsv>
-                <ERSRATING>257</ERSRATING>
+                <ERSRating value='257' />
             </Tsv>
         </Results>
-    </AllResults>
+    </Program>
 </HouseFile>
     """
     base_data['RAW_XML'] = xml_data

--- a/etl/tests/test_snippets.py
+++ b/etl/tests/test_snippets.py
@@ -44,6 +44,17 @@ def test_energy_snippet_to_dict(energy_upgrades: element.Element) -> None:
     assert len(output) == 1
 
 
+def test_other_data_snippet_to_dict() -> None:
+    data = snippets.OtherDataSnippet(
+        forward_sortation_area='H0H',
+        ers_rating='267',
+    )
+    assert data.to_dict() == {
+        'forwardSortationArea': 'H0H',
+        'ersRating': '267',
+    }
+
+
 def test_ceiling_snippet(house: element.Element) -> None:
     output = snippets.snip_house(house)
     assert len(output.ceilings) == 2
@@ -258,3 +269,11 @@ def test_upgrades_snippet(energy_upgrades: element.Element) -> None:
 
     doc = {'upgrades': output.upgrades}
     assert checker.validate(doc)
+
+
+def test_other_data_snippet(doc: element.Element) -> None:
+    output = snippets.snip_other_data(doc)
+    assert output == snippets.OtherDataSnippet(
+        forward_sortation_area='H0H',
+        ers_rating='267',
+    )


### PR DESCRIPTION
This PR moves the extraction of forward sortation area and ErsRating from CSV fields to fields extracted directly from the XML. This is not necessarily a good long-term change, but it does bring the extractor in line with the format of the data that we have. i.e. no Postal code or ERSRating field in the CSV.

This is really to unblock our progress at this end for now, it can be moved back at a later date.