### PR TITLE
Refactor azure/local reading

### DIFF
--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -13,3 +13,4 @@ python-dateutil==2.6.1
 lxml==4.1.1
 coverage==4.5.1
 tqdm==4.19.6
+typing-extensions==3.6.2.1

--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -44,12 +44,15 @@ def load(username: str,
     )
     if azure:
         LOGGER.info(f'Loading data from Azure into {db_name}.{collection}')
+        coords = transform.AzureCoordinates.from_env()
+        reader = transform.AzureExtractReader(coords)
     elif filename:
         LOGGER.info(f'Loading data from {filename} into {db_name}.{collection}')
+        reader = transform.LocalExtractReader(filename)
     else:
         LOGGER.error('Must supply a filename or use azure')
         raise ValueError('Must supply a filename or use azure')
-    data = transform.transform(azure, filename)
+    data = transform.transform(reader)
     database.load(coords, db_name, collection, data, append)
     LOGGER.info(f'Finished loading data')
 

--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -42,10 +42,12 @@ def load(username: str,
         host=host,
         port=port
     )
+
+    reader: transform.ExtractProtocol
     if azure:
         LOGGER.info(f'Loading data from Azure into {db_name}.{collection}')
-        coords = transform.AzureCoordinates.from_env()
-        reader = transform.AzureExtractReader(coords)
+        azure_coords = transform.AzureCoordinates.from_env()
+        reader = transform.AzureExtractReader(azure_coords)
     elif filename:
         LOGGER.info(f'Loading data from {filename} into {db_name}.{collection}')
         reader = transform.LocalExtractReader(filename)

--- a/etl/src/energuide/transform.py
+++ b/etl/src/energuide/transform.py
@@ -1,3 +1,4 @@
+import abc
 import itertools
 import json
 import os
@@ -13,40 +14,67 @@ from energuide.exceptions import EnerguideError
 LOGGER = logging.get_logger(__name__)
 
 
-class AzureCoordinates(typing.NamedTuple):
+class _AzureCoordinates(typing.NamedTuple):
     account: str
     key: str
     container: str
     domain: typing.Optional[str]
 
 
-def _read_local(zip_filename: str) -> typing.Iterator[bytes]:
-    with zipfile.ZipFile(zip_filename) as zip_input:
-        for file in zip_input.namelist():
-            yield zip_input.read(file)
+class AzureCoordinates(_AzureCoordinates):
+    @classmethod
+    def from_env(cls) -> 'AzureCoordinates':
+        return AzureCoordinates(
+            account=os.environ.get('EXTRACT_ENDPOINT_STORAGE_ACCOUNT', ''),
+            key=os.environ.get('EXTRACT_ENDPOINT_STORAGE_KEY', ''),
+            container=os.environ.get('EXTRACT_ENDPOINT_CONTAINER', ''),
+            domain=os.environ.get('EXTRACT_ENDPOINT_STORAGE_DOMAIN', None)
+        )
 
 
-def _read_azure(coords: AzureCoordinates) -> typing.Iterator[bytes]:
-    azure_service = blob.BlockBlobService(account_name=coords.account,
-                                          account_key=coords.key,
-                                          custom_domain=coords.domain)
+class ExtractReader(abc.ABC):
 
