### PR TITLE
[WIP] Triggers continued

### DIFF
--- a/extract_endpoint/src/extract_endpoint/azure_utils.py
+++ b/extract_endpoint/src/extract_endpoint/azure_utils.py
@@ -26,7 +26,7 @@ class StorageProtocol(typing_extensions.Protocol):
         pass
 
 
-class MockStorage:
+class MockStorage(StorageProtocol):
     def __init__(self) -> None:
         self._data: typing.Dict[str, bytes] = {}
 
@@ -41,7 +41,7 @@ class MockStorage:
             raise LookupError('File does not exist')
 
 
-class AzureStorage:
+class AzureStorage(StorageProtocol):
     def __init__(self, coords: StorageCoordinates) -> None:
         self._coords = coords
         self._azure_service = blob.BlockBlobService(account_name=self._coords.account,

--- a/extract_endpoint/src/extract_endpoint/endpoint_runner.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_runner.py
@@ -1,15 +1,6 @@
 import typing
 from extract_endpoint.endpoint_triggers import EndpointTrigger
 
-# class EndpointRunner:
-#     def __init__(self, stream: typing.IO[bytes], timestamp: str, url: str) -> None:
-#         self.stream = stream
-#         self.timestamp = timestamp
-#         self.url = url
-#
-#     def apply(self, stream: typing.IO[bytes]) -> None:
-#         this_is_a_test()
-
 
 class EndpointRunner:
     def __init__(self, triggers: typing.List[EndpointTrigger]) -> None:
@@ -17,10 +8,6 @@ class EndpointRunner:
         return None
 
     def apply(self) -> None:
-        this_is_a_test()
         for trigger in self.triggers:
             trigger.run()
-
-
-def this_is_a_test() -> None:
-    print("Starting tests")
+            # raise error here if code is not correct

--- a/extract_endpoint/src/extract_endpoint/endpoint_runner.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_runner.py
@@ -1,13 +1,15 @@
 import typing
+from http import HTTPStatus
 from extract_endpoint.endpoint_triggers import EndpointTrigger
 
 
 class EndpointRunner:
     def __init__(self, triggers: typing.List[EndpointTrigger]) -> None:
         self.triggers = triggers
-        return None
 
-    def apply(self) -> None:
+    def apply(self) -> int:
         for trigger in self.triggers:
-            trigger.run()
-            # raise error here if code is not correct
+            result = trigger.run()
+            if result != HTTPStatus.CREATED:
+                return result
+        return HTTPStatus.CREATED

--- a/extract_endpoint/src/extract_endpoint/endpoint_runner.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_runner.py
@@ -1,0 +1,26 @@
+import typing
+from extract_endpoint.endpoint_triggers import EndpointTrigger
+
+# class EndpointRunner:
+#     def __init__(self, stream: typing.IO[bytes], timestamp: str, url: str) -> None:
+#         self.stream = stream
+#         self.timestamp = timestamp
+#         self.url = url
+#
+#     def apply(self, stream: typing.IO[bytes]) -> None:
+#         this_is_a_test()
+
+
+class EndpointRunner:
+    def __init__(self, triggers: typing.List[EndpointTrigger]) -> None:
+        self.triggers = triggers
+        return None
+
+    def apply(self) -> None:
+        this_is_a_test()
+        for trigger in self.triggers:
+            trigger.run()
+
+
+def this_is_a_test() -> None:
+    print("Starting tests")

--- a/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
@@ -10,6 +10,10 @@ SAMPLE_FILENAME = "sample_file.txt"
 
 
 class EndpointTrigger(typing_extensions.Protocol):
+
+    def run_count(self) -> int:
+        pass
+
     def run(self) -> int:
         pass
 
@@ -19,18 +23,28 @@ class MockUploadToAzure(EndpointTrigger):
         self._data = data
         self._timestamp = timestamp
         self._timestamp_filename = timestamp_filename
+        self._run_count = 0
+
+    @property
+    def run_count(self) -> int:
+        return self._run_count
 
     def run(self) -> int:
         mock_service = azure_utils.MockStorage()
+        self._run_count += 1
         return upload_to_storage(mock_service, self._data, self._timestamp, self._timestamp_filename)
 
 
 class MockTriggerTL(EndpointTrigger):
-    def __init__(self, data: typing.IO[bytes]) -> None:
-        self._data = data
+    def __init__(self) -> None:
+        self._run_count = 0
+
+    @property
+    def run_count(self) -> int:
+        return self._run_count
 
     def run(self) -> int:
-        print("Mock trigger for Transform process is triggered, Huzzah!")
+        self._run_count += 1
         return HTTPStatus.CREATED
 
 
@@ -51,8 +65,8 @@ class UploadFilesToAzure(EndpointTrigger):
 
 
 class TriggerTL(EndpointTrigger):
-    def __init__(self, data: typing.IO[bytes]) -> None:
-        self._data = data
+    def __init__(self) -> None:
+        self._placeholder = True
 
     def run(self) -> int:
         print("Transform process is triggered, huzzah!")

--- a/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
@@ -1,8 +1,8 @@
 import typing
-import typing_extensions
-import zipfile
-from werkzeug import utils
 from http import HTTPStatus
+import zipfile
+import typing_extensions
+from werkzeug import utils
 from extract_endpoint import azure_utils
 
 
@@ -35,7 +35,11 @@ class MockTriggerTL(EndpointTrigger):
 
 
 class UploadFilesToAzure(EndpointTrigger):
-    def __init__(self, data: typing.IO[bytes], timestamp: str, timestamp_filename: str, coords: azure_utils.StorageCoordinates) -> None:
+    def __init__(self, data: typing.IO[bytes],
+                 timestamp: str,
+                 timestamp_filename: str,
+                 coords: azure_utils.StorageCoordinates) -> None:
+
         self._data = data
         self._coords = coords
         self._timestamp = timestamp

--- a/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint_triggers.py
@@ -1,0 +1,74 @@
+import typing
+import typing_extensions
+import zipfile
+from werkzeug import utils
+from http import HTTPStatus
+from extract_endpoint import azure_utils
+
+
+SAMPLE_FILENAME = "sample_file.txt"
+
+
+class EndpointTrigger(typing_extensions.Protocol):
+    def run(self) -> int:
+        pass
+
+
+class MockUploadToAzure(EndpointTrigger):
+    def __init__(self, data: typing.IO[bytes], timestamp: str, timestamp_filename: str) -> None:
+        self._data = data
+        self._timestamp = timestamp
+        self._timestamp_filename = timestamp_filename
+
+    def run(self) -> int:
+        mock_service = azure_utils.MockStorage()
+        return upload_to_storage(mock_service, self._data, self._timestamp, self._timestamp_filename)
+
+
+class MockTriggerTL(EndpointTrigger):
+    def __init__(self, data: typing.IO[bytes]) -> None:
+        self._data = data
+
+    def run(self) -> int:
+        print("Mock trigger for Transform process is triggered, Huzzah!")
+        return HTTPStatus.CREATED
+
+
+class UploadFilesToAzure(EndpointTrigger):
+    def __init__(self, data: typing.IO[bytes], timestamp: str, timestamp_filename: str, coords: azure_utils.StorageCoordinates) -> None:
+        self._data = data
+        self._coords = coords
+        self._timestamp = timestamp
+        self._timestamp_filename = timestamp_filename
+
+    def run(self) -> int:
+        azure_service = azure_utils.AzureStorage(self._coords)
+        return upload_to_storage(azure_service, self._data, self._timestamp, self._timestamp_filename)
+
+
+class TriggerTL(EndpointTrigger):
+    def __init__(self, data: typing.IO[bytes]) -> None:
+        self._data = data
+
+    def run(self) -> int:
+        print("Transform process is triggered, huzzah!")
+        return HTTPStatus.CREATED
+
+
+def upload_to_storage(storage_service: azure_utils.StorageProtocol,
+                      data: typing.IO[bytes],
+                      timestamp: str,
+                      timestamp_filename: str) -> int:
+    try:
+        file_z = zipfile.ZipFile(data)
+    except zipfile.BadZipFile:
+        return HTTPStatus.BAD_REQUEST
+
+    for json_file in [file_z.open(zipinfo) for zipinfo in file_z.infolist()]:
+        if not storage_service.upload(json_file.read(), utils.secure_filename(json_file.name)):
+            return HTTPStatus.BAD_GATEWAY
+
+    if not storage_service.upload(timestamp.encode(), timestamp_filename):
+        return HTTPStatus.BAD_GATEWAY
+
+    return HTTPStatus.CREATED

--- a/extract_endpoint/tests/conftest.py
+++ b/extract_endpoint/tests/conftest.py
@@ -1,5 +1,6 @@
 import io
 import datetime
+import hashlib
 import zipfile
 import typing
 import pytest
@@ -79,3 +80,32 @@ def sample_zipfile_fixture(tmpdir: py._path.local.LocalPath,
 @pytest.fixture
 def sample_nonzipfile() -> io.BytesIO:
     return io.BytesIO(b'Not a zipfile')
+
+
+@pytest.fixture
+def sample_salt() -> str:
+    return 'sample salt'
+
+
+@pytest.fixture
+def sample_salt_signature(sample_salt: str, sample_secret_key: str) -> str:
+    hasher = hashlib.new('sha3_256')
+    hasher.update((sample_salt + sample_secret_key).encode())
+    return hasher.hexdigest()
+
+
+@pytest.fixture
+def sample_trigger_url() -> str:
+    return 'https://www.nrcan.ca:4000/run_tl'
+
+
+@pytest.fixture
+def sample_trigger_data(sample_salt: str, sample_salt_signature: str) -> typing.Dict[str, str]:
+    sample_trigger_data = {'salt': sample_salt, 'signature': sample_salt_signature}
+    return sample_trigger_data
+
+
+@pytest.fixture
+def sample_trigger_bad_data(sample_salt: str, sample_salt_signature: str) -> typing.Dict[str, str]:
+    sample_trigger_bad_data = {'not-salt': sample_salt, 'signature': sample_salt_signature}
+    return sample_trigger_bad_data

--- a/extract_endpoint/tests/conftest.py
+++ b/extract_endpoint/tests/conftest.py
@@ -74,3 +74,8 @@ def sample_zipfile_fixture(tmpdir: py._path.local.LocalPath,
         file_z.writestr(name, contents)
     file_z.close()
     return file
+
+
+@pytest.fixture
+def sample_nonzipfile() -> io.BytesIO:
+    return io.BytesIO(b'Not a zipfile')

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -44,11 +44,6 @@ def sample_zipfile_signature(sample_salt: str, sample_secret_key: str, sample_zi
 
 
 @pytest.fixture
-def sample_nonzipfile() -> io.BytesIO:
-    return io.BytesIO(b'Not a zipfile')
-
-
-@pytest.fixture
 def sample_nonzipfile_signature(sample_salt: str, sample_secret_key: str, sample_nonzipfile: io.BytesIO) -> str:
     hasher = hashlib.new('sha3_256')
     hasher.update((sample_salt + sample_secret_key).encode())

--- a/extract_endpoint/tests/test_endpoint_runner.py
+++ b/extract_endpoint/tests/test_endpoint_runner.py
@@ -1,26 +1,41 @@
 import io
 import typing
+from http import HTTPStatus
 import pytest
-from extract_endpoint import endpoint_runner, endpoint_triggers, endpoint
+from extract_endpoint import endpoint
+from extract_endpoint.endpoint_triggers import EndpointTrigger, MockUploadToAzure, MockTriggerTL
+from extract_endpoint.endpoint_runner import EndpointRunner
 
 
 @pytest.fixture
 def sample_trigger_list(sample_zipfile: io.BytesIO,
-                        sample_timestamp: str) -> typing.List[endpoint_triggers.EndpointTrigger]:
+                        sample_timestamp: str) -> typing.List[EndpointTrigger]:
 
-    sample_trigger_list = [endpoint_triggers.MockUploadToAzure(sample_zipfile, sample_timestamp,
-                                                               endpoint.TIMESTAMP_FILENAME),
-                           endpoint_triggers.MockTriggerTL()]
+    sample_trigger_list = [MockUploadToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME),
+                           MockTriggerTL()]
 
     return sample_trigger_list
 
 
-def test_endpoint_runner_runs_triggers(sample_trigger_list: typing.List[endpoint_triggers.EndpointTrigger]) -> None:
-    test_runner = endpoint_runner.EndpointRunner(sample_trigger_list)
-    test_runner.apply()
+@pytest.fixture
+def sample_trigger_list_fail(sample_nonzipfile: io.BytesIO, sample_timestamp: str) -> typing.List[EndpointTrigger]:
+
+    sample_trigger_list_fail = [MockUploadToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME),
+                                MockTriggerTL()]
+    return sample_trigger_list_fail
+
+
+def test_endpoint_runner_runs_triggers(sample_trigger_list: typing.List[EndpointTrigger]) -> None:
+    test_runner = EndpointRunner(sample_trigger_list)
+    result = test_runner.apply()
+    assert result == HTTPStatus.CREATED
     for trigger in test_runner.triggers:
         assert trigger.run_count == 1
 
 
-def test_endpoint_runner_stops_if_trigger_fails() -> None:
-    assert True
+def test_endpoint_runner_stops_if_fail(sample_trigger_list_fail: typing.List[EndpointTrigger]) -> None:
+    test_runner = EndpointRunner(sample_trigger_list_fail)
+    result = test_runner.apply()
+    assert result == HTTPStatus.BAD_REQUEST
+    assert test_runner.triggers[0].run_count == 1
+    assert test_runner.triggers[1].run_count == 0

--- a/extract_endpoint/tests/test_endpoint_runner.py
+++ b/extract_endpoint/tests/test_endpoint_runner.py
@@ -9,19 +9,38 @@ from extract_endpoint.endpoint_runner import EndpointRunner
 
 @pytest.fixture
 def sample_trigger_list(sample_zipfile: io.BytesIO,
-                        sample_timestamp: str) -> typing.List[EndpointTrigger]:
+                        sample_timestamp: str,
+                        sample_secret_key: str,
+                        sample_trigger_url: str) -> typing.List[EndpointTrigger]:
 
     sample_trigger_list = [MockUploadToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME),
