### PR TITLE
I18N-ize the Date field description

### DIFF
--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -6,6 +6,7 @@ import {
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql'
+import { GraphQLDate } from 'graphql-iso-date'
 
 let mockServer = new Server({
   client: jest.fn(),
@@ -69,6 +70,17 @@ describe('configuration', () => {
       let { __type: { description } } = response.body.data
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLBoolean.description),
+      )
+    })
+  })
+
+  describe('graphql iso date field', () => {
+    it('GraphQLDate returns the same description as I18NDate', async () => {
+      let response = await makeRequest({ typeName: 'I18NDate' })
+
+      let { __type: { description } } = response.body.data
+      expect(description).toEqual(
+        replaceBackTicksWithSingleQuotes(GraphQLDate.description),
       )
     })
   })

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -13,7 +13,7 @@ const Schema = i18n => {
     scalar I18NFloat
     scalar I18NString
     scalar I18NBoolean
-    scalar GraphQLDate
+    scalar I18NDate
 
     # ${i18n.t`An operator to describe how results will be filtered`}
     enum Comparator {
@@ -41,9 +41,9 @@ const Schema = i18n => {
       # ${i18n.t`Name of the date field results will be filtered by`}
       field: DateField!
       # ${i18n.t`Evaluation dates must be equal to or later than this value`}
-      startDate: GraphQLDate
+      startDate: I18NDate
       # ${i18n.t`Evaluation dates must be equal to or earlier than this value`}
-      endDate: GraphQLDate
+      endDate: I18NDate
     }
 
     # ${i18n.t`An improvement that could increase the energy efficiency of the dwelling`}

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -1,6 +1,5 @@
 import MongoPaging from 'mongo-cursor-pagination'
 import { GraphQLError } from 'graphql'
-import { GraphQLDate } from 'graphql-iso-date'
 
 /* eslint-disable import/named */
 import {
@@ -147,6 +146,7 @@ import { createI18NFloat } from './types/I18NFloat'
 import { createI18NInt } from './types/I18NInt'
 import { createI18NString } from './types/I18NString'
 import { createI18NBoolean } from './types/I18NBoolean'
+import { createI18NDate } from './types/I18NDate'
 
 const Resolvers = i18n => {
   return {
@@ -154,7 +154,7 @@ const Resolvers = i18n => {
     I18NString: createI18NString(i18n),
     I18NFloat: createI18NFloat(i18n),
     I18NBoolean: createI18NBoolean(i18n),
-    GraphQLDate: GraphQLDate,
+    I18NDate: createI18NDate(i18n),
     Query: {
       dwelling: async (root, { houseId }, { client }) => {
         let query = {

--- a/api/src/schema/types/I18NDate.js
+++ b/api/src/schema/types/I18NDate.js
@@ -1,0 +1,11 @@
+import { GraphQLDate } from 'graphql-iso-date'
+
+export const createI18NDate = i18n => {
+  const I18NDate = GraphQLDate
+  I18NDate.description = i18n.t`
+    'A date string, such as 2007-12-03, compliant with the 'full-date' format
+    outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard
+    for representation of dates and times using the Gregorian calendar.'
+  `
+  return I18NDate
+}


### PR DESCRIPTION
Same as with the default scalar types, we need to have a french-language description for our new `GraphQLDate` field.

Note that this PR doesn't add the french description -- just it adds the possibility to add one.