### PR TITLE
Robustify TL web app

### DIFF
--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -4,6 +4,7 @@ Flask==0.12.2
 azure-storage-blob==1.1.0
 pylint==1.8.1
 pytest==3.3.2
+pytest-timeout==1.2.1
 pytest-cov==2.5.1
 mypy==0.560
 click==6.7

--- a/etl/src/energuide/flask_app.py
+++ b/etl/src/energuide/flask_app.py
@@ -69,6 +69,11 @@ class ThreadRunner:
     def is_thread_running(cls) -> bool:
         return cls._running_thread is not None and cls._running_thread.is_alive()
 
+    @classmethod
+    def join(cls) -> None:
+        if cls._running_thread is not None:
+            cls._running_thread.join()
+
 
 @App.route('/', methods=['GET'])
 def frontend() -> str:

--- a/etl/src/energuide/flask_app.py
+++ b/etl/src/energuide/flask_app.py
@@ -55,14 +55,13 @@ def _run_tl_and_verify() -> None:
         LOGGER.warning('Error, no records created')
     else:
         LOGGER.info(f'Success, {records_created} created')
-    return records_created
 
 
 class ThreadRunner:
     _running_thread: typing.Optional[threading.Thread] = None
 
     @classmethod
-    def start_new_thread(cls, target) -> None:
+    def start_new_thread(cls, target: typing.Callable[[], None]) -> None:
         cls._running_thread = threading.Thread(target=target)
         cls._running_thread.start()
 
@@ -109,7 +108,7 @@ def run_tl() -> typing.Tuple[str, int]:
         return 'TL already running', HTTPStatus.TOO_MANY_REQUESTS
 
     ThreadRunner.start_new_thread(target=_run_tl_and_verify)
-    return 'starting ', HTTPStatus.OK
+    return 'TL starting', HTTPStatus.OK
 
 
 if __name__ == "__main__":

--- a/etl/src/energuide/flask_app.py
+++ b/etl/src/energuide/flask_app.py
@@ -1,6 +1,7 @@
 import os
 import typing
 from http import HTTPStatus
+import threading
 import hashlib
 import flask
 import pymongo
