### PR TITLE
Allow single pre-retrofit evaluations

### DIFF
--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -366,7 +366,10 @@ class Dwelling:
 
     @classmethod
     def _from_parsed_group(cls, data: typing.List[ParsedDwellingDataRow]) -> 'Dwelling':
-        if len(data) == 2:
+        if 0 < len(data) < 3:
+            if len(data) == 1 and data[0].eval_type is EvaluationType.POST_RETROFIT:
+                raise InvalidInputDataError('Only Pre-retrofit evaluations are allowed a group size of 1')
+
             evaluations = [Evaluation.from_data(row) for row in data]
             return Dwelling(
                 house_id=data[0].eval_id,
@@ -377,7 +380,7 @@ class Dwelling:
                 evaluations=evaluations,
             )
         else:
-            raise InvalidGroupSizeError(f'Invalid group size "{len(data)}". Groups must be size 2')
+            raise InvalidGroupSizeError(f'Invalid group size "{len(data)}". Groups must be size 1 or 2')
 
     @classmethod
     def from_group(cls, data: typing.List[typing.Dict[str, typing.Any]]) -> 'Dwelling':

--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -366,7 +366,7 @@ class Dwelling:
 
     @classmethod
     def _from_parsed_group(cls, data: typing.List[ParsedDwellingDataRow]) -> 'Dwelling':
-        if 0 < len(data) < 3:
+        if len(data) == 1 or len(data) == 2:
             if len(data) == 1 and data[0].eval_type is EvaluationType.POST_RETROFIT:
                 raise InvalidInputDataError('Only Pre-retrofit evaluations are allowed a group size of 1')
 

--- a/etl/src/energuide/dwelling.py
+++ b/etl/src/energuide/dwelling.py
@@ -366,10 +366,10 @@ class Dwelling:
 
     @classmethod
     def _from_parsed_group(cls, data: typing.List[ParsedDwellingDataRow]) -> 'Dwelling':
-        if len(data) == 1 or len(data) == 2:
-            if len(data) == 1 and data[0].eval_type is EvaluationType.POST_RETROFIT:
-                raise InvalidInputDataError('Only Pre-retrofit evaluations are allowed a group size of 1')
+        if len(data) == 1 and data[0].eval_type is EvaluationType.POST_RETROFIT:
+            raise InvalidInputDataError('Only Pre-retrofit evaluations are allowed a group size of 1')
 
+        if len(data) == 1 or len(data) == 2:
             evaluations = [Evaluation.from_data(row) for row in data]
             return Dwelling(
                 house_id=data[0].eval_id,

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -896,6 +896,14 @@ class TestDwelling:
         assert output.region == dwelling.Region.ONTARIO
         assert output.forward_sortation_area == 'K1P'
 
+    def test_single_pre_evaluation(self, sample_input_d: typing.Dict[str, typing.Any]) -> None:
+        output = dwelling.Dwelling.from_group([sample_input_d])
+        assert len(output.evaluations) == 1
+
+    def test_single_post_evaluation(self, sample_input_e: typing.Dict[str, typing.Any]) -> None:
+        with pytest.raises(InvalidInputDataError):
+            output = dwelling.Dwelling.from_group([sample_input_e])
+
     def test_evaluations(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
         output = dwelling.Dwelling.from_group(sample)
         assert len(output.evaluations) == 2

--- a/etl/tests/test_dwelling.py
+++ b/etl/tests/test_dwelling.py
@@ -902,7 +902,7 @@ class TestDwelling:
 
     def test_single_post_evaluation(self, sample_input_e: typing.Dict[str, typing.Any]) -> None:
         with pytest.raises(InvalidInputDataError):
-            output = dwelling.Dwelling.from_group([sample_input_e])
+            dwelling.Dwelling.from_group([sample_input_e])
 
     def test_evaluations(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
         output = dwelling.Dwelling.from_group(sample)


### PR DESCRIPTION
This PR allows 1 length groups of `ParsedDwellingDataRow` as long as they are pre-retrofit