### PR TITLE
Add pytest fixture and example test

### DIFF
--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -93,4 +93,4 @@ def is_azurite_running() -> None:
         return
     else:
         sock.close()
-        pytest.skip()
+        pytest.skip("Azure simulator not running, test skipped")

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -91,5 +91,3 @@ def is_azurite_running() -> None:
     else:
         sock.close()
         pytest.skip()
-
-

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import random
 import typing
+import socket
 
 import py
 import pymongo
@@ -78,3 +79,17 @@ def energuide_zip_fixture(tmpdir: py._path.local.LocalPath, energuide_fixture: s
     data = extractor.extract_data(energuide_fixture)
     extractor.write_data(data, outfile)
     return outfile
+
+
+@pytest.fixture
+def is_azurite_running() -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(("127.0.0.1", 10000))
+    except socket.error:
+        return
+    else:
+        sock.close()
+        pytest.skip()
+
+

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -82,7 +82,7 @@ def energuide_zip_fixture(tmpdir: py._path.local.LocalPath, energuide_fixture: s
 
 
 @pytest.fixture
-def is_azurite_running() -> None:
+def skip_if_azure_simulator_not_running() -> None:
     if 'CIRCLECI' in os.environ:
         return
 

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -83,6 +83,9 @@ def energuide_zip_fixture(tmpdir: py._path.local.LocalPath, energuide_fixture: s
 
 @pytest.fixture
 def is_azurite_running() -> None:
+    if 'CIRCLECI' in os.environ:
+        return
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.bind(("127.0.0.1", 10000))

--- a/etl/tests/test_azure_skip.py
+++ b/etl/tests/test_azure_skip.py
@@ -1,7 +1,6 @@
 import pytest
-import os
 
 
 @pytest.mark.usefixtures('is_azurite_running')
 def test_if_azure_is_running():
-    assert False
+    assert True

--- a/etl/tests/test_azure_skip.py
+++ b/etl/tests/test_azure_skip.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.usefixtures('is_azurite_running')
+def test_if_azure_is_running():
+    assert True

--- a/etl/tests/test_azure_skip.py
+++ b/etl/tests/test_azure_skip.py
@@ -1,6 +1,0 @@
-import pytest
-
-
-@pytest.mark.usefixtures('is_azurite_running')
-def test_if_azure_is_running():
-    assert True

--- a/etl/tests/test_azure_skip.py
+++ b/etl/tests/test_azure_skip.py
@@ -1,6 +1,7 @@
 import pytest
+import os
 
 
 @pytest.mark.usefixtures('is_azurite_running')
 def test_if_azure_is_running():
-    assert True
+    assert False


### PR DESCRIPTION
This PR creates a fixture that attempts to check whether or not the Azure emulator Azurite is running. The fixture checks for the following:

* If the CIRCLECI environment variable exists, run the tests
* If it doesn't exist, try binding to the port Azurite uses (10000)
* If a port error is received (in use), assume it is Azurite & try to run the tests
* If no port error, skip the tests

To use the fixture, add @pytest.mark.usefixtures('is_azurite_running') before any test that requires the Azure emulator