### PR TITLE
Tighten up documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ del allthedata.zip
 Unit tests for the python code.
 ```sh
 pytest tests
-mypy src tests --ignore-missing-imports
+mypy src tests
 ```
 
 #### using the mongodb command-line client

--- a/etl/README.md
+++ b/etl/README.md
@@ -23,6 +23,8 @@ source env/bin/activate
 ```
 This will create a new virtualenv in a  folder called `env`, and activate the virutalenv. To deactivate the virtualenv, run `deactivate`
 
+**WINDOWS NOTE** To activate a virtual environment on Windows instead run `env\Scripts\activate.bat`
+
 #### Installing the app
 
 Inside an activated virtualenv, and from the python folder of the project, run:
@@ -35,7 +37,7 @@ pip install -e .
 
 The ETL application is accessed from the `energuide` CLI. Run `energuide --help` for help.
 
-There are currently two commands for energuide: 
+There are currently two commands for energuide:
 ```
 energuide extract --infile /path/to/file --outfile /path/to/other/file
 ```
@@ -83,9 +85,14 @@ pylint src tests
 
 To run the mypy type checker, run:
 ```
-mypy src tests --ignore-missing-imports
+mypy src tests
 ```
 
 #### Automated Testing
 
 This repo is connected to CircleCI, and all tests, linters, and static type checking must pass before merging to master.
+
+
+### Running Locally
+
+The system can be run locally using the CLI commands that are described above, but to run all the components behaving as they do when deployed to Azure, follow instructions in the **Running Locally** section of the `extract_endpoint` module.

--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -16,18 +16,44 @@ def main() -> None:
 
 
 @main.command()
-@click.option('--username', envvar=database.EnvVariables.username.value, default=database.EnvDefaults.username.value)
-@click.option('--password', envvar=database.EnvVariables.password.value, default=database.EnvDefaults.password.value)
-@click.option('--host', envvar=database.EnvVariables.host.value, default=database.EnvDefaults.host.value)
-@click.option('--port', envvar=database.EnvVariables.port.value, default=database.EnvDefaults.port.value, type=int)
-@click.option('--db_name', envvar=database.EnvVariables.database.value, default=database.EnvDefaults.database.value)
+@click.option('--username',
+              envvar=database.EnvVariables.username.value,
+              default=database.EnvDefaults.username.value,
+              help='Username for MongoDB Server')
+@click.option('--password',
+              envvar=database.EnvVariables.password.value,
+              default=database.EnvDefaults.password.value,
+              help='Password for MongoDB Server')
+@click.option('--host',
+              envvar=database.EnvVariables.host.value,
+              default=database.EnvDefaults.host.value,
+              help='Hostname for MongoDB Server')
+@click.option('--port',
+              envvar=database.EnvVariables.port.value,
+              default=database.EnvDefaults.port.value,
+              type=int,
+              help='Port for MongoDB Server')
+@click.option('--db_name',
+              envvar=database.EnvVariables.database.value,
+              default=database.EnvDefaults.database.value,
+              help='Database name for MongoDB Server')
 @click.option('--collection',
               envvar=database.EnvVariables.collection.value,
-              default=database.EnvDefaults.collection.value)
-@click.option('--azure', is_flag=True, help='Download data from Azure')
-@click.option('--filename', type=click.Path(exists=True), required=False)
-@click.option('-a', '--append', is_flag=True, help='Append data instead of overwriting')
-@click.option('--progress/--no-progress', default=True)
+              default=database.EnvDefaults.collection.value,
+              help='Collection to load data into in Database')
+@click.option('--azure',
+              is_flag=True,
+              help='Download data from Azure')
+@click.option('--filename',
+              type=click.Path(exists=True),
+              required=False,
+              help='Filename to load data from')
+@click.option('-a', '--append',
+              is_flag=True,
+              help='Append data instead of overwriting')
+@click.option('--progress/--no-progress',
+              default=True,
+              help='Enable/Disable progress bar')
 @click.option('--production/--local',
               envvar=database.EnvVariables.production.value,
               default=False,

--- a/etl/src/energuide/cli.py
+++ b/etl/src/energuide/cli.py
@@ -96,8 +96,14 @@ def load(username: str,
 
 
 @main.command()
-@click.option('--infile', required=True)
-@click.option('--outfile', required=True)
+@click.option('--infile',
+              type=click.Path(exists=True),
+              required=True,
+              help='CSV files to extract data from')
+@click.option('--outfile',
+              required=True,
+              type=click.Path(),
+              help='Path to output file')
 @click.option('--progress/--no-progress', default=True)
 def extract(infile: str, outfile: str, progress: bool) -> None:
     LOGGER.info(f'Extracting data from {infile} into {outfile}')

--- a/etl/tests/test_cli.py
+++ b/etl/tests/test_cli.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import typing
 import zipfile
 import py
@@ -170,8 +171,8 @@ def test_extract_invalid(invalid_filepath: str, tmpdir: py._path.local.LocalPath
 
 
 def test_extract_missing(tmpdir: py._path.local.LocalPath) -> None:
-    outfile = f'{tmpdir}/output.zip'
-    infile = f'{tmpdir}/idontexist.csv'
+    outfile = os.path.join(tmpdir, 'output.zip')
+    infile = os.path.join(tmpdir, 'idontexist.csv')
     runner = testing.CliRunner()
     result = runner.invoke(cli.main, args=[
         'extract',
@@ -180,6 +181,4 @@ def test_extract_missing(tmpdir: py._path.local.LocalPath) -> None:
     ])
 
     assert result.exit_code != 0
-
-    with zipfile.ZipFile(outfile, 'r') as output:
-        assert not output.namelist()
+    assert not os.path.exists(outfile)


### PR DESCRIPTION
This PR makes some adjustments to the `readme` files of ETL and the root project, as well as some changes to allow clearer introspection of operation of the CLI via adding types and help messages to it's options.

As a result of this 1 test needed to be changed, because once the input file of extract is specified as having to exist, the output empty zip is no longer produced, so the test which relied on it's existing failed.