### PR TITLE
Remove redundant config lines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,6 @@ workflows:
       - etl
       - extract_endpoint
       - python_integration
-      - deploy_endpoint
       - node_integration
       - deploy_endpoint:
           filters:
@@ -259,7 +258,7 @@ workflows:
                 - master
           requires:
             - extract_endpoint
-            - python_integration
+            - node_integration
             - etl
             - node
       - node_integration:
@@ -274,7 +273,6 @@ workflows:
             - etl
             - extract_endpoint
             - node_integration
-            - python_integration
           filters:
             branches:
               only:
@@ -285,19 +283,7 @@ workflows:
             - etl
             - extract_endpoint
             - node_integration
-            - python_integration
           filters:
             branches:
              only:
                - master
-      - deploy_endpoint:
-          requires:
-            - node
-            - etl
-            - extract_endpoint
-            - node_integration
-            - python_integration
-          filters:
-            branches:
-              only:
-                - master


### PR DESCRIPTION
This PR removes some redundant lines in the circleci config.

1. `deploy_endpoint` was present 3 times.
2. `python_integration` and `node_integration` were both present in requires lists, but `node_integration` requires `python_integration` so having both is redundant.