### PR TITLE
Cleanup connection string generation

### DIFF
--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -42,7 +42,8 @@ def load(username: str,
          filename: typing.Optional[str],
          append: bool,
          progress: bool,
-         production: bool,) -> None:
+         production: bool,
+        ) -> None:
 
     coords = database.DatabaseCoordinates(
         username=username,

--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -28,6 +28,10 @@ def main() -> None:
 @click.option('--filename', type=click.Path(exists=True), required=False)
 @click.option('-a', '--append', is_flag=True, help='Append data instead of overwriting')
 @click.option('--progress/--no-progress', default=True)
+@click.option('--production/--local',
+              envvar=database.EnvVariables.production.value,
+              default=False,
+              help='Generate a connection string to an Atlas managed MongoDB instance')
 def load(username: str,
          password: str,
          host: str,
@@ -37,12 +41,15 @@ def load(username: str,
          azure: bool,
          filename: typing.Optional[str],
          append: bool,
-         progress: bool) -> None:
+         progress: bool,
+         production: bool,) -> None:
+
     coords = database.DatabaseCoordinates(
         username=username,
         password=password,
         host=host,
-        port=port
+        port=port,
+        production=production
     )
 
     reader: transform.ExtractProtocol

--- a/etl/src/energuide/database.py
+++ b/etl/src/energuide/database.py
@@ -5,6 +5,10 @@ import typing
 import pymongo
 
 from energuide import dwelling
+from energuide import logger
+
+
+LOGGER = logger.get_logger(__name__)
 
 
 class EnvVariables(enum.Enum):
@@ -49,7 +53,11 @@ class DatabaseCoordinates(_DatabaseCoordinates):
 
 @contextmanager  # type: ignore
 def mongo_client(database_coordinates: DatabaseCoordinates) -> typing.Iterable[pymongo.MongoClient]:
-    with pymongo.MongoClient(f'{database_coordinates.connection_string}') as client:
+    connection_string = database_coordinates.connection_string
+
+    LOGGER.info(f'Connecting to {connection_string}')
+
+    with pymongo.MongoClient(f'{connection_string}') as client:
         yield client
 
 

--- a/etl/src/energuide/flask_app.py
+++ b/etl/src/energuide/flask_app.py
@@ -27,7 +27,10 @@ DATABASE_COORDS = database.DatabaseCoordinates(
     username=os.environ.get(database.EnvVariables.username.value, default=database.EnvDefaults.username.value),
     password=os.environ.get(database.EnvVariables.password.value, default=database.EnvDefaults.password.value),
     host=os.environ.get(database.EnvVariables.host.value, default=database.EnvDefaults.host.value),
-    port=int(os.environ.get(database.EnvVariables.port.value, default=database.EnvDefaults.port.value))
+    port=int(os.environ.get(database.EnvVariables.port.value, default=database.EnvDefaults.port.value)),
+    production=bool(
+        os.environ.get(database.EnvVariables.production.value, default=database.EnvDefaults.production.value)
+    ),
 )
 
 DATABASE_NAME = os.environ.get(database.EnvVariables.database.value, default=database.EnvDefaults.database.value)
@@ -46,7 +49,8 @@ def _run_tl_and_verify() -> None:
                       azure=True,
                       filename=None,
                       append=False,
-                      progress=False)
+                      progress=False,
+                      production=True)
 
     mongo_client: pymongo.MongoClient
     with database.mongo_client(DATABASE_COORDS) as mongo_client:

--- a/etl/tests/conftest.py
+++ b/etl/tests/conftest.py
@@ -48,6 +48,11 @@ def port() -> int:
 
 
 @pytest.fixture
+def production() -> bool:
+    return bool(os.environ.get(database.EnvVariables.production.value, database.EnvDefaults.production.value))
+
+
+@pytest.fixture
 def database_name(database_coordinates: database.DatabaseCoordinates) -> typing.Iterable[str]:
     db_name = os.environ.get(database.EnvVariables.database.value, database.EnvDefaults.database.value)
     db_name = f'{db_name}_test_{random.randint(1000, 9999)}'
@@ -68,12 +73,14 @@ def collection() -> str:
 def database_coordinates(username: str,
                          password: str,
                          host: str,
-                         port: int) -> database.DatabaseCoordinates:
+                         port: int,
+                         production: bool) -> database.DatabaseCoordinates:
     return database.DatabaseCoordinates(
         username=username,
         password=password,
         host=host,
         port=port,
+        production=production,
     )
 
 

--- a/etl/tests/test_flask_app.py
+++ b/etl/tests/test_flask_app.py
@@ -44,12 +44,15 @@ def thread_runner() -> typing.Generator:
 
 @pytest.fixture
 def fake_db_coords(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> typing.Generator:
-    def connection_string(self) -> str:
+    def connection_string(self: database.DatabaseCoordinates) -> str:
         prefix = f'{self.username}:{self.password}@' if self.username and self.password else ''
         return f'{prefix}{self.host}:{self.port}'
-    connection_string = property(connection_string)
 
-    monkeypatch.setattr(database.DatabaseCoordinates, 'connection_string', connection_string)
+    connection_string_propery = property(connection_string)
+
+    monkeypatch.setattr(database.DatabaseCoordinates, 'connection_string', connection_string_propery)
+    yield
+
 
 
 def test_threadrunner(thread_runner: flask_app.ThreadRunner) -> None:

--- a/etl/tests/test_flask_app.py
+++ b/etl/tests/test_flask_app.py
@@ -54,7 +54,6 @@ def fake_db_coords(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> typing.Gener
     yield
 
 
-
 def test_threadrunner(thread_runner: flask_app.ThreadRunner) -> None:
     stay_asleep = True
 


### PR DESCRIPTION
This PR changes how connection strings for MongoDB are generated, as well as adds a `production` flag to the CLI, indication what method of connection string generation should be used.

`--production` signals that it is an Atlas managed MongoDB instance, while `--local` is for anything else (ostensibly a local db, but not necessarily)