### PR TITLE
Empty embedded exception message

### DIFF
--- a/etl/src/energuide/exceptions.py
+++ b/etl/src/energuide/exceptions.py
@@ -17,8 +17,11 @@ class InvalidEmbeddedDataTypeError(EnerguideError):
 
     def __init__(self, data_class: type, msg: typing.Optional[str] = None) -> None:
         self.data_class = data_class
-        super().__init__(msg)
 
+        if msg:
+            super().__init__(msg)
+        else:
+            super().__init__()
 
 class ElementGetValueError(EnerguideError):
     pass

--- a/etl/src/energuide/exceptions.py
+++ b/etl/src/energuide/exceptions.py
@@ -18,7 +18,7 @@ class InvalidEmbeddedDataTypeError(EnerguideError):
     def __init__(self, data_class: type, msg: typing.Optional[str] = None) -> None:
         self.data_class = data_class
 
-        if msg:
+        if msg is not None:
             super().__init__(msg)
         else:
             super().__init__()


### PR DESCRIPTION
This PR changes the behaviour of the `InvalidEmbeddedDataTypeError` exception to call `super().__init__` with no arguments if no message was passed in, mimicking how a default exception would behave if nothing was passed to it.