### PR TITLE
Add date filtering to evaluation date fields

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -12,7 +12,6 @@
     "build": "babel src --copy-files --out-dir dist",
     "dockerize": "yarn build && docker build -t cdssnc/nrcan_api .",
     "dbg": "node --inspect-brk node_modules/jest/bin/jest.js",
-    "extract": "lingui extract",
     "extract": "./node_modules/lingui-cli/dist/lingui.js extract",
     "compile": "./node_modules/lingui-cli/dist/lingui.js compile",
     "lint": "eslint src/** test/** --ignore-pattern src/locale",
@@ -33,6 +32,7 @@
     "express": "^4.16.2",
     "express-request-language": "^1.1.15",
     "graphql": "^0.13.1",
+    "graphql-iso-date": "^3.5.0",
     "lingui-i18n": "^1.3.3",
     "mongo-cursor-pagination": "^6.2.0",
     "mongodb": "^3.0.2"

--- a/api/src/schema/enums.js
+++ b/api/src/schema/enums.js
@@ -24,6 +24,15 @@ dwellingFields.forEach(attr => {
   module.exports[generateName('dwelling', attr)] = attachToString(fn)
 })
 
+// The fields on the dwelling type
+const evaluationDateFields = ['entryDate', 'creationDate', 'modificationDate']
+
+evaluationDateFields.forEach(attr => {
+  // eslint-disable-next-line no-new-func
+  let fn = new Function('matcher', `return {"evaluations.${attr}": matcher}`)
+  module.exports[generateName('evaluation', attr)] = attachToString(fn)
+})
+
 // The fields on the ventilation type
 const ventilationFields = [
   'typeEnglish',

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -1,5 +1,6 @@
 import { Resolvers } from './resolvers'
 import { makeExecutableSchema } from 'graphql-tools'
+
 import { createFoundation } from './types/Foundation'
 import { createFoundationFloor } from './types/FoundationFloor'
 import { createFoundationWall } from './types/FoundationWall'
@@ -12,6 +13,7 @@ const Schema = i18n => {
     scalar I18NFloat
     scalar I18NString
     scalar I18NBoolean
+    scalar GraphQLDate
 
     # ${i18n.t`An operator to describe how results will be filtered`}
     enum Comparator {
@@ -32,6 +34,16 @@ const Schema = i18n => {
       comparator: Comparator!
       # ${i18n.t`Results will be compared to this value`}
       value: I18NString!
+    }
+
+    # ${i18n.t`Filter by dwellings containing evaluations that were entered, created, or modified between a range of dates`}
+    input DateRange {
+      # ${i18n.t`Name of the date field results will be filtered by`}
+      field: DateField!
+      # ${i18n.t`Evaluation dates must be equal to or later than this value`}
+      startDate: GraphQLDate
+      # ${i18n.t`Evaluation dates must be equal to or earlier than this value`}
+      endDate: GraphQLDate
     }
 
     # ${i18n.t`An improvement that could increase the energy efficiency of the dwelling`}
@@ -329,7 +341,17 @@ const Schema = i18n => {
       # ${i18n.t`Details for a specific dwelling`}
       dwelling(houseId: I18NInt!): Dwelling
       # ${i18n.t`Details for all dwellings, optionally filtered by one or more values`}
-      dwellings(filters: [Filter!] limit: I18NInt next: I18NString previous: I18NString): PaginatedResultSet
+      dwellings(filters: [Filter!] dateRange: DateRange limit: I18NInt next: I18NString previous: I18NString): PaginatedResultSet
+    }
+
+    # ${i18n.t`An ISO date value, formatted 'YYYY-MM-DD'`}
+    enum DateField {
+      # ${i18n.t`Filter results by the dwellings containing at least one evaluation with a specific entry date`}
+      evaluationEntryDate
+      # ${i18n.t`Filter results by the dwellings containing at least one evaluation with a specific record creation date`}
+      evaluationCreationDate
+      # ${i18n.t`Filter results by the dwellings containing at least one evaluation with a specific record modification date`}
+      evaluationModificationDate
     }
 
     enum Field {

--- a/api/test/enum.test.js
+++ b/api/test/enum.test.js
@@ -25,7 +25,7 @@ describe('Enum values', () => {
     client.close()
   })
 
-  const testData = {
+  const testFields = {
     dwellingHouseId: { testValue: 189250 },
     dwellingYearBuilt: { testValue: 1900 },
     dwellingCity: { testValue: 'Charlottetown' },
@@ -130,17 +130,17 @@ describe('Enum values', () => {
     foundationMaterialFrench: { testValue: 'béton' },
   }
 
-  Object.keys(testData).forEach(functionName => {
+  Object.keys(testFields).forEach(functionName => {
     describe(functionName, () => {
       it('returns a query object capable of returning data', async () => {
-        let { testValue } = testData[functionName] // eslint-disable-line
+        let { testValue } = testFields[functionName] // eslint-disable-line
         let query = enumFunctions[functionName](testValue) //eslint-disable-line
         let result = await collection.findOne(query)
         expect(result).not.toBe(null)
       })
 
       it(`${functionName} is included in the filter field enum`, async () => {
-        let { testValue } = testData[functionName] // eslint-disable-line
+        let { testValue } = testFields[functionName] // eslint-disable-line
         let server = new Server({
           client: collection,
         })
@@ -162,6 +162,23 @@ describe('Enum values', () => {
                }`,
           })
         expect(response.body).not.toHaveProperty('errors')
+      })
+    })
+  })
+
+  const testDates = {
+    evaluationEntryDate: { testValue: '2011-11-18' },
+    evaluationCreationDate: { testValue: '2012-10-01T15:08:41' },
+    evaluationModificationDate: { testValue: '2012-06-09T11:20:20' },
+  }
+
+  Object.keys(testDates).forEach(functionName => {
+    describe(functionName, () => {
+      it('returns a query object capable of returning data', async () => {
+        let { testValue } = testDates[functionName] // eslint-disable-line
+        let query = enumFunctions[functionName](testValue) //eslint-disable-line
+        let result = await collection.findOne(query)
+        expect(result).not.toBe(null)
       })
     })
   })

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -2346,6 +2346,10 @@ graphql-extensions@^0.0.x:
     core-js "^2.5.1"
     source-map-support "^0.5.0"
 
+graphql-iso-date@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.5.0.tgz#55a1be0efa8d28c1453afd2eb5ce1d052189a513"
+
 graphql-tools@^2.21.0:
   version "2.21.0"
   resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-2.21.0.tgz#c0d0fbda6f40a87c8d267a2989ade2ae8b9a288e"


### PR DESCRIPTION
### Add ability to filter evaluations by date

Adds a new input parameter 'dateRange' to the 'dwellings' query.
'dateRange' accepts
- a field name: which date to search on
- a startDate: dates that equal or match this date will be returned
- an endDate: dates that equal or match this date will be returned

A few notes:
- Valid queries include:
  - a field and a startDate
  - a field and an endDate
  - a field, a startDate, and an endDate that comes after the
    startDate

- Invalid queries include:
  - not submitting a field
  - a field, but not submitting a 'startDate' or an 'endDate'
  - a field, and submitting a startDate equal to or later than
    an endDate

- 'creationDate' and 'modificationDate' are both strings that
  include timestamp information, but 'entryDate' is just formatted 
  'YYYY-MM-DD'. In practice, the only difference between these
  formats to users is that 'endDate' can be used to exactly
  match an 'entryDate' but it will never exactly match the others
  More on this below.
- Because we are doing string comparisons in the database against
  strings that include times, a 'startDate' of '2012-10-01' will
  match against a string like '2012-10-01T12:00:00' but an 'endDate'
  of '2012-10-01' won't. So it is best to think of startDate as
  looking for dates that are equal or greater, but endDates as looking
  for dates that are less than, but not equal to it.