### PR TITLE
Add azure skip if azure isn't running

### DIFF
--- a/extract_endpoint/tests/test_azure_utils.py
+++ b/extract_endpoint/tests/test_azure_utils.py
@@ -31,6 +31,7 @@ def put_file_in_azure(azure_emulator_coords: azure_utils.StorageCoordinates,
     azure_service.delete_blob(azure_emulator_coords.container, filename)
 
 
+@pytest.mark.usefixtures('azure_service')
 def check_file_in_azure(azure_service: blob.BlockBlobService,
                         azure_emulator_coords: azure_utils.StorageCoordinates,
                         filename: str,
@@ -41,6 +42,7 @@ def check_file_in_azure(azure_service: blob.BlockBlobService,
     assert actual_blob.content == contents
 
 
+@pytest.mark.usefixtures('azure_service')
 def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
                       azure_service: blob.BlockBlobService,
                       sample_data: bytes,
@@ -51,6 +53,7 @@ def test_upload_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
     check_file_in_azure(azure_service, azure_emulator_coords, sample_filename, sample_stream_content)
 
 
+@pytest.mark.usefixtures('azure_service')
 def test_download_bytes(azure_emulator_coords: azure_utils.StorageCoordinates,
                         put_file_in_azure: str,
                         sample_stream_content: str) -> None:

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -139,6 +139,7 @@ def test_timestamp(test_client: testing.FlaskClient, sample_timestamp: str) -> N
     assert get_return.data == sample_timestamp.encode()
 
 
+@pytest.mark.usefixtures('azure_service')
 def test_timestamp_no_file(test_client: testing.FlaskClient) -> None:
     get_return = test_client.get('/timestamp')
     assert get_return.status_code == HTTPStatus.BAD_GATEWAY


### PR DESCRIPTION
It would probably be helpful to add in the automatic test skip from etl if azure emulator isn't running, for tests that require it. This is handy because if someone starts the tests without starting the emulator, the tests that require it will hang with no feedback.

🎉 
![screen shot 2018-03-16 at 11 01 53 am](https://user-images.githubusercontent.com/1545806/37531130-a445e7c8-2911-11e8-9690-8f6f21051aa2.png)
