### PR TITLE
🔥 azure references in test_endpoint

### DIFF
--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -103,37 +103,6 @@ def check_file_in_azure(azure_service: blob.BlockBlobService,
     assert actual_blob.content == contents
 
 
-def test_upload_with_timestamp(azure_emulator_coords: azure_utils.StorageCoordinates,
-                               test_client: testing.FlaskClient,
-                               azure_service: blob.BlockBlobService,
-                               sample_timestamp: str,
-                               sample_salt: str,
-                               sample_zipfile_signature: str,
-                               sample_file_contents: str,
-                               sample_filenames: str,
-                               sample_zipfile: io.BytesIO) -> None:
-
-    post_return = test_client.post('/upload_file', data=dict(salt=sample_salt, signature=sample_zipfile_signature,
-                                                             timestamp=sample_timestamp,
-                                                             file=(sample_zipfile, 'zipfile')))
-    assert post_return.status_code == HTTPStatus.CREATED
-    check_file_in_azure(azure_service, azure_emulator_coords, endpoint.TIMESTAMP_FILENAME, sample_timestamp)
-    for name, contents in zip(sample_filenames, sample_file_contents):
-        check_file_in_azure(azure_service, azure_emulator_coords, name, contents)
-
-
-@pytest.mark.usefixtures('azure_service')
-def test_upload_without_timestamp(test_client: testing.FlaskClient,
-                                  sample_salt: str,
-                                  sample_zipfile_signature: str,
-                                  sample_zipfile: io.BytesIO) -> None:
-
-    post_return = test_client.post('/upload_file', data=dict(salt=sample_salt, signature=sample_zipfile_signature,
-                                                             file=(sample_zipfile, 'zipfile')))
-    assert post_return.status_code == HTTPStatus.BAD_REQUEST
-
-
-@pytest.mark.usefixtures('azure_service')
 def test_upload_no_key_in_env(test_client: testing.FlaskClient,
                               sample_timestamp: str,
                               sample_salt: str,
@@ -146,7 +115,6 @@ def test_upload_no_key_in_env(test_client: testing.FlaskClient,
                                                    timestamp=sample_timestamp, file=(sample_zipfile, 'zipfile')))
 
 
-@pytest.mark.usefixtures('azure_service')
 def test_upload_no_salt(test_client: testing.FlaskClient,
                         sample_timestamp: str,
                         sample_zipfile_signature: str,
@@ -158,7 +126,6 @@ def test_upload_no_salt(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures('azure_service')
 def test_upload_wrong_salt(test_client: testing.FlaskClient,
                            sample_timestamp: str,
                            sample_zipfile_signature: str,
@@ -170,7 +137,6 @@ def test_upload_wrong_salt(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures('azure_service', 'sample_secret_key')
 def test_upload_no_signature(test_client: testing.FlaskClient,
                              sample_timestamp: str,
                              sample_salt: str,
@@ -181,7 +147,6 @@ def test_upload_no_signature(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures('azure_service', 'sample_secret_key')
 def test_upload_wrong_signature(test_client: testing.FlaskClient,
                                 sample_timestamp: str,
                                 sample_salt: str,
@@ -193,7 +158,6 @@ def test_upload_wrong_signature(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures('azure_service')
 def test_upload_no_file(test_client: testing.FlaskClient,
                         sample_timestamp: str,
                         sample_salt: str,
@@ -204,7 +168,6 @@ def test_upload_no_file(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures('azure_service')
 def test_upload_with_non_zipfile(test_client: testing.FlaskClient,
                                  sample_timestamp: str,
                                  sample_salt: str,

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -93,16 +93,6 @@ def test_timestamp_no_file(test_client: testing.FlaskClient) -> None:
     assert get_return.status_code == HTTPStatus.BAD_GATEWAY
 
 
-def check_file_in_azure(azure_service: blob.BlockBlobService,
-                        azure_emulator_coords: azure_utils.StorageCoordinates,
-                        filename: str,
-                        contents: str) -> None:
-
-    assert filename in [blob.name for blob in azure_service.list_blobs(azure_emulator_coords.container)]
-    actual_blob = azure_service.get_blob_to_text(azure_emulator_coords.container, filename)
-    assert actual_blob.content == contents
-
-
 def test_upload_no_key_in_env(test_client: testing.FlaskClient,
                               sample_timestamp: str,
                               sample_salt: str,
@@ -137,6 +127,7 @@ def test_upload_wrong_salt(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
+@pytest.mark.usefixtures('sample_secret_key')
 def test_upload_no_signature(test_client: testing.FlaskClient,
                              sample_timestamp: str,
                              sample_salt: str,
@@ -147,6 +138,7 @@ def test_upload_no_signature(test_client: testing.FlaskClient,
     assert post_return.status_code == HTTPStatus.BAD_REQUEST
 
 
+@pytest.mark.usefixtures('sample_secret_key')
 def test_upload_wrong_signature(test_client: testing.FlaskClient,
                                 sample_timestamp: str,
                                 sample_salt: str,

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -93,6 +93,29 @@ def test_timestamp_no_file(test_client: testing.FlaskClient) -> None:
     assert get_return.status_code == HTTPStatus.BAD_GATEWAY
 
 
+@pytest.mark.usefixtures('azure_service')
+def test_upload_with_timestamp(test_client: testing.FlaskClient,
+                               sample_timestamp: str,
+                               sample_salt: str,
+                               sample_zipfile_signature: str,
+                               sample_zipfile: io.BytesIO) -> None:
+
+    post_return = test_client.post('/upload_file', data=dict(salt=sample_salt, signature=sample_zipfile_signature,
+                                                             timestamp=sample_timestamp,
+                                                             file=(sample_zipfile, 'zipfile')))
+    assert post_return.status_code == HTTPStatus.CREATED
+
+
+def test_upload_without_timestamp(test_client: testing.FlaskClient,
+                                  sample_salt: str,
+                                  sample_zipfile_signature: str,
+                                  sample_zipfile: io.BytesIO) -> None:
+
+    post_return = test_client.post('/upload_file', data=dict(salt=sample_salt, signature=sample_zipfile_signature,
+                                                             file=(sample_zipfile, 'zipfile')))
+    assert post_return.status_code == HTTPStatus.BAD_REQUEST
+
+
 def test_upload_no_key_in_env(test_client: testing.FlaskClient,
                               sample_timestamp: str,
                               sample_salt: str,

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -134,7 +134,6 @@ def test_post_stream_cli_no_timestamp(sample_zipfile_fixture: str, upload_url: s
     assert result.exit_code != 0
 
 
-@pytest.mark.usefixtures('run_endpoint')
 def test_post_stream_cli_no_url(azure_service: blob.BlockBlobService,
                                 azure_emulator_coords: azure_utils.StorageCoordinates,
                                 sample_timestamp: str,


### PR DESCRIPTION
Removed timestamp related tests because those are now covered by post_to_endpoint with CLI refactor.

Burned references to azure fixtures in test_endpoint, since none of the tests are hitting (or need to hit) the azure storage.