-    # itertools.groupby() needs its input sorted by the groupby key. We are assuming that that key is the filename
-    files = sorted([blob_.name for blob_ in azure_service.list_blobs(coords.container)
-                    if 'timestamp' not in blob_.name])
-    for file in files:
-        yield azure_service.get_blob_to_bytes(coords.container, file).content
+    @abc.abstractmethod
+    def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
+        pass
 
 
-def _read(reader: typing.Iterable[bytes]) -> typing.Iterator[typing.Dict[str, typing.Any]]:
-    for content in reader:
-        house = json.loads(content)
-        house['jsonFileName'] = content
-        yield house
+class LocalExtractReader(ExtractReader):
+
+    def __init__(self, zip_filename: str) -> None:
+        self._zip_filename = zip_filename
+
+    def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
+        with zipfile.ZipFile(self._zip_filename) as zip_input:
+            for file in zip_input.namelist():
+                content = zip_input.read(file)
+                house = json.loads(content)
+                house['jsonFileName'] = content
+                yield house
 
 
-def _read_groups(reader: typing.Iterable[bytes]) -> typing.Iterator[typing.List[typing.Dict[str, typing.Any]]]:
-    for group in itertools.groupby(_read(reader), lambda y: y.get(dwelling.Dwelling.GROUPING_FIELD)):
+class AzureExtractReader(ExtractReader):
+
+    def __init__(self, coords: AzureCoordinates) -> None:
+        self._coords = coords
+
+    def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
+        azure_service = blob.BlockBlobService(account_name=self._coords.account,
+                                              account_key=self._coords.key,
+                                              custom_domain=self._coords.domain)
+        # itertools.groupby() needs its input sorted by the groupby key. We are assuming that that key is the filename
+        files = sorted([blob_.name for blob_ in azure_service.list_blobs(self.coords.container)
+                        if 'timestamp' not in blob_.name])
+        for file in files:
+            content = azure_service.get_blob_to_bytes(self.coords.container, file).content
+            house = json.loads(content)
+            house['jsonFileName'] = content
+            yield house
+
+
+def _read_groups(extracted_rows: typing.Iterable[typing.Dict[str, typing.Any]]
+                ) -> typing.Iterator[typing.List[typing.Dict[str, typing.Any]]]:
+    for group in itertools.groupby(extracted_rows, lambda y: y.get(dwelling.Dwelling.GROUPING_FIELD)):
         yield [x for x in group[1]]
 
 
@@ -63,21 +91,8 @@ def _generate_dwellings(grouped: typing.List[typing.Dict[str, typing.Any]]) -> t
     return None
 
 
-def transform(azure: bool, filename: typing.Optional[str]) -> typing.Iterator[dwelling.Dwelling]:
-    if azure:
-        azure_coordinates = AzureCoordinates(
-            account=os.environ.get('EXTRACT_ENDPOINT_STORAGE_ACCOUNT', ''),
-            key=os.environ.get('EXTRACT_ENDPOINT_STORAGE_KEY', ''),
-            container=os.environ.get('EXTRACT_ENDPOINT_CONTAINER', ''),
-            domain=os.environ.get('EXTRACT_ENDPOINT_STORAGE_DOMAIN', None)
-        )
-        data_reader = _read_azure(azure_coordinates)
-    elif filename:
-        data_reader = _read_local(filename)
-    else:
-        raise ValueError("must supply a filename if not using Azure")
-
-    for row_group in _read_groups(data_reader):
+def transform(extract_reader: ExtractReader) -> typing.Iterator[dwelling.Dwelling]:
+    for row_group in _read_groups(extract_reader.extracted_rows()):
         output = _generate_dwellings(row_group)
         if output:
             yield output

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from azure.storage import blob
 from energuide import database
 from energuide import extractor
+from energuide import transform
 
 
 def azure_emulator_is_running() -> bool:
@@ -102,41 +103,45 @@ def sample_fixture() -> str:
     return os.path.join(os.path.dirname(__file__), 'sample.csv')
 
 
-@pytest.fixture
-def azure_container_name() -> str:
-    return 'test-container'
+def _get_blob_service(coords: transform.AzureCoordinates)-> blob.BlockBlobService:
+    return blob.BlockBlobService(account_name=coords.account,
+                                 account_key=coords.key,
+                                 custom_domain=coords.domain)
 
 
 @pytest.fixture
