### PR TITLE
run endpoint with gunicorn

### DIFF
--- a/extract_endpoint/Dockerfile
+++ b/extract_endpoint/Dockerfile
@@ -8,4 +8,4 @@ ADD . .
 RUN pip install -r requirements.txt 
 RUN pip install -e .
 
-CMD ["python", "src/extract_endpoint/endpoint.py"]
+CMD ["gunicorn", "--pythonpath=src/extract_endpoint", "--bind=0.0.0.0:5000", "endpoint:App"]

--- a/extract_endpoint/Dockerfile
+++ b/extract_endpoint/Dockerfile
@@ -1,11 +1,12 @@
-FROM python:3
+FROM python:3.6
 MAINTAINER Steven Zinck <steven.zinck@cds-snc.ca>
 LABEL Description="Python ETL Endpoint" Vendor="Canadian Digital Service"
 
 # Set version in .circlei/config.yml for docker build
 
-ADD . . 
-RUN pip install -r requirements.txt 
-RUN pip install -e .
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
 
+COPY . .
+RUN pip install -e .
 CMD ["gunicorn", "--pythonpath=src/extract_endpoint", "--bind=0.0.0.0:5000", "endpoint:App"]

--- a/extract_endpoint/requirements.txt
+++ b/extract_endpoint/requirements.txt
@@ -2,6 +2,7 @@ astroid==1.5.3
 azure-storage-blob==1.1.0
 coverage==4.5.1
 Flask==0.12.2
+gunicorn==19.7.1
 pylint==1.8.1
 pytest==3.3.2
 pytest-cov==2.5.1


### PR DESCRIPTION
We were running the flask apps using flask's development web server (ie `App.run()`). It's recommended to use `gunicorn` in production.

I think this should do the trick and have it still work on Azure? The new docker container works on my laptop, at least.