### PR TITLE
Configure subloggers instead of root logger

### DIFF
--- a/etl/src/energuide/logger.py
+++ b/etl/src/energuide/logger.py
@@ -1,9 +1,5 @@
 import logging
 
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(name)s: %(message)s',
-                    datefmt='%Y-%m-%dT%H:%M:%S%z')
-
 
 def unwrap_exception_message(exc: BaseException, join: str = ' - ') -> str:
     if exc.__context__:
@@ -16,4 +12,14 @@ def unwrap_exception_message(exc: BaseException, join: str = ' - ') -> str:
 def get_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
+
+    if not logger.hasHandlers():
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            fmt='%(asctime)s - %(levelname)s - %(name)s: %(message)s',
+            datefmt='%Y-%m-%dT%H:%M:%S%z'
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
     return logger


### PR DESCRIPTION
This PR changes how loggers are configured.
Instead of using `logging.basicConfig`, which configures the root logger, it applies the same configuration to loggers produced by `logger.get_logger`.

This results in our logs not being polluted by logging performed by 3rd party libraries such as the `azure` module