-                           MockTriggerTL()]
+                           MockTriggerTL(sample_secret_key, sample_trigger_url, None)]
 
     return sample_trigger_list
 
 
 @pytest.fixture
-def sample_trigger_list_fail(sample_nonzipfile: io.BytesIO, sample_timestamp: str) -> typing.List[EndpointTrigger]:
+def sample_trigger_list_fail_azure(sample_nonzipfile: io.BytesIO,
+                                   sample_timestamp: str,
+                                   sample_secret_key: str,
+                                   sample_trigger_url: str) -> typing.List[EndpointTrigger]:
 
     sample_trigger_list_fail = [MockUploadToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME),
-                                MockTriggerTL()]
+                                MockTriggerTL(sample_secret_key, sample_trigger_url, None)]
+
+    return sample_trigger_list_fail
+
+
+@pytest.fixture
+def sample_trigger_list_fail_tl(sample_zipfile: io.BytesIO,
+                                sample_timestamp: str,
+                                sample_secret_key: str,
+                                sample_trigger_url: str,
+                                sample_trigger_bad_data: typing.Dict[str, str]) -> typing.List[EndpointTrigger]:
+
+    sample_trigger_list_fail = [MockUploadToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME),
+                                MockTriggerTL(sample_secret_key, sample_trigger_url, sample_trigger_bad_data)]
+
     return sample_trigger_list_fail
 
 
