### PR TITLE
:fire: transform.run

### DIFF
--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -48,7 +48,8 @@ def load(username: str,
     else:
         LOGGER.error('Must supply a filename or use azure')
         raise ValueError('Must supply a filename or use azure')
-    transform.run(coords, db_name, collection, azure, filename, append)
+    data = transform.transform(azure, filename)
+    database.load(coords, db_name, collection, data, append)
     LOGGER.info(f'Finished loading data')
 
 

--- a/etl/src/energuide/transform.py
+++ b/etl/src/energuide/transform.py
@@ -4,7 +4,6 @@ import os
 import typing
 import zipfile
 from azure.storage import blob
-from energuide import database
 from energuide import dwelling
 from energuide import logging
 from energuide.exceptions import InvalidEmbeddedDataTypeError
@@ -82,13 +81,3 @@ def transform(azure: bool, filename: typing.Optional[str]) -> typing.Iterator[dw
         output = _generate_dwellings(row_group)
         if output:
             yield output
-
-
-def run(coords: database.DatabaseCoordinates,
-        database_name: str,
-        collection: str,
-        azure: bool,
-        filename: typing.Optional[str],
-        append: bool) -> None:
-    dwellings = transform(azure, filename)
-    database.load(coords, database_name, collection, dwellings, append)

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -1,35 +1,13 @@
 import _pytest
 import pytest
-import pymongo
-from energuide import database
 from energuide import transform
 from energuide.embedded import ceiling
 from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
-def test_run_no_azure(database_coordinates: database.DatabaseCoordinates,
-                      mongo_client: pymongo.MongoClient,
-                      database_name: str,
-                      collection: str,
-                      energuide_zip_fixture: str) -> None:
-
-    transform.run(database_coordinates, database_name, collection, False, energuide_zip_fixture, append=False)
-    assert mongo_client[database_name][collection].count() == 7
-
-
 def test_transform_no_azure(energuide_zip_fixture: str) -> None:
     output = list(transform.transform(False, energuide_zip_fixture))
     assert len(output) == 7
-
-
-@pytest.mark.usefixtures('populated_azure_service')
-def test_run_azure(database_coordinates: database.DatabaseCoordinates,
-                   mongo_client: pymongo.MongoClient,
-                   database_name: str,
-                   collection: str) -> None:
-
-    transform.run(database_coordinates, database_name, collection, True, None, append=False)
-    assert mongo_client[database_name][collection].count() == 7
 
 
 @pytest.mark.usefixtures('populated_azure_service')
@@ -44,11 +22,7 @@ def test_transform_no_azure_no_filename() -> None:
         list(transform.transform(False, None))
 
 
-def test_bad_data(database_coordinates: database.DatabaseCoordinates,
-                  mongo_client: pymongo.MongoClient,
-                  database_name: str,
-                  collection: str,
-                  energuide_zip_fixture: str,
+def test_bad_data(energuide_zip_fixture: str,
                   monkeypatch: _pytest.monkeypatch.MonkeyPatch,
                   capsys: _pytest.capture.CaptureFixture) -> None:
 
@@ -57,8 +31,8 @@ def test_bad_data(database_coordinates: database.DatabaseCoordinates,
 
     monkeypatch.setattr(ceiling.Ceiling, 'from_data', raise_error)
 
-    transform.run(database_coordinates, database_name, collection, False, energuide_zip_fixture, append=False)
-    assert mongo_client[database_name][collection].count() == 0
+    output = list(transform.transform(False, energuide_zip_fixture))
+    assert not output
 
     _, err = capsys.readouterr()
     assert all('Ceiling' in line for line in err.split()[1:-1])


### PR DESCRIPTION
This PR :fire: `transform.run` since it just calls `database.load` anyway. The "transform" and "load" functions are now separated nicely which simplifies tests.