### PR TITLE
Make certain dwelling fields nullable

### DIFF
--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -107,7 +107,8 @@ def _cast_nullable_string(value: str) -> typing.Optional[int]:
 
 class ParsedDwellingDataRow(_ParsedDwellingDataRow):
 
-    _XML_SCHEMA = {'type': 'xml', 'nullable': True, 'required': True, 'coerce': 'parse_xml'}
+    _XML_SCHEMA = {'type': 'xml', 'required': True, 'coerce': 'parse_xml'}
+    _NULLABLE_XML_SCHEMA = {'type': 'xml', 'nullable': True, 'required': True, 'coerce': 'parse_xml'}
     _XML_LIST_SCHEMA = {'type': 'list', 'required': True, 'schema': _XML_SCHEMA}
 
     _SCHEMA = {
@@ -128,10 +129,10 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
         'walls': _XML_LIST_SCHEMA,
         'doors': _XML_LIST_SCHEMA,
         'windows': _XML_LIST_SCHEMA,
-        'heatedFloorArea': _XML_SCHEMA,
-        'heating_cooling': _XML_SCHEMA,
+        'heatedFloorArea': _NULLABLE_XML_SCHEMA,
+        'heating_cooling': _NULLABLE_XML_SCHEMA,
         'ventilations': _XML_LIST_SCHEMA,
-        'waterHeatings': _XML_SCHEMA,
+        'waterHeatings': _NULLABLE_XML_SCHEMA,
         'basements': _XML_LIST_SCHEMA,
         'crawlspaces': _XML_LIST_SCHEMA,
         'slabs': _XML_LIST_SCHEMA,
@@ -179,7 +180,9 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
             heated_floor=heated_floor_area.HeatedFloorArea.from_data(parsed['heatedFloorArea'])
             if parsed['heatedFloorArea'] is not None else None,
 
-            water_heatings=water_heating.WaterHeating.from_data(parsed['waterHeatings']),
+            water_heatings=water_heating.WaterHeating.from_data(parsed['waterHeatings'])
+            if parsed['waterHeatings'] is not None else [],
+
             ventilations=[ventilation.Ventilation.from_data(ventilation_node)
                           for ventilation_node in parsed['ventilations']],
             heating_system=heating.Heating.from_data(parsed['heating_cooling'])

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -532,6 +532,7 @@ def sample_input_missing(sample_input_d: typing.Dict[str, typing.Any]) -> typing
     output['ersRating'] = None
     output['heatedFloorArea'] = None
     output['heating_cooling'] = None
+    output['waterHeatings'] = None
     return output
 
 

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -526,6 +526,16 @@ def sample_input_e(sample_input_d: typing.Dict[str, typing.Any]) -> typing.Dict[
 
 
 @pytest.fixture
+def sample_input_missing(sample_input_d: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    output = copy.deepcopy(sample_input_d)
+    output['MODIFICATIONDATE'] = None
+    output['ersRating'] = None
+    output['heatedFloorArea'] = None
+    output['heating_cooling'] = None
+    return output
+
+
+@pytest.fixture
 def sample_parsed_d(sample_input_d: typing.Dict[str, typing.Any]) -> dwelling.ParsedDwellingDataRow:
     return dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
 
@@ -812,6 +822,11 @@ class TestParsedDwellingDataRow:
                 ),
             ]
         )
+
+    def test_null_fields_are_accepted(self, sample_input_missing: typing.Dict[str, typing.Any]) -> None:
+        output = dwelling.ParsedDwellingDataRow.from_row(sample_input_missing)
+
+        assert output.modification_date == output.ers_rating == output.heating_system == output.heated_floor == None
 
     def test_bad_postal_code(self, sample_input_d: typing.Dict[str, typing.Any]) -> None:
         sample_input_d['forwardSortationArea'] = 'K16'


### PR DESCRIPTION
This PR changes some fields in the `Dwelling` validation step to nullable, meaning they are allowed to be `None` (as long as the keys themselves still exist).