### PR TITLE
Merge null snippets

### DIFF
--- a/etl/src/energuide/extractor.py
+++ b/etl/src/energuide/extractor.py
@@ -80,16 +80,22 @@ def _extract_snippets(row: typing.Dict[str, typing.Any]) -> typing.Dict[str, typ
     if house_node:
         house_snippets = snippets.snip_house(house_node[0])
         row = _safe_merge(row, house_snippets.to_dict())
+    else:
+        row = _safe_merge(row, snippets.HouseSnippet.EMPTY_SNIPPET)
 
     code_node = doc.xpath('Codes')
     if code_node:
         code_snippets = snippets.snip_codes(code_node[0])
         row = _safe_merge(row, code_snippets.to_dict())
+    else:
+        row = _safe_merge(row, snippets.Codes.EMPTY_SNIPPET)
 
     upgrades_node = doc.xpath('EnergyUpgrades')
     if upgrades_node:
         energy_snippets = snippets.snip_energy_upgrades(upgrades_node[0])
         row = _safe_merge(row, energy_snippets.to_dict())
+    else:
+        row = _safe_merge(row, snippets.EnergyUpgradesSnippet.EMPTY_SNIPPET)
 
     tsv_fields = snippets.snip_other_data(doc)
     row = _safe_merge(row, tsv_fields.to_dict())

--- a/etl/src/energuide/snippets.py
+++ b/etl/src/energuide/snippets.py
@@ -10,7 +10,7 @@ class _Codes(typing.NamedTuple):
 
 class Codes(_Codes):
 
-    EMPTY_SNIPPET = {
+    EMPTY_SNIPPET: typing.Dict[str, typing.Dict[str, typing.List[str]]] = {
         'codes': {
             'wall': [],
             'window': [],
@@ -43,7 +43,7 @@ class _HouseSnippet(typing.NamedTuple):
 
 class HouseSnippet(_HouseSnippet):
 
-    EMPTY_SNIPPET = {
+    EMPTY_SNIPPET: typing.Dict[str, typing.Union[typing.List[str], typing.Optional[str]]] = {
         'ceilings': [],
         'floors': [],
         'walls': [],
@@ -81,7 +81,7 @@ class _EnergyUpgradesSnippet(typing.NamedTuple):
 
 class EnergyUpgradesSnippet(_EnergyUpgradesSnippet):
 
-    EMPTY_SNIPPET = {
+    EMPTY_SNIPPET: typing.Dict[str, typing.List[str]] = {
         'upgrades': [],
     }
 

--- a/etl/src/energuide/snippets.py
+++ b/etl/src/energuide/snippets.py
@@ -10,6 +10,13 @@ class _Codes(typing.NamedTuple):
 
 class Codes(_Codes):
 
+    EMPTY_SNIPPET = {
+        'codes': {
+            'wall': [],
+            'window': [],
+        }
+    }
+
     def to_dict(self) -> typing.Dict[str, typing.Dict[str, typing.List[str]]]:
         return {
             'codes': {
@@ -36,6 +43,21 @@ class _HouseSnippet(typing.NamedTuple):
 
 class HouseSnippet(_HouseSnippet):
 
+    EMPTY_SNIPPET = {
+        'ceilings': [],
+        'floors': [],
+        'walls': [],
+        'doors': [],
+        'windows': [],
+        'heatedFloorArea': None,
+        'heating_cooling': None,
+        'ventilations': [],
+        'waterHeatings': None,
+        'basements': [],
+        'crawlspaces': [],
+        'slabs': [],
+    }
+
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'ceilings': self.ceilings,
@@ -58,6 +80,10 @@ class _EnergyUpgradesSnippet(typing.NamedTuple):
 
 
 class EnergyUpgradesSnippet(_EnergyUpgradesSnippet):
+
+    EMPTY_SNIPPET = {
+        'upgrades': [],
+    }
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {

--- a/etl/tests/test_extractor.py
+++ b/etl/tests/test_extractor.py
@@ -133,6 +133,7 @@ def test_extract_with_snippets(tmpdir: py._path.local.LocalPath, base_data: typi
     output = next(extractor.extract_data(str(input_file)))
     assert output
     assert output['ceilings']
+    assert output['upgrades'] == []
 
 
 def test_extract_with_tsv_snippets(tmpdir: py._path.local.LocalPath, base_data: typing.Dict[str, str]) -> None:


### PR DESCRIPTION
This PR changes the `_extract_snippets` step of extraction to merge in empty versions of the snippets if the nodes are not present, where as the current code simply does not generate those keys in the output if the node is missing.

The current behaviour results in the extractor producing output that fails input validation of the load portion. This new behaviour should ensure that extract does not produce output that is invalid to load. 