@@ -33,9 +52,15 @@ def test_endpoint_runner_runs_triggers(sample_trigger_list: typing.List[Endpoint
         assert trigger.run_count == 1
 
 
-def test_endpoint_runner_stops_if_fail(sample_trigger_list_fail: typing.List[EndpointTrigger]) -> None:
-    test_runner = EndpointRunner(sample_trigger_list_fail)
+def test_endpoint_runner_stops_if_azure_fail(sample_trigger_list_fail_azure: typing.List[EndpointTrigger]) -> None:
+    test_runner = EndpointRunner(sample_trigger_list_fail_azure)
     result = test_runner.apply()
     assert result == HTTPStatus.BAD_REQUEST
     assert test_runner.triggers[0].run_count == 1
     assert test_runner.triggers[1].run_count == 0
+
+
+def test_endpoint_runner_fails_if_trigger_fail(sample_trigger_list_fail_tl: typing.List[EndpointTrigger]) -> None:
+    test_runner = EndpointRunner(sample_trigger_list_fail_tl)
+    result = test_runner.apply()
+    assert result == HTTPStatus.BAD_REQUEST

--- a/extract_endpoint/tests/test_endpoint_runner.py
+++ b/extract_endpoint/tests/test_endpoint_runner.py
@@ -1,0 +1,26 @@
+import io
+import typing
+import pytest
+from extract_endpoint import endpoint_runner, endpoint_triggers, endpoint
+
+
+@pytest.fixture
+def sample_trigger_list(sample_zipfile: io.BytesIO,
+                        sample_timestamp: str) -> typing.List[endpoint_triggers.EndpointTrigger]:
+
+    sample_trigger_list = [endpoint_triggers.MockUploadToAzure(sample_zipfile, sample_timestamp,
+                                                               endpoint.TIMESTAMP_FILENAME),
+                           endpoint_triggers.MockTriggerTL()]
+
+    return sample_trigger_list
+
+
+def test_endpoint_runner_runs_triggers(sample_trigger_list: typing.List[endpoint_triggers.EndpointTrigger]) -> None:
+    test_runner = endpoint_runner.EndpointRunner(sample_trigger_list)
+    test_runner.apply()
+    for trigger in test_runner.triggers:
+        assert trigger.run_count == 1
+
+
+def test_endpoint_runner_stops_if_trigger_fails() -> None:
+    assert True

--- a/extract_endpoint/tests/test_endpoint_triggers.py
+++ b/extract_endpoint/tests/test_endpoint_triggers.py
@@ -1,0 +1,43 @@
+import io
+import pytest
+from http import HTTPStatus
+from extract_endpoint import endpoint_triggers, endpoint, azure_utils
+
+
+@pytest.fixture
+def sample_nonzipfile() -> io.BytesIO:
+    return io.BytesIO(b'Not a zipfile')
+
+
+def test_mock_upload_trigger(sample_zipfile: io.BytesIO, sample_timestamp: str):
+
+    mock_upload = endpoint_triggers.MockUploadToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME)
+    result = mock_upload.run()
+
+    assert result == HTTPStatus.CREATED
+
+
+def test_mock_upload_trigger_bad_file(sample_nonzipfile: io.BytesIO, sample_timestamp: str):
+
+    mock_upload = endpoint_triggers.MockUploadToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME)
+    result = mock_upload.run()
+
+    assert result == HTTPStatus.BAD_REQUEST
+
+
+@pytest.mark.usefixtures('azure_service')
+def test_azure_upload_trigger(azure_emulator_coords: azure_utils.StorageCoordinates, sample_zipfile: io.BytesIO, sample_timestamp: str):
+
+    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME, azure_emulator_coords)
+    result = azure_upload.run()
+
+    assert result == HTTPStatus.CREATED
+
+
+@pytest.mark.usefixtures('azure_service')
+def test_azure_upload_trigger_bad_file(azure_emulator_coords: azure_utils.StorageCoordinates, sample_nonzipfile: io.BytesIO, sample_timestamp: str):
+
+    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME, azure_emulator_coords)
+    result = azure_upload.run()
+
+    assert result == HTTPStatus.BAD_REQUEST