-def azure_service(azure_container_name: str,
-                  monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> typing.Iterator[blob.BlockBlobService]:
+def azure_coordinates(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> transform.AzureCoordinates:
     if not azure_emulator_is_running():
         pytest.skip("Azure emulator is not running.")
 
     account = 'devstoreaccount1'
     key = 'Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
     domain = 'http://127.0.0.1:10000/devstoreaccount1'
+    container_name = 'test-container'
     monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_ACCOUNT', account)
     monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_KEY', key)
     monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_DOMAIN', domain)
-    monkeypatch.setenv('EXTRACT_ENDPOINT_CONTAINER', azure_container_name)
-
-    azure_service = blob.BlockBlobService(account_name=account,
-                                          account_key=key,
-                                          custom_domain=domain)
-    azure_service.create_container(azure_container_name)
-    yield azure_service
-    azure_service.delete_container(azure_container_name)
+    monkeypatch.setenv('EXTRACT_ENDPOINT_CONTAINER', container_name)
+    return transform.AzureCoordinates(key=key, account=account, container=container_name, domain=domain)
 
 
 @pytest.fixture
-def populated_azure_service(azure_service: blob.BlockBlobService,
-                            azure_container_name: str,
-                            energuide_zip_fixture: str) -> blob.BlockBlobService:
+def azure_service(azure_coordinates: transform.AzureCoordinates) -> typing.Iterator[transform.AzureCoordinates]:
+    service = _get_blob_service(azure_coordinates)
+    service.create_container(azure_coordinates.container)
+    yield azure_coordinates
+    service.delete_container(azure_coordinates.container)
+
+
+@pytest.fixture
+def populated_azure_service(azure_service: transform.AzureCoordinates,
+                            energuide_zip_fixture: str) -> transform.AzureCoordinates:
 
     file_z = zipfile.ZipFile(energuide_zip_fixture)
-    azure_service.create_blob_from_text(azure_container_name, 'timestamp.txt', 'Wednesday')
+    service = _get_blob_service(azure_service)
+
+    service.create_blob_from_text(azure_service.container, 'timestamp.txt', 'Wednesday')
     for json_file in [file_z.open(zipinfo) for zipinfo in file_z.infolist()]:
-        azure_service.create_blob_from_bytes(azure_container_name, json_file.name, json_file.read())
+        service.create_blob_from_bytes(azure_service.container, json_file.name, json_file.read())
 
     return azure_service

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -126,7 +126,7 @@ def azure_coordinates(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> transform
 
 
 @pytest.fixture
-def azure_service(azure_coordinates: transform.AzureCoordinates) -> typing.Iterator[transform.AzureCoordinates]:
+def azure_emulator(azure_coordinates: transform.AzureCoordinates) -> typing.Iterator[transform.AzureCoordinates]:
     service = _get_blob_service(azure_coordinates)
     service.create_container(azure_coordinates.container)
     yield azure_coordinates
@@ -134,14 +134,14 @@ def azure_service(azure_coordinates: transform.AzureCoordinates) -> typing.Itera
 
 
 @pytest.fixture
-def populated_azure_service(azure_service: transform.AzureCoordinates,
-                            energuide_zip_fixture: str) -> transform.AzureCoordinates:
+def populated_azure_emulator(azure_emulator: transform.AzureCoordinates,
+                             energuide_zip_fixture: str) -> transform.AzureCoordinates:
 
     file_z = zipfile.ZipFile(energuide_zip_fixture)
-    service = _get_blob_service(azure_service)
+    service = _get_blob_service(azure_emulator)
 
-    service.create_blob_from_text(azure_service.container, 'timestamp.txt', 'Wednesday')
+    service.create_blob_from_text(azure_emulator.container, 'timestamp.txt', 'Wednesday')
     for json_file in [file_z.open(zipinfo) for zipinfo in file_z.infolist()]:
-        service.create_blob_from_bytes(azure_service.container, json_file.name, json_file.read())
+        service.create_blob_from_bytes(azure_emulator.container, json_file.name, json_file.read())
 
-    return azure_service
+    return azure_emulator

--- a/etl/tests/test_cli.py
+++ b/etl/tests/test_cli.py
@@ -96,7 +96,7 @@ def test_load_filename(energuide_zip_fixture: str,
     assert coll.count() == 7
 
 
-@pytest.mark.usefixtures('populated_azure_service')
+@pytest.mark.usefixtures('populated_azure_emulator')
 def test_load_azure(database_name: str,
                     collection: str,
                     mongo_client: pymongo.MongoClient) -> None:

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -11,8 +11,8 @@ def local_reader(energuide_zip_fixture: str) -> transform.LocalExtractReader:
 
 
 @pytest.fixture
-def azure_reader(populated_azure_service: transform.AzureCoordinates) -> transform.AzureExtractReader:
-    return transform.AzureExtractReader(populated_azure_service)
+def azure_reader(populated_azure_emulator: transform.AzureCoordinates) -> transform.AzureExtractReader:
+    return transform.AzureExtractReader(populated_azure_emulator)
 
 
 def test_reader(local_reader: transform.LocalExtractReader) -> None:

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -5,24 +5,50 @@ from energuide.embedded import ceiling
 from energuide.exceptions import InvalidEmbeddedDataTypeError
 
 
-def test_transform_no_azure(energuide_zip_fixture: str) -> None:
-    output = list(transform.transform(False, energuide_zip_fixture))
-    assert len(output) == 7
+@pytest.fixture
+def local_reader(energuide_zip_fixture: str) -> transform.LocalExtractReader:
+    return transform.LocalExtractReader(energuide_zip_fixture)
 
 
-@pytest.mark.usefixtures('populated_azure_service')
-def test_transform_azure() -> None:
-
-    output = list(transform.transform(True, None))
-    assert len(output) == 7
+@pytest.fixture
+def azure_reader(populated_azure_service: transform.AzureCoordinates) -> transform.AzureExtractReader:
+    return transform.AzureExtractReader(populated_azure_service)
 
 
-def test_transform_no_azure_no_filename() -> None:
-    with pytest.raises(ValueError):
-        list(transform.transform(False, None))
+def test_reader(local_reader: transform.LocalExtractReader) -> None:
+    output = list(local_reader.extracted_rows())
+    unique_builders = {row['BUILDER'] for row in output}
+    assert len(output) == 14
+    assert len(unique_builders) == 14
 
 
-def test_bad_data(energuide_zip_fixture: str,
+def test_azure_reader(azure_reader: transform.AzureExtractReader) -> None:
+    output = list(azure_reader.extracted_rows())
+    unique_builders = {row['BUILDER'] for row in output}
+    assert len(output) == 14
+    assert len(unique_builders) == 14
+
+
+def test_azure_coordinates_from_env(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
+    monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_ACCOUNT', 'foo')
+    monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_KEY', 'bar')
+    monkeypatch.setenv('EXTRACT_ENDPOINT_STORAGE_DOMAIN', 'baz')
+    monkeypatch.setenv('EXTRACT_ENDPOINT_CONTAINER', 'qux')
+    coords = transform.AzureCoordinates.from_env()
+    assert coords == transform.AzureCoordinates(
+        account='foo',
+        key='bar',
+        domain='baz',
+        container='qux'
+    )
+
+
+def test_transform(local_reader: transform.LocalExtractReader) -> None:
+    output = transform.transform(local_reader)
+    assert len(list(output)) == 7
+
+
+def test_bad_data(local_reader: transform.LocalExtractReader,
                   monkeypatch: _pytest.monkeypatch.MonkeyPatch,
                   capsys: _pytest.capture.CaptureFixture) -> None:
 
@@ -31,7 +57,7 @@ def test_bad_data(energuide_zip_fixture: str,
 
     monkeypatch.setattr(ceiling.Ceiling, 'from_data', raise_error)
 
-    output = list(transform.transform(False, energuide_zip_fixture))
+    output = list(transform.transform(local_reader))
     assert not output
 
     _, err = capsys.readouterr()


### PR DESCRIPTION
This PR cleans up some of the local/Azure switching to use some duck-typing to abstract away the problem of reading extracted rows. That had the benefit of cleaning up tests considerably.
