### PR TITLE
add progress bar to transform, clean up output

### DIFF
--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -27,6 +27,7 @@ def main() -> None:
 @click.option('--azure', is_flag=True, help='Download data from Azure')
 @click.option('--filename', type=click.Path(exists=True), required=False)
 @click.option('-a', '--append', is_flag=True, help='Append data instead of overwriting')
+@click.option('--progress/--no-progress', default=True)
 def load(username: str,
          password: str,
          host: str,
@@ -35,7 +36,8 @@ def load(username: str,
          collection: str,
          azure: bool,
          filename: typing.Optional[str],
-         append: bool) -> None:
+         append: bool,
+         progress: bool) -> None:
     coords = database.DatabaseCoordinates(
         username=username,
         password=password,
@@ -54,7 +56,7 @@ def load(username: str,
     else:
         LOGGER.error('Must supply a filename or use azure')
         raise ValueError('Must supply a filename or use azure')
-    data = transform.transform(reader)
+    data = transform.transform(reader, progress)
     database.load(coords, db_name, collection, data, append)
     LOGGER.info(f'Finished loading data')
 

--- a/etl/src/energuide/transform.py
+++ b/etl/src/energuide/transform.py
@@ -3,6 +3,7 @@ import json
 import os
 import typing
 import zipfile
+from tqdm import tqdm
 import typing_extensions
 from azure.storage import blob
 from energuide import dwelling
@@ -36,6 +37,9 @@ class ExtractProtocol(typing_extensions.Protocol):
     def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
         pass
 
+    def num_rows(self) -> int:
+        pass
+
 
 class LocalExtractReader:
 
@@ -47,27 +51,43 @@ class LocalExtractReader:
             for file in zip_input.namelist():
                 content = zip_input.read(file)
                 house = json.loads(content)
-                house['jsonFileName'] = content
+                house['jsonFileName'] = file
                 yield house
+
+    def num_rows(self) -> int:
+        with zipfile.ZipFile(self._zip_filename) as zip_input:
+            return len(zip_input.namelist())
 
 
 class AzureExtractReader:
 
     def __init__(self, coords: AzureCoordinates) -> None:
         self._coords = coords
+        self._azure: typing.Optional[blob.BlockBlobService] = None
+
+    @property
+    def _azure_service(self) -> blob.BlockBlobService:
+        if self._azure is None:
+            self._azure = blob.BlockBlobService(account_name=self._coords.account,
+                                                account_key=self._coords.key,
+                                                custom_domain=self._coords.domain)
+        return self._azure
+
+    def _files(self) -> typing.List[str]:
+        # itertools.groupby() needs its input sorted by the groupby key. We are assuming that that key is the filename
+        files = sorted([blob_.name for blob_ in self._azure_service.list_blobs(self._coords.container)
+                        if 'timestamp' not in blob_.name])
+        return files
 
     def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
-        azure_service = blob.BlockBlobService(account_name=self._coords.account,
-                                              account_key=self._coords.key,
-                                              custom_domain=self._coords.domain)
-        # itertools.groupby() needs its input sorted by the groupby key. We are assuming that that key is the filename
-        files = sorted([blob_.name for blob_ in azure_service.list_blobs(self._coords.container)
-                        if 'timestamp' not in blob_.name])
-        for file in files:
-            content = azure_service.get_blob_to_bytes(self._coords.container, file).content
+        for file in self._files():
+            content = self._azure_service.get_blob_to_bytes(self._coords.container, file).content
             house = json.loads(content)
-            house['jsonFileName'] = content
+            house['jsonFileName'] = file
             yield house
+
+    def num_rows(self) -> int:
+        return len(self._files())
 
 
 def _read_groups(extracted_rows: typing.Iterable[typing.Dict[str, typing.Any]]
@@ -89,8 +109,10 @@ def _generate_dwellings(grouped: typing.List[typing.Dict[str, typing.Any]]) -> t
     return None
 
 
-def transform(extract_reader: ExtractProtocol) -> typing.Iterator[dwelling.Dwelling]:
-    for row_group in _read_groups(extract_reader.extracted_rows()):
+def transform(extract_reader: ExtractProtocol, show_progress: bool = False) -> typing.Iterator[dwelling.Dwelling]:
+    extracted_rows = tqdm(extract_reader.extracted_rows(), total=extract_reader.num_rows(),
+                          unit=' files', disable=not show_progress)
+    for row_group in _read_groups(extracted_rows):
         output = _generate_dwellings(row_group)
         if output:
             yield output

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -24,6 +24,10 @@ def test_reader(local_reader: transform.LocalExtractReader) -> None:
     assert len(unique_builders) == 14
 
 
+def test_reader_num_rows(local_reader: transform.LocalExtractReader) -> None:
+    assert local_reader.num_rows() == 14
+
+
 def test_azure_reader(azure_reader: transform.AzureExtractReader) -> None:
     output = list(azure_reader.extracted_rows())
     output = sorted(output, key=lambda row: row['BUILDER'])
@@ -31,6 +35,10 @@ def test_azure_reader(azure_reader: transform.AzureExtractReader) -> None:
     assert len(output) == 14
     assert output[0]['BUILDER'] == '11W2D00606'
     assert len(unique_builders) == 14
+
+
+def test_azure_reader_num_rows(azure_reader: transform.AzureExtractReader) -> None:
+    assert azure_reader.num_rows() == 14
 
 
 def test_azure_coordinates_from_env(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:

--- a/etl/tests/test_transform.py
+++ b/etl/tests/test_transform.py
@@ -17,15 +17,19 @@ def azure_reader(populated_azure_emulator: transform.AzureCoordinates) -> transf
 
 def test_reader(local_reader: transform.LocalExtractReader) -> None:
     output = list(local_reader.extracted_rows())
+    output = sorted(output, key=lambda row: row['BUILDER'])
     unique_builders = {row['BUILDER'] for row in output}
     assert len(output) == 14
+    assert output[0]['BUILDER'] == '11W2D00606'
     assert len(unique_builders) == 14
 
 
 def test_azure_reader(azure_reader: transform.AzureExtractReader) -> None:
     output = list(azure_reader.extracted_rows())
+    output = sorted(output, key=lambda row: row['BUILDER'])
     unique_builders = {row['BUILDER'] for row in output}
     assert len(output) == 14
+    assert output[0]['BUILDER'] == '11W2D00606'
     assert len(unique_builders) == 14
 
 


### PR DESCRIPTION
This PR addresses some issues I had trying to run the `transform` command on the sample data:
- no progress bar
- very messy/long output being displayed on error messages