--- a/extract_endpoint/tests/test_endpoint_triggers.py
+++ b/extract_endpoint/tests/test_endpoint_triggers.py
@@ -1,4 +1,5 @@
 import io
+import typing
 from http import HTTPStatus
 import pytest
 from extract_endpoint import endpoint_triggers, endpoint, azure_utils
@@ -16,6 +17,30 @@ def test_mock_upload_trigger_bad_file(sample_nonzipfile: io.BytesIO, sample_time
 
     mock_upload = endpoint_triggers.MockUploadToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME)
     result = mock_upload.run()
+
+    assert result == HTTPStatus.BAD_REQUEST
+
+
+def test_mock_trigger_tl(sample_secret_key: str, sample_trigger_url: str, sample_trigger_data: typing.Dict[str, str]):
+    mock_trigger = endpoint_triggers.MockTriggerTL(sample_secret_key, sample_trigger_url, sample_trigger_data)
+    result = mock_trigger.run()
+
+    assert result == HTTPStatus.CREATED
+
+
+def test_mock_trigger_tl_no_data(sample_secret_key: str, sample_trigger_url: str):
+    mock_trigger = endpoint_triggers.MockTriggerTL(sample_secret_key, sample_trigger_url, None)
+    result = mock_trigger.run()
+
+    assert result == HTTPStatus.CREATED
+
+
+def test_mock_trigger_tl_bad_data(sample_secret_key: str,
+                                  sample_trigger_url: str,
+                                  sample_trigger_bad_data: typing.Dict[str, str]):
+
+    mock_trigger = endpoint_triggers.MockTriggerTL(sample_secret_key, sample_trigger_url, sample_trigger_bad_data)
+    result = mock_trigger.run()
 
     assert result == HTTPStatus.BAD_REQUEST
 

