### PR TITLE
Remove `I18N` prefix from our scalar types

### DIFF
--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -38,9 +38,10 @@ const replaceBackTicksWithSingleQuotes = function(str) {
 describe('configuration', () => {
   describe('graphql default scalar value', () => {
     it('GraphQLInt returns the same description as I18NInt', async () => {
-      let response = await makeRequest({ typeName: 'I18NInt' })
+      let response = await makeRequest({ typeName: 'Int' })
 
-      let { __type: { description } } = response.body.data
+      let { __type: { name, description } } = response.body.data
+      expect(name).toEqual(GraphQLInt.name)
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLInt.description),
       )

--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -76,9 +76,11 @@ describe('configuration', () => {
 
   describe('graphql iso date field', () => {
     it('GraphQLDate returns the same description as I18NDate', async () => {
-      let response = await makeRequest({ typeName: 'I18NDate' })
+      let response = await makeRequest({ typeName: 'Date' })
 
-      let { __type: { description } } = response.body.data
+      let { __type: { name, description } } = response.body.data
+      // name is overwritten (we are not using Object.create()) so this assertion is useless
+      // expect(name).toEqual(GraphQLDate.name)
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLDate.description),
       )

--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -48,9 +48,10 @@ describe('configuration', () => {
     })
 
     it('GraphQLFloat returns the same description as I18NFloat', async () => {
-      let response = await makeRequest({ typeName: 'I18NFloat' })
+      let response = await makeRequest({ typeName: 'Float' })
 
-      let { __type: { description } } = response.body.data
+      let { __type: { name, description } } = response.body.data
+      expect(name).toEqual(GraphQLFloat.name)
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLFloat.description),
       )

--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -6,7 +6,6 @@ import {
   GraphQLString,
   GraphQLBoolean,
 } from 'graphql'
-import { GraphQLDate } from 'graphql-iso-date'
 
 let mockServer = new Server({
   client: jest.fn(),
@@ -78,18 +77,7 @@ describe('configuration', () => {
     })
   })
 
-  describe('graphql iso date field', () => {
-    it('GraphQLDate returns the same description as I18NDate', async () => {
-      let response = await makeRequest({ typeName: 'Date' })
-
-      let { __type: { name, description } } = response.body.data
-      // name is overwritten (we are not using Object.create()) so this assertion is useless
-      // expect(name).toEqual(GraphQLDate.name)
-      expect(description).toEqual(
-        replaceBackTicksWithSingleQuotes(GraphQLDate.description),
-      )
-    })
-  })
+  // We are deliberately *not* testing GraphQLDate, unlike the other scalars
 
   describe('i18n', () => {
     it('returns french description when french language header sent', async () => {

--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -65,9 +65,10 @@ describe('configuration', () => {
     })
 
     it('GraphQLBoolean returns the same description as I18NBoolean', async () => {
-      let response = await makeRequest({ typeName: 'I18NBoolean' })
+      let response = await makeRequest({ typeName: 'Boolean' })
 
-      let { __type: { description } } = response.body.data
+      let { __type: { name, description } } = response.body.data
+      expect(name).toEqual(GraphQLBoolean.name)
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLBoolean.description),
       )

--- a/api/src/__tests__/i18n.test.js
+++ b/api/src/__tests__/i18n.test.js
@@ -57,9 +57,10 @@ describe('configuration', () => {
     })
 
     it('GraphQLString returns the same description as I18NString', async () => {
-      let response = await makeRequest({ typeName: 'I18NString' })
+      let response = await makeRequest({ typeName: 'String' })
 
-      let { __type: { description } } = response.body.data
+      let { __type: { name, description } } = response.body.data
+      expect(name).toEqual(GraphQLString.name)
       expect(description).toEqual(
         replaceBackTicksWithSingleQuotes(GraphQLString.description),
       )

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -13,7 +13,7 @@ const Schema = i18n => {
     scalar I18NFloat
     scalar I18NString
     scalar I18NBoolean
-    scalar I18NDate
+    scalar Date
 
     # ${i18n.t`An operator to describe how results will be filtered`}
     enum Comparator {
@@ -40,9 +40,9 @@ const Schema = i18n => {
       # ${i18n.t`Name of the date field results will be filtered by`}
       field: DateField!
       # ${i18n.t`Evaluation dates must be equal to or later than this value`}
-      startDate: I18NDate
+      startDate: Date
       # ${i18n.t`Evaluation dates must be equal to or earlier than this value`}
-      endDate: I18NDate
+      endDate: Date
     }
 
     # ${i18n.t`An improvement that could increase the energy efficiency of the dwelling`}

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -12,7 +12,7 @@ const Schema = i18n => {
     scalar I18NInt
     scalar I18NFloat
     scalar I18NString
-    scalar I18NBoolean
+    scalar Boolean
     scalar Date
 
     # ${i18n.t`An operator to describe how results will be filtered`}
@@ -135,9 +135,9 @@ const Schema = i18n => {
     # ${i18n.t`One page of results`}
     type PaginatedResultSet @cacheControl(maxAge: 90) {
       # ${i18n.t`If true, a further page of results can be returned`}
-      hasNext: I18NBoolean
+      hasNext: Boolean
       # ${i18n.t`If true, a previous page of results can be returned`}
-      hasPrevious: I18NBoolean
+      hasPrevious: Boolean
       # ${i18n.t`Identifier used to return the next page of results`}
       next: I18NString
       # ${i18n.t`Identifier cursor used to return the previous page of results`}

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -100,9 +100,9 @@ const Schema = i18n => {
       # ${i18n.t`Capacity of the tank in gallons (Gal)`}
       tankVolumeGallon: Float
       # ${i18n.t`Measures how effectively your water heater is burning fuel or turning fuel into heat`}
-      efficiencyEf: String
+      efficiencyEf: Float
       # ${i18n.t`A percentage representing the ratio of how effectively your water heater is turning fuel into heat`}
-      efficiencyPercentage: String
+      efficiencyPercentage: Float
     }
 
     # ${i18n.t`A principal heating system is either the only source of heat for the house, or is used for at least 70% of the heating load`}
@@ -318,7 +318,7 @@ const Schema = i18n => {
       # ${i18n.t`The details of the foundation`}
       foundations: [Foundation]
       # ${i18n.t`The EnerGuide Rating calculated for this evaluation`}
-      ersRating: String
+      ersRating: Int
     }
 
     # ${i18n.t`A residential building evaluted under the Energuide program`}

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -10,7 +10,7 @@ const Schema = i18n => {
   const typeDefs = [
     `
     scalar Int
-    scalar I18NFloat
+    scalar Float
     scalar String
     scalar Boolean
     scalar Date
@@ -62,9 +62,9 @@ const Schema = i18n => {
       # ${i18n.t`Ventilation type installed (fr)`}
       typeFrench: String
       # ${i18n.t`Air flow rate in litres per second (L/s)`}
-      airFlowRateLps: I18NFloat
+      airFlowRateLps: Float
       # ${i18n.t`Air flow rate in cubic feet per minute (f3/m)`}
-      airFlowRateCfm: I18NFloat
+      airFlowRateCfm: Float
     }
 
     # ${i18n.t`Floors represents the usable area of the house`}
@@ -72,21 +72,21 @@ const Schema = i18n => {
       # ${i18n.t`Description of floor location`}
       label: String
       # ${i18n.t`Floor insulation nominal RSI (R-value Systeme International)`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`Floor insulation nominal R-value`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`Floor insulation effective RSI (R-value Systeme International)`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`Floor insulation effective R-value`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`Floor area of the house in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Floor area of the house in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`Floor length of the house in metres (m)`}
-      lengthMetres: I18NFloat
+      lengthMetres: Float
       # ${i18n.t`Floor area of the house in square feet (ft2)`}
-      lengthFeet: I18NFloat
+      lengthFeet: Float
     }
 
     # ${i18n.t`Water heaters heat the domestic water in a house`}
@@ -96,9 +96,9 @@ const Schema = i18n => {
       # ${i18n.t`Type of tank being used to heat the domestic water in the house (fr)`}
       typeFrench: String
       # ${i18n.t`Capacity of the tank in litres (L)`}
-      tankVolumeLitres: I18NFloat
+      tankVolumeLitres: Float
       # ${i18n.t`Capacity of the tank in gallons (Gal)`}
-      tankVolumeGallon: I18NFloat
+      tankVolumeGallon: Float
       # ${i18n.t`Measures how effectively your water heater is burning fuel or turning fuel into heat`}
       efficiencyEf: String
       # ${i18n.t`A percentage representing the ratio of how effectively your water heater is turning fuel into heat`}
@@ -122,11 +122,11 @@ const Schema = i18n => {
       # ${i18n.t`Equipment type of heating system (fr)`}
       equipmentTypeFrench: String
       # ${i18n.t`Output capacity of the heating system in kilowatt hours (kWh)`}
-      outputSizeKW: I18NFloat
+      outputSizeKW: Float
       # ${i18n.t`Output capacity of the heating system in British Thermal Units per hour (BTU/h)`}
-      outputSizeBtu: I18NFloat
+      outputSizeBtu: Float
       # ${i18n.t`Measures how effectively your heating system is burning fuel or turning fuel into heat`}
-      efficiency: I18NFloat
+      efficiency: Float
       # ${i18n.t`Steady-state efficiency is the combustion efficiency of the equipment at peak performance.
         The Annual Fuel Utilization Efficiency (AFUE) is a measure of efficiency based on average usage, accounting for the fact that most heating systems rarely run long enough to reach peak performance.`}
       steadyState: String
@@ -149,13 +149,13 @@ const Schema = i18n => {
     # ${i18n.t`Heated floor areas represents the usable areas of a house that is conditioned to a specified temperature during the whole heating season`}
     type HeatedFloorArea @cacheControl(maxAge: 90) {
       # ${i18n.t`Above-grade heated area of the house in square metres (m2), i.e. the ground floor`}
-      areaAboveGradeMetres: I18NFloat
+      areaAboveGradeMetres: Float
       # ${i18n.t`Above-grade heated area of the house in square feet (ft2), i.e. the ground floor`}
-      areaAboveGradeFeet: I18NFloat
+      areaAboveGradeFeet: Float
       # ${i18n.t`Below-grade heated area of the house in square metres (m2), i.e. the basement`}
-      areaBelowGradeMetres: I18NFloat
+      areaBelowGradeMetres: Float
       # ${i18n.t`Below-grade heated area of the house in square feet (ft2), i.e. the basement`}
-      areaBelowGradeFeet: I18NFloat
+      areaBelowGradeFeet: Float
     }
 
     # ${i18n.t`Walls separate the interior heated space from the outside (interior partition walls are not considered walls)`}
@@ -171,25 +171,25 @@ const Schema = i18n => {
       # ${i18n.t`Size of the component type (fr)`}
       componentTypeSizeFrench: String
       # ${i18n.t`Wall insulation nominal RSI (R-value Systeme International)`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`Wall insulation nominal R-value`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`Wall insulation effective RSI (R-value Systeme International)`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`Wall insulation nominal R-value`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`Wall area of the house in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Wall area of the house in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`Wall perimeter of the house in metres (m)`}
-      perimeterMetres: I18NFloat
+      perimeterMetres: Float
       # ${i18n.t`Wall perimeter of the house in feet (ft)`}
-      perimeterFeet: I18NFloat
+      perimeterFeet: Float
       # ${i18n.t`Wall height of the house in metres (m)`}
-      heightMetres: I18NFloat
+      heightMetres: Float
       # ${i18n.t`Wall height of the house in feet (ft)`}
-      heightFeet: I18NFloat
+      heightFeet: Float
     }
 
     # ${i18n.t`Doors are on outside walls, separating the interior heated space from the outside`}
@@ -199,17 +199,17 @@ const Schema = i18n => {
       # ${i18n.t`Describes the construction of the door (fr)`}
       typeFrench: String
       # ${i18n.t`Door RSI (R-value Systeme International)`}
-      insulationRsi: I18NFloat
+      insulationRsi: Float
       # ${i18n.t`Door R-value`}
-      insulationR: I18NFloat
+      insulationR: Float
       # ${i18n.t`Door U-factor in metric: watts per square metre per degree Celcius (W/m2C)`}
-      uFactor: I18NFloat
+      uFactor: Float
       # ${i18n.t`Door U-factor in imperial: British Thermal Units per square feet per degree Fahrenheit (BTU/ft2F)`}
-      uFactorImperial: I18NFloat
+      uFactorImperial: Float
       # ${i18n.t`Door area in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Door area in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
     }
 
     # ${i18n.t`Windows separate the interior heated space from the outside`}
@@ -217,9 +217,9 @@ const Schema = i18n => {
       # ${i18n.t`Used to identify the window component in the house`}
       label: String
       # ${i18n.t`Window RSI (R-value Systeme International)`}
-      insulationRsi: I18NFloat
+      insulationRsi: Float
       # ${i18n.t`Window R-value`}
-      insulationR: I18NFloat
+      insulationR: Float
       # ${i18n.t`Number of panes of transparent material in a window (en)`}
       glazingTypesEnglish: String
       # ${i18n.t`Number of panes of transparent material in a window (fr)`}
@@ -245,17 +245,17 @@ const Schema = i18n => {
       # ${i18n.t`Material type of the window frame (fr)`}
       frameMaterialFrench: String
       # ${i18n.t`Window area in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Window area in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`Window width in metres (m)`}
-      widthMetres: I18NFloat
+      widthMetres: Float
       # ${i18n.t`Window width in feet (ft)`}
-      widthFeet: I18NFloat
+      widthFeet: Float
       # ${i18n.t`Window height in metres (m)`}
-      heightMetres: I18NFloat
+      heightMetres: Float
       # ${i18n.t`Window height in feet (ft)`}
-      heightFeet: I18NFloat
+      heightFeet: Float
     }
 
     # ${i18n.t`Ceilings are the upper interior surface of a room`}
@@ -267,21 +267,21 @@ const Schema = i18n => {
       # ${i18n.t`Describes the construction of the ceiling (fr)`}
       typeFrench: String
       # ${i18n.t`Ceiling insulation nominal RSI (R-value Systeme International)`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`Ceiling insulation nominal R-value`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`Ceiling insulation effective RSI (R-value Systeme International)`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`Ceiling insulation effective R-value`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`Ceiling area in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Ceiling area in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`Ceiling length in metres (m)`}
-      lengthMetres: I18NFloat
+      lengthMetres: Float
       # ${i18n.t`Ceiling length in feet (ft)`}
-      lengthFeet: I18NFloat
+      lengthFeet: Float
     }
 
     # ${i18n.t`Detailed information about specific features of a given dwelling`}

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -11,7 +11,7 @@ const Schema = i18n => {
     `
     scalar Int
     scalar I18NFloat
-    scalar I18NString
+    scalar String
     scalar Boolean
     scalar Date
 
@@ -32,7 +32,7 @@ const Schema = i18n => {
       # ${i18n.t`An operator to describe how results will be filtered`}
       comparator: Comparator!
       # ${i18n.t`Results will be compared to this value`}
-      value: I18NString!
+      value: String!
     }
 
     # ${i18n.t`Filter by dwellings containing evaluations that were entered, created, or modified between a range of dates`}
@@ -48,7 +48,7 @@ const Schema = i18n => {
     # ${i18n.t`An improvement that could increase the energy efficiency of the dwelling`}
     type Upgrade @cacheControl(maxAge: 90) {
       # ${i18n.t`Part of the dwelling to be upgraded`}
-      upgradeType: I18NString
+      upgradeType: String
       # ${i18n.t`Estimated cost of upgrade`}
       cost: Int
       # ${i18n.t`Order of importance of upgrade recommendation (lower number means a higher priority)`}
@@ -58,9 +58,9 @@ const Schema = i18n => {
     # ${i18n.t`Ventilation systems draw exterior air into the house, exhaust interior air to the exterior, or both`}
     type Ventilation @cacheControl(maxAge: 90) {
       # ${i18n.t`Ventilation type installed (en)`}
-      typeEnglish: I18NString
+      typeEnglish: String
       # ${i18n.t`Ventilation type installed (fr)`}
-      typeFrench: I18NString
+      typeFrench: String
       # ${i18n.t`Air flow rate in litres per second (L/s)`}
       airFlowRateLps: I18NFloat
       # ${i18n.t`Air flow rate in cubic feet per minute (f3/m)`}
@@ -70,7 +70,7 @@ const Schema = i18n => {
     # ${i18n.t`Floors represents the usable area of the house`}
     type Floor @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of floor location`}
-      label: I18NString
+      label: String
       # ${i18n.t`Floor insulation nominal RSI (R-value Systeme International)`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`Floor insulation nominal R-value`}
@@ -92,35 +92,35 @@ const Schema = i18n => {
     # ${i18n.t`Water heaters heat the domestic water in a house`}
     type WaterHeater @cacheControl(maxAge: 90) {
       # ${i18n.t`Type of tank being used to heat the domestic water in the house (en)`}
-      typeEnglish: I18NString
+      typeEnglish: String
       # ${i18n.t`Type of tank being used to heat the domestic water in the house (fr)`}
-      typeFrench: I18NString
+      typeFrench: String
       # ${i18n.t`Capacity of the tank in litres (L)`}
       tankVolumeLitres: I18NFloat
       # ${i18n.t`Capacity of the tank in gallons (Gal)`}
       tankVolumeGallon: I18NFloat
       # ${i18n.t`Measures how effectively your water heater is burning fuel or turning fuel into heat`}
-      efficiencyEf: I18NString
+      efficiencyEf: String
       # ${i18n.t`A percentage representing the ratio of how effectively your water heater is turning fuel into heat`}
-      efficiencyPercentage: I18NString
+      efficiencyPercentage: String
     }
 
     # ${i18n.t`A principal heating system is either the only source of heat for the house, or is used for at least 70% of the heating load`}
     type Heating @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of heating system`}
-      label: I18NString
+      label: String
       # ${i18n.t`Type of heating system (en)`}
-      heatingTypeEnglish: I18NString
+      heatingTypeEnglish: String
       # ${i18n.t`Type of heating system (fr)`}
-      heatingTypeFrench: I18NString
+      heatingTypeFrench: String
       # ${i18n.t`The source of fuel for the heating system (en)`}
-      energySourceEnglish: I18NString
+      energySourceEnglish: String
       # ${i18n.t`The source of fuel for the heating system (fr)`}
-      energySourceFrench: I18NString
+      energySourceFrench: String
       # ${i18n.t`Equipment type of heating system (en)`}
-      equipmentTypeEnglish: I18NString
+      equipmentTypeEnglish: String
       # ${i18n.t`Equipment type of heating system (fr)`}
-      equipmentTypeFrench: I18NString
+      equipmentTypeFrench: String
       # ${i18n.t`Output capacity of the heating system in kilowatt hours (kWh)`}
       outputSizeKW: I18NFloat
       # ${i18n.t`Output capacity of the heating system in British Thermal Units per hour (BTU/h)`}
@@ -129,7 +129,7 @@ const Schema = i18n => {
       efficiency: I18NFloat
       # ${i18n.t`Steady-state efficiency is the combustion efficiency of the equipment at peak performance.
         The Annual Fuel Utilization Efficiency (AFUE) is a measure of efficiency based on average usage, accounting for the fact that most heating systems rarely run long enough to reach peak performance.`}
-      steadyState: I18NString
+      steadyState: String
     }
 
     # ${i18n.t`One page of results`}
@@ -139,9 +139,9 @@ const Schema = i18n => {
       # ${i18n.t`If true, a previous page of results can be returned`}
       hasPrevious: Boolean
       # ${i18n.t`Identifier used to return the next page of results`}
-      next: I18NString
+      next: String
       # ${i18n.t`Identifier cursor used to return the previous page of results`}
-      previous: I18NString
+      previous: String
       # ${i18n.t`A list of dwellings`}
       results: [Dwelling]
     }
@@ -161,15 +161,15 @@ const Schema = i18n => {
     # ${i18n.t`Walls separate the interior heated space from the outside (interior partition walls are not considered walls)`}
     type Wall @cacheControl(maxAge: 90) {
       # ${i18n.t`Description of wall location`}
-      label: I18NString
+      label: String
       # ${i18n.t`Wall construction being used (en)`}
-      structureTypeEnglish: I18NString
+      structureTypeEnglish: String
       # ${i18n.t`Wall construction being used (fr)`}
-      structureTypeFrench: I18NString
+      structureTypeFrench: String
       # ${i18n.t`Size of the component type (en)`}
-      componentTypeSizeEnglish: I18NString
+      componentTypeSizeEnglish: String
       # ${i18n.t`Size of the component type (fr)`}
-      componentTypeSizeFrench: I18NString
+      componentTypeSizeFrench: String
       # ${i18n.t`Wall insulation nominal RSI (R-value Systeme International)`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`Wall insulation nominal R-value`}
@@ -195,9 +195,9 @@ const Schema = i18n => {
     # ${i18n.t`Doors are on outside walls, separating the interior heated space from the outside`}
     type Door @cacheControl(maxAge: 90) {
       # ${i18n.t`Describes the construction of the door (en)`}
-      typeEnglish: I18NString
+      typeEnglish: String
       # ${i18n.t`Describes the construction of the door (fr)`}
-      typeFrench: I18NString
+      typeFrench: String
       # ${i18n.t`Door RSI (R-value Systeme International)`}
       insulationRsi: I18NFloat
       # ${i18n.t`Door R-value`}
@@ -215,35 +215,35 @@ const Schema = i18n => {
     # ${i18n.t`Windows separate the interior heated space from the outside`}
     type Window @cacheControl(maxAge: 90) {
       # ${i18n.t`Used to identify the window component in the house`}
-      label: I18NString
+      label: String
       # ${i18n.t`Window RSI (R-value Systeme International)`}
       insulationRsi: I18NFloat
       # ${i18n.t`Window R-value`}
       insulationR: I18NFloat
       # ${i18n.t`Number of panes of transparent material in a window (en)`}
-      glazingTypesEnglish: I18NString
+      glazingTypesEnglish: String
       # ${i18n.t`Number of panes of transparent material in a window (fr)`}
-      glazingTypesFrench: I18NString
+      glazingTypesFrench: String
       # ${i18n.t`Type of coating and tint on a window pane (en)`}
-      coatingsTintsEnglish: I18NString
+      coatingsTintsEnglish: String
       # ${i18n.t`Type of coating and tint on a window pane (fr)`}
-      coatingsTintsFrench: I18NString
+      coatingsTintsFrench: String
       # ${i18n.t`Type of gas injected between the glass layers (en)`}
-      fillTypeEnglish: I18NString
+      fillTypeEnglish: String
       # ${i18n.t`Type of gas injected between the glass layers (fr)`}
-      fillTypeFrench: I18NString
+      fillTypeFrench: String
       # ${i18n.t`Spacer systems used between the glass layers (en)`}
-      spacerTypeEnglish: I18NString
+      spacerTypeEnglish: String
       # ${i18n.t`Spacer systems used between the glass layers (fr)`}
-      spacerTypeFrench: I18NString
+      spacerTypeFrench: String
       # ${i18n.t`Describes the construction of the window (en)`}
-      typeEnglish: I18NString
+      typeEnglish: String
       # ${i18n.t`Describes the construction of the window (fr)`}
-      typeFrench: I18NString
+      typeFrench: String
       # ${i18n.t`Material type of the window frame (en)`}
-      frameMaterialEnglish: I18NString
+      frameMaterialEnglish: String
       # ${i18n.t`Material type of the window frame (fr)`}
-      frameMaterialFrench: I18NString
+      frameMaterialFrench: String
       # ${i18n.t`Window area in square metres (m2)`}
       areaMetres: I18NFloat
       # ${i18n.t`Window area in square feet (ft2)`}
@@ -261,11 +261,11 @@ const Schema = i18n => {
     # ${i18n.t`Ceilings are the upper interior surface of a room`}
     type Ceiling @cacheControl(maxAge: 90) {
       # ${i18n.t`Used to identify the ceiling in the house`}
-      label: I18NString
+      label: String
       # ${i18n.t`Describes the construction of the ceiling (en)`}
-      typeEnglish: I18NString
+      typeEnglish: String
       # ${i18n.t`Describes the construction of the ceiling (fr)`}
-      typeFrench: I18NString
+      typeFrench: String
       # ${i18n.t`Ceiling insulation nominal RSI (R-value Systeme International)`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`Ceiling insulation nominal R-value`}
@@ -287,14 +287,14 @@ const Schema = i18n => {
     # ${i18n.t`Detailed information about specific features of a given dwelling`}
     type Evaluation @cacheControl(maxAge: 90) {
       # ${i18n.t`Evaluation type codes are used to define the type of evaluation performed and to distinguish the house type (i.e. newly built or existing)`}
-      evaluationType: I18NString
+      evaluationType: String
       # ${i18n.t`Date the evaluation was made`}
-      entryDate: I18NString
-      fileId: I18NString
+      entryDate: String
+      fileId: String
       # ${i18n.t`Date the record was first created`}
-      creationDate: I18NString
+      creationDate: String
       # ${i18n.t`Date the record was last modified`}
-      modificationDate: I18NString
+      modificationDate: String
       # ${i18n.t`A list of ceiling data entries for a dwelling`}
       ceilings: [Ceiling]
       # ${i18n.t`A list of wall data entries for a dwelling`}
@@ -318,7 +318,7 @@ const Schema = i18n => {
       # ${i18n.t`The details of the foundation`}
       foundations: [Foundation]
       # ${i18n.t`The EnerGuide Rating calculated for this evaluation`}
-      ersRating: I18NString
+      ersRating: String
     }
 
     # ${i18n.t`A residential building evaluted under the Energuide program`}
@@ -328,11 +328,11 @@ const Schema = i18n => {
       # ${i18n.t`Year of construction`}
       yearBuilt: Int
       # ${i18n.t`Name of city where dwelling is located`}
-      city: I18NString
+      city: String
       # ${i18n.t`Region of country for dwelling (province/territory)`}
-      region: I18NString
+      region: String
       # ${i18n.t`The first three characters of a Canadian postal code, which correspond to a geographical area defined by Canada Post`}
-      forwardSortationArea: I18NString
+      forwardSortationArea: String
       # ${i18n.t`A list of evaluations of specific features of the dwelling`}
       evaluations: [Evaluation]
     }
@@ -342,7 +342,7 @@ const Schema = i18n => {
       # ${i18n.t`Details for a specific dwelling`}
       dwelling(houseId: Int!): Dwelling
       # ${i18n.t`Details for all dwellings, optionally filtered by one or more values`}
-      dwellings(filters: [Filter!] dateRange: DateRange limit: Int next: I18NString previous: I18NString): PaginatedResultSet
+      dwellings(filters: [Filter!] dateRange: DateRange limit: Int next: String previous: String): PaginatedResultSet
     }
 
     # ${i18n.t`An ISO date value, formatted 'YYYY-MM-DD'`}

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -9,7 +9,7 @@ import { createHeader } from './types/Header'
 const Schema = i18n => {
   const typeDefs = [
     `
-    scalar I18NInt
+    scalar Int
     scalar I18NFloat
     scalar I18NString
     scalar Boolean
@@ -50,9 +50,9 @@ const Schema = i18n => {
       # ${i18n.t`Part of the dwelling to be upgraded`}
       upgradeType: I18NString
       # ${i18n.t`Estimated cost of upgrade`}
-      cost: I18NInt
+      cost: Int
       # ${i18n.t`Order of importance of upgrade recommendation (lower number means a higher priority)`}
-      priority: I18NInt
+      priority: Int
     }
 
     # ${i18n.t`Ventilation systems draw exterior air into the house, exhaust interior air to the exterior, or both`}
@@ -324,9 +324,9 @@ const Schema = i18n => {
     # ${i18n.t`A residential building evaluted under the Energuide program`}
     type Dwelling @cacheControl(maxAge: 90) {
       # ${i18n.t`Unique identification number for a dwelling`}
-      houseId: I18NInt
+      houseId: Int
       # ${i18n.t`Year of construction`}
-      yearBuilt: I18NInt
+      yearBuilt: Int
       # ${i18n.t`Name of city where dwelling is located`}
       city: I18NString
       # ${i18n.t`Region of country for dwelling (province/territory)`}
@@ -340,9 +340,9 @@ const Schema = i18n => {
     # ${i18n.t`The root query type`}
     type Query @cacheControl(maxAge: 90) {
       # ${i18n.t`Details for a specific dwelling`}
-      dwelling(houseId: I18NInt!): Dwelling
+      dwelling(houseId: Int!): Dwelling
       # ${i18n.t`Details for all dwellings, optionally filtered by one or more values`}
-      dwellings(filters: [Filter!] dateRange: DateRange limit: I18NInt next: I18NString previous: I18NString): PaginatedResultSet
+      dwellings(filters: [Filter!] dateRange: DateRange limit: Int next: I18NString previous: I18NString): PaginatedResultSet
     }
 
     # ${i18n.t`An ISO date value, formatted 'YYYY-MM-DD'`}

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -156,7 +156,7 @@ const Resolvers = i18n => {
   return {
     Int: createI18NInt(i18n),
     String: createI18NString(i18n),
-    I18NFloat: createI18NFloat(i18n),
+    Float: createI18NFloat(i18n),
     Boolean: createI18NBoolean(i18n),
     Date: createI18NDate(i18n),
     Query: {

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -157,7 +157,7 @@ const Resolvers = i18n => {
     I18NInt: createI18NInt(i18n),
     I18NString: createI18NString(i18n),
     I18NFloat: createI18NFloat(i18n),
-    I18NBoolean: createI18NBoolean(i18n),
+    Boolean: createI18NBoolean(i18n),
     Date: createI18NDate(i18n),
     Query: {
       dwelling: async (root, { houseId }, { client }) => {

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -158,7 +158,7 @@ const Resolvers = i18n => {
     I18NString: createI18NString(i18n),
     I18NFloat: createI18NFloat(i18n),
     I18NBoolean: createI18NBoolean(i18n),
-    I18NDate: createI18NDate(i18n),
+    Date: createI18NDate(i18n),
     Query: {
       dwelling: async (root, { houseId }, { client }) => {
         let query = {

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -155,7 +155,7 @@ import { createI18NDate } from './types/I18NDate'
 const Resolvers = i18n => {
   return {
     Int: createI18NInt(i18n),
-    I18NString: createI18NString(i18n),
+    String: createI18NString(i18n),
     I18NFloat: createI18NFloat(i18n),
     Boolean: createI18NBoolean(i18n),
     Date: createI18NDate(i18n),

--- a/api/src/schema/resolvers.js
+++ b/api/src/schema/resolvers.js
@@ -154,7 +154,7 @@ import { createI18NDate } from './types/I18NDate'
 
 const Resolvers = i18n => {
   return {
-    I18NInt: createI18NInt(i18n),
+    Int: createI18NInt(i18n),
     I18NString: createI18NString(i18n),
     I18NFloat: createI18NFloat(i18n),
     Boolean: createI18NBoolean(i18n),

--- a/api/src/schema/types/Foundation.js
+++ b/api/src/schema/types/Foundation.js
@@ -3,17 +3,17 @@ export const createFoundation = i18n => {
     # ${i18n.t`The lowest load-bearing part of a dwelling`}
     type Foundation @cacheControl(maxAge: 90) {
       # ${i18n.t`The type of foundation (en)`}
-      foundationTypeEnglish: I18NString
+      foundationTypeEnglish: String
       # ${i18n.t`The type of foundation (fr)`}
-      foundationTypeFrench: I18NString
+      foundationTypeFrench: String
       # ${i18n.t`A descriptive label for the foundation`}
-      label: I18NString
+      label: String
       # ${i18n.t`The type of configuration for the foundation`}
-      configurationType: I18NString
+      configurationType: String
       # ${i18n.t`The material used in the construction of this foundation (en)`}
-      materialEnglish: I18NString
+      materialEnglish: String
       # ${i18n.t`The material used in the construction of this foundation (fr)`}
-      materialFrench: I18NString
+      materialFrench: String
       # ${i18n.t`The details of the floors associated with this foundation`}
       floors: [FoundationFloor]
       # ${i18n.t`The details of the walls associated with this foundation`}

--- a/api/src/schema/types/FoundationFloor.js
+++ b/api/src/schema/types/FoundationFloor.js
@@ -3,9 +3,9 @@ export const createFoundationFloor = i18n => {
     # ${i18n.t`A floor below ground that represents the usable area of the house`}
     type FoundationFloor @cacheControl(maxAge: 90) {
       # ${i18n.t`Type of foundation floor (en)`}
-      floorTypeEnglish: I18NString
+      floorTypeEnglish: String
       # ${i18n.t`Type of foundation floor (fr)`}
-      floorTypeFrench: I18NString
+      floorTypeFrench: String
       # ${i18n.t`The insulation nominal RSI (R-value Systeme International) of the foundation floor`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`The insulation nominal R-value of the foundation floor`}

--- a/api/src/schema/types/FoundationFloor.js
+++ b/api/src/schema/types/FoundationFloor.js
@@ -7,29 +7,29 @@ export const createFoundationFloor = i18n => {
       # ${i18n.t`Type of foundation floor (fr)`}
       floorTypeFrench: String
       # ${i18n.t`The insulation nominal RSI (R-value Systeme International) of the foundation floor`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`The insulation nominal R-value of the foundation floor`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`The insulation effective RSI (R-value Systeme International) of the foundation floor`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`The insulation effective R-value of the foundation floor`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`The area of the foundation floor in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`The area of the foundation floor in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`The perimeter of the foundation floor in metres (m)`}
-      perimeterMetres: I18NFloat
+      perimeterMetres: Float
       # ${i18n.t`The perimeter of the foundation floor in feet (ft)`}
-      perimeterFeet: I18NFloat
+      perimeterFeet: Float
       # ${i18n.t`The width of the foundation floor in metres (m)`}
-      heightMetres: I18NFloat
+      heightMetres: Float
       # ${i18n.t`The width of the foundation floor in feet (ft)`}
-      heightFeet: I18NFloat
+      heightFeet: Float
       # ${i18n.t`The length of the foundation floor in metres (m)`}
-      lengthMetres: I18NFloat
+      lengthMetres: Float
       # ${i18n.t`The length of the foundation floor in feet (ft)`}
-      lengthFeet: I18NFloat
+      lengthFeet: Float
     }
   `
   return FoundationFloor

--- a/api/src/schema/types/FoundationWall.js
+++ b/api/src/schema/types/FoundationWall.js
@@ -7,19 +7,19 @@ export const createFoundationWall = i18n => {
       # ${i18n.t`Wall construction being used (fr)`}
       wallTypeFrench: String
       # ${i18n.t`Wall insulation nominal RSI (R-value Systeme International)`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`Wall insulation nominal R-value`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`Wall insulation effective RSI (R-value Systeme International)`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`Wall insulation nominal R-value`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`Wall area of the house in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Wall area of the house in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`The percentage of the total wall area this section accounts for`}
-      percentage: I18NFloat
+      percentage: Float
     }
   `
   return FoundationWall

--- a/api/src/schema/types/FoundationWall.js
+++ b/api/src/schema/types/FoundationWall.js
@@ -3,9 +3,9 @@ export const createFoundationWall = i18n => {
     # ${i18n.t`Foundation Walls are below-ground walls separating the interior heated space from the outside (interior partition walls are not considered walls)`}
     type FoundationWall @cacheControl(maxAge: 90) {
       # ${i18n.t`Wall construction being used (en)`}
-      wallTypeEnglish: I18NString
+      wallTypeEnglish: String
       # ${i18n.t`Wall construction being used (fr)`}
-      wallTypeFrench: I18NString
+      wallTypeFrench: String
       # ${i18n.t`Wall insulation nominal RSI (R-value Systeme International)`}
       insulationNominalRsi: I18NFloat
       # ${i18n.t`Wall insulation nominal R-value`}

--- a/api/src/schema/types/Header.js
+++ b/api/src/schema/types/Header.js
@@ -2,25 +2,25 @@ export const createHeader = i18n => {
   const Header = `
     type Header @cacheControl(maxAge: 90) {
       # ${i18n.t`Header insulation nominal RSI (R-value Systeme International)`}
-      insulationNominalRsi: I18NFloat
+      insulationNominalRsi: Float
       # ${i18n.t`Header insulation nominal R-value`}
-      insulationNominalR: I18NFloat
+      insulationNominalR: Float
       # ${i18n.t`Header insulation effective RSI (R-value Systeme International)`}
-      insulationEffectiveRsi: I18NFloat
+      insulationEffectiveRsi: Float
       # ${i18n.t`Header insulation effective R-value`}
-      insulationEffectiveR: I18NFloat
+      insulationEffectiveR: Float
       # ${i18n.t`Header area in square metres (m2)`}
-      areaMetres: I18NFloat
+      areaMetres: Float
       # ${i18n.t`Header area in square feet (ft2)`}
-      areaFeet: I18NFloat
+      areaFeet: Float
       # ${i18n.t`Header perimeter of the house in metres (m)`}
-      perimeterMetres: I18NFloat
+      perimeterMetres: Float
       # ${i18n.t`Header perimeter of the house in feet (ft)`}
-      perimeterFeet: I18NFloat
+      perimeterFeet: Float
       # ${i18n.t`Header height in metres (m)`}
-      heightMetres: I18NFloat
+      heightMetres: Float
       # ${i18n.t`Header height in feet (ft)`}
-      heightFeet: I18NFloat
+      heightFeet: Float
     }
   `
   return Header

--- a/api/src/schema/types/__tests__/Foundation.test.js
+++ b/api/src/schema/types/__tests__/Foundation.test.js
@@ -19,7 +19,7 @@ describe('Schema Types', () => {
       schema = makeExecutableSchema({
         typeDefs: [
           createFoundation(i18n),
-          `scalar I18NString`,
+          `scalar String`,
           `scalar I18NFloat`,
           createFoundationFloor(i18n),
           createFoundationWall(i18n),
@@ -28,7 +28,7 @@ describe('Schema Types', () => {
         resolvers: [
           {
             I18NFloat: createI18NFloat(i18n),
-            I18NString: createI18NString(i18n),
+            String: createI18NString(i18n),
           },
         ],
       })

--- a/api/src/schema/types/__tests__/FoundationFloor.test.js
+++ b/api/src/schema/types/__tests__/FoundationFloor.test.js
@@ -15,11 +15,11 @@ describe('Schema Types', () => {
     beforeEach(() => {
       const FoundationFloor = createFoundationFloor(i18n)
       schema = makeExecutableSchema({
-        typeDefs: [FoundationFloor, `scalar I18NFloat`, `scalar I18NString`],
+        typeDefs: [FoundationFloor, `scalar I18NFloat`, `scalar String`],
         resolvers: [
           {
             I18NFloat: createI18NFloat(i18n),
-            I18NString: createI18NString(i18n),
+            String: createI18NString(i18n),
           },
         ],
       })

--- a/api/src/schema/types/__tests__/FoundationWall.test.js
+++ b/api/src/schema/types/__tests__/FoundationWall.test.js
@@ -15,11 +15,11 @@ describe('Schema Types', () => {
     beforeEach(() => {
       const FoundationWall = createFoundationWall(i18n)
       schema = makeExecutableSchema({
-        typeDefs: [FoundationWall, `scalar I18NFloat`, `scalar I18NString`],
+        typeDefs: [FoundationWall, `scalar I18NFloat`, `scalar String`],
         resolvers: [
           {
             I18NFloat: createI18NFloat(i18n),
-            I18NString: createI18NString(i18n),
+            String: createI18NString(i18n),
           },
         ],
       })


### PR DESCRIPTION
Changing all of the names of our overwritten types to their default names. This will make it easier for external clients to connect to our API, as having changed the names of all the primitive scalar types is possibly a weird gotcha.

`I18NDate` -> `Date`
`I18NBoolean` -> `Boolean`
`I18NInt` -> `Int`
`I18NString` -> `String`
`I18NFloat` -> `Float`

Also changed the return types of a couple fields in the final commit. @buckley-w-david, do those changes look okay to you?