@@ -32,6 +33,42 @@ DATABASE_COORDS = database.DatabaseCoordinates(
 DATABASE_NAME = os.environ.get(database.EnvVariables.database.value, default=database.EnvDefaults.database.value)
 
 COLLECTION = os.environ.get(database.EnvVariables.collection.value, default=database.EnvDefaults.collection.value)
+
+
+def _run_tl_and_verify() -> None:
+    LOGGER.info("TL starting")
+    cli.load.callback(username=DATABASE_COORDS.username,
+                      password=DATABASE_COORDS.password,
+                      host=DATABASE_COORDS.host,
+                      port=DATABASE_COORDS.port,
+                      db_name=DATABASE_NAME,
+                      collection=COLLECTION,
+                      azure=True,
+                      filename=None,
+                      append=False,
+                      progress=False)
+
+    mongo_client: pymongo.MongoClient
+    with database.mongo_client(DATABASE_COORDS) as mongo_client:
+        records_created = mongo_client[DATABASE_NAME][COLLECTION].count()
+    if records_created == 0:
+        LOGGER.warning('Error, no records created')
+    else:
+        LOGGER.info(f'Success, {records_created} created')
+    return records_created
+
+
+class ThreadRunner:
+    _running_thread: typing.Optional[threading.Thread] = None
+
+    @classmethod
+    def start_new_thread(cls, target) -> None:
+        cls._running_thread = threading.Thread(target=target)
+        cls._running_thread.start()
+
+    @classmethod
+    def is_thread_running(cls) -> bool:
+        return cls._running_thread is not None and cls._running_thread.is_alive()
 
 
 @App.route('/', methods=['GET'])
@@ -67,25 +104,12 @@ def run_tl() -> typing.Tuple[str, int]:
         LOGGER.warning("request contained incorrect signature")
         return 'bad signature', HTTPStatus.BAD_REQUEST
 
-    cli.load.callback(username=DATABASE_COORDS.username,
-                      password=DATABASE_COORDS.password,
-                      host=DATABASE_COORDS.host,
-                      port=DATABASE_COORDS.port,
-                      db_name=DATABASE_NAME,
-                      collection=COLLECTION,
-                      azure=True,
-                      filename=None,
-                      append=False,
-                      progress=False)
+    if ThreadRunner.is_thread_running():
+        LOGGER.warning("TL already running, not starting")
+        return 'TL already running', HTTPStatus.TOO_MANY_REQUESTS
 
-    mongo_client: pymongo.MongoClient
-    with database.mongo_client(DATABASE_COORDS) as mongo_client:
-        records_created = mongo_client[DATABASE_NAME][COLLECTION].count()
-    if records_created == 0:
-        LOGGER.warning('error, no records created')
-        return 'error, no records created', HTTPStatus.BAD_GATEWAY
-    LOGGER.info(f'success, {records_created} created')
-    return f'success, {records_created} created', HTTPStatus.CREATED
+    ThreadRunner.start_new_thread(target=_run_tl_and_verify)
+    return 'starting ', HTTPStatus.OK
 
 
 if __name__ == "__main__":

--- a/etl/tests/test_flask_app.py
+++ b/etl/tests/test_flask_app.py
@@ -44,15 +44,16 @@ def thread_runner() -> typing.Generator:
 
 
 def test_threadrunner(thread_runner: flask_app.ThreadRunner) -> None:
+    stay_asleep = True
 
     def sleeper() -> None:
-        time.sleep(0.5)
+        while stay_asleep:
+            pass
 
     thread_runner.start_new_thread(sleeper)
     assert thread_runner.is_thread_running()
-    time.sleep(0.4)
-    assert thread_runner.is_thread_running()
-    time.sleep(0.2)
+    stay_asleep = False
+    time.sleep(0.1)
     assert not thread_runner.is_thread_running()
 
 

--- a/etl/tests/test_flask_app.py
+++ b/etl/tests/test_flask_app.py
@@ -85,6 +85,7 @@ def test_run_tl_busy(test_client: testing.FlaskClient,
                      sample_salt: str,
                      sample_signature: str) -> None:
 
+    assert not flask_app.ThreadRunner.is_thread_running()
     test_client.post('/run_tl', data=dict(salt=sample_salt, signature=sample_signature))
     post_return = test_client.post('/run_tl', data=dict(salt=sample_salt, signature=sample_signature))
     assert post_return.status_code == HTTPStatus.TOO_MANY_REQUESTS

--- a/etl/tests/test_flask_app.py
+++ b/etl/tests/test_flask_app.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 import hashlib
-import time
 import typing
 import _pytest
 import pymongo
@@ -39,8 +38,7 @@ def test_client(monkeypatch: _pytest.monkeypatch.MonkeyPatch, database_name: str
 @pytest.fixture()
 def thread_runner() -> typing.Generator:
     yield flask_app.ThreadRunner
-    while flask_app.ThreadRunner.is_thread_running():
-        time.sleep(0.1)
+    flask_app.ThreadRunner.join()
 
 
 def test_threadrunner(thread_runner: flask_app.ThreadRunner) -> None:
@@ -53,7 +51,7 @@ def test_threadrunner(thread_runner: flask_app.ThreadRunner) -> None:
     thread_runner.start_new_thread(sleeper)
     assert thread_runner.is_thread_running()
     stay_asleep = False
-    time.sleep(0.1)
+    thread_runner.join()
     assert not thread_runner.is_thread_running()
 
 
@@ -83,8 +81,7 @@ def test_run_tl(test_client: testing.FlaskClient,
 
     post_return = test_client.post('/run_tl', data=dict(salt=sample_salt, signature=sample_signature))
     assert post_return.status_code == HTTPStatus.OK
-    while thread_runner.is_thread_running():
-        time.sleep(0.1)
+    thread_runner.join()
     assert mongo_client[database_name][collection].count() == 7
 
 


### PR DESCRIPTION
* when TL is triggered, respond immediately to Endpoint, and start running TL in a new thread
* if TL is triggered again before it has finished running, ignore the trigger request (and return a `TOO_MANY_REQUESTS` code