--- a/extract_endpoint/tests/test_endpoint_triggers.py
+++ b/extract_endpoint/tests/test_endpoint_triggers.py
@@ -4,11 +4,6 @@ import pytest
 from extract_endpoint import endpoint_triggers, endpoint, azure_utils
 
 
-@pytest.fixture
-def sample_nonzipfile() -> io.BytesIO:
-    return io.BytesIO(b'Not a zipfile')
-
-
 def test_mock_upload_trigger(sample_zipfile: io.BytesIO, sample_timestamp: str):
 
     mock_upload = endpoint_triggers.MockUploadToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME)

--- a/extract_endpoint/tests/test_endpoint_triggers.py
+++ b/extract_endpoint/tests/test_endpoint_triggers.py
@@ -1,6 +1,6 @@
 import io
-import pytest
 from http import HTTPStatus
+import pytest
 from extract_endpoint import endpoint_triggers, endpoint, azure_utils
 
 
@@ -26,18 +26,29 @@ def test_mock_upload_trigger_bad_file(sample_nonzipfile: io.BytesIO, sample_time
 
 
 @pytest.mark.usefixtures('azure_service')
-def test_azure_upload_trigger(azure_emulator_coords: azure_utils.StorageCoordinates, sample_zipfile: io.BytesIO, sample_timestamp: str):
+def test_azure_upload_trigger(azure_emulator_coords:
+                              azure_utils.StorageCoordinates,
+                              sample_zipfile: io.BytesIO,
+                              sample_timestamp: str):
 
-    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_zipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME, azure_emulator_coords)
+    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_zipfile,
+                                                        sample_timestamp,
+                                                        endpoint.TIMESTAMP_FILENAME,
+                                                        azure_emulator_coords)
     result = azure_upload.run()
 
     assert result == HTTPStatus.CREATED
 
 
 @pytest.mark.usefixtures('azure_service')
