### PR TITLE
Fix Heating errors

### DIFF
--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -134,7 +134,8 @@ class Heating(_Heating):
         try:
             steady_state_value = node.get('Type1/*/Specifications/@isSteadyState', str)
         except ElementGetValueError as exc:
-            raise InvalidEmbeddedDataTypeError(Heating, 'No isSteadyState value') from exc
+            return 'Steady State'
+            # raise InvalidEmbeddedDataTypeError(Heating, 'No isSteadyState value') from exc
 
         return 'Steady State' if steady_state_value == 'true' else 'AFUE'
 

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -136,8 +136,8 @@ class Heating(_Heating):
     def _get_steady_state(node: element.Element) -> str:
         try:
             steady_state_value = node.get('Type1/*/Specifications/@isSteadyState', str)
-        except ElementGetValueError:
-            return 'Steady State'
+        except ElementGetValueError as exc:
+            raise InvalidEmbeddedDataTypeError('No isSteadyState property value') from exc
 
         return 'Steady State' if steady_state_value == 'true' else 'AFUE'
 

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -40,6 +40,7 @@ class Heating(_Heating):
         'Baseboards': HeatingType.BASEBOARD,
         'Furnace': HeatingType.FURNACE,
         'Boiler': HeatingType.BOILER,
+        'ComboHeatDhw': HeatingType.COMBO_HEAT_DHW
     }
 
     _HEATING_TYPE_TRANSLATIONS = {
@@ -61,6 +62,8 @@ class Heating(_Heating):
         4: EnergySource.PROPANE,
         5: EnergySource.WOOD,
         6: EnergySource.WOOD,
+        7: EnergySource.WOOD,
+        8: EnergySource.WOOD,
     }
 
     _ENERGY_SOURCE_TRANSLATIONS = {
@@ -133,9 +136,8 @@ class Heating(_Heating):
     def _get_steady_state(node: element.Element) -> str:
         try:
             steady_state_value = node.get('Type1/*/Specifications/@isSteadyState', str)
-        except ElementGetValueError as exc:
+        except ElementGetValueError:
             return 'Steady State'
-            # raise InvalidEmbeddedDataTypeError(Heating, 'No isSteadyState value') from exc
 
         return 'Steady State' if steady_state_value == 'true' else 'AFUE'
 
@@ -147,14 +149,26 @@ class Heating(_Heating):
         except ElementGetValueError as exc:
             raise InvalidEmbeddedDataTypeError(Heating, 'Invalid/missing Heating values') from exc
 
+        heating_type = cls._get_heating_type(node)
+        output_size = cls._get_output_size(node)
+
+        if heating_type is HeatingType.BASEBOARD:
+            steady_state = 'Steady State'
+            energy_source = EnergySource.ELECTRIC
+            equipment_type = cls._HEATING_TYPE_TRANSLATIONS[HeatingType.BASEBOARD]
+        else:
+            steady_state = cls._get_steady_state(node)
+            energy_source = cls._get_energy_source(node)
+            equipment_type = cls._get_equipment_type(node)
+
         return Heating(
             label=label,
-            output_size=cls._get_output_size(node),
+            output_size=output_size,
             efficiency=efficiency,
-            steady_state=cls._get_steady_state(node),
-            heating_type=cls._get_heating_type(node),
-            energy_source=cls._get_energy_source(node),
-            equipment_type=cls._get_equipment_type(node),
+            steady_state=steady_state,
+            heating_type=heating_type,
+            energy_source=energy_source,
+            equipment_type=equipment_type,
         )
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:

--- a/etl/src/energuide/embedded/heating.py
+++ b/etl/src/energuide/embedded/heating.py
@@ -137,7 +137,7 @@ class Heating(_Heating):
         try:
             steady_state_value = node.get('Type1/*/Specifications/@isSteadyState', str)
         except ElementGetValueError as exc:
-            raise InvalidEmbeddedDataTypeError('No isSteadyState property value') from exc
+            raise InvalidEmbeddedDataTypeError(Heating, 'No isSteadyState property value') from exc
 
         return 'Steady State' if steady_state_value == 'true' else 'AFUE'
 

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -136,7 +136,7 @@ def test_boiler() -> None:
     assert output.heating_type == heating.HeatingType.BOILER
 
 
-@pytest.mark.parametrize("energy_code", [5, 6])
+@pytest.mark.parametrize("energy_code", [5, 6, 7, 8])
 def test_wood_energy_source(energy_code: int) -> None:
     equipment_node = sample_equipment(energy_source_code=energy_code)
     node = sample_node(equipment_node=equipment_node)

--- a/etl/tests/embedded/test_heating.py
+++ b/etl/tests/embedded/test_heating.py
@@ -145,7 +145,7 @@ def test_wood_energy_source(energy_code: int) -> None:
 
 
 def test_unknown_energy_source_code() -> None:
-    equipment_node = sample_equipment(energy_source_code=7)
+    equipment_node = sample_equipment(energy_source_code=9)
     node = sample_node(equipment_node=equipment_node)
 
     with pytest.raises(InvalidEmbeddedDataTypeError) as ex:


### PR DESCRIPTION
This PR introduces some changes to `Heating` to correctly parse Baseboard and ComboHeatDhw heater types.

ComboHeatDhw are parsed just like any other type, but Baseboards are structured differently, and fail the parsing, but are all configured the same way.

This PR also adds some missing energy source codes for different types of wood.