### PR TITLE
Use gunicorn to run etl flask app

### DIFF
--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3
+FROM python:3.6
+MAINTAINER Steven Zinck <steven.zinck@cds-snc.ca>
 LABEL Description="NRCan ETL" Vendor="Canadian Digital Service"
 
-MAINTAINER Steven Zinck <steven.zinck@cds-snc.ca>
-
-ADD . .
-
+COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
-RUN pip install -e .
 
+COPY . .
+RUN pip install -e .
 CMD ["gunicorn", "--pythonpath=src/energuide", "--bind=0.0.0.0:5010", "flask_app:App"]

--- a/etl/Dockerfile
+++ b/etl/Dockerfile
@@ -8,6 +8,4 @@ ADD . .
 RUN pip install -r requirements.txt
 RUN pip install -e .
 
-CMD ["python", "src/energuide/flask_app.py"]
-
-
+CMD ["gunicorn", "--pythonpath=src/energuide", "--bind=0.0.0.0:5010", "flask_app:App"]

--- a/etl/requirements.txt
+++ b/etl/requirements.txt
@@ -1,6 +1,7 @@
 setuptools==38.4.0
 astroid==1.5.3
 Flask==0.12.2
+gunicorn==19.7.1
 azure-storage-blob==1.1.0
 pylint==1.8.1
 pytest==3.3.2


### PR DESCRIPTION
We were running the flask apps using flask's development web server (ie App.run()). It's recommended to use gunicorn in production.