-def test_azure_upload_trigger_bad_file(azure_emulator_coords: azure_utils.StorageCoordinates, sample_nonzipfile: io.BytesIO, sample_timestamp: str):
+def test_azure_upload_trigger_bad_file(azure_emulator_coords: azure_utils.StorageCoordinates,
+                                       sample_nonzipfile: io.BytesIO,
+                                       sample_timestamp: str):
 
-    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_nonzipfile, sample_timestamp, endpoint.TIMESTAMP_FILENAME, azure_emulator_coords)
+    azure_upload = endpoint_triggers.UploadFilesToAzure(sample_nonzipfile,
+                                                        sample_timestamp,
+                                                        endpoint.TIMESTAMP_FILENAME,
+                                                        azure_emulator_coords)
     result = azure_upload.run()
 
     assert result == HTTPStatus.BAD_REQUEST


### PR DESCRIPTION
This PR follows the azure_utils refactor. It adds endpoint_triggers and endpoint_runner. The idea is to create a list of triggers to send to the runner & separate out a bit of the POST upload function (especially azure components). 

To start, this PR adds an upload to azure trigger and a mock version. 

This is turning out to be a larger refactor than I anticipated and I'm not sure of the value of a massive refactor right before the deadline but... I had fun doing it and this is cool, so it'll at least live in a WIP PR :D (until it gets 🗡 )