### PR TITLE
return better code when TL has problems

### DIFF
--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -95,7 +95,11 @@ def run_tl_route() -> typing.Tuple[str, int]:
     if flask.request.form['signature'] != signature:
         flask.abort(HTTPStatus.BAD_REQUEST)
 
-    return '', run_tl(data=flask.request.form)
+    run_tl_return_code = run_tl(data=flask.request.form)
+    LOGGER.info(f"TL returned {run_tl_return_code}")
+    if run_tl_return_code in [HTTPStatus.OK, HTTPStatus.TOO_MANY_REQUESTS]:
+        return '', run_tl_return_code
+    return '', HTTPStatus.BAD_GATEWAY
 
 
 @App.route('/upload_file', methods=['POST'])
@@ -139,7 +143,11 @@ def upload_file() -> typing.Tuple[str, int]:
         LOGGER.warning("Timestamp upload to Azure storage failed")
         flask.abort(HTTPStatus.BAD_GATEWAY)
 
-    return '', run_tl()
+    run_tl_return_code = run_tl()
+    LOGGER.info(f"TL returned {run_tl_return_code}")
+    if run_tl_return_code in [HTTPStatus.OK, HTTPStatus.TOO_MANY_REQUESTS]:
+        return '', run_tl_return_code
+    return '', HTTPStatus.BAD_GATEWAY
 
 
 if __name__ == "__main__":

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -80,7 +80,7 @@ def mocked_tl_app(monkeypatch: _pytest.monkeypatch.MonkeyPatch, sample_secret_ke
         actual_signature = hasher.hexdigest()
         if data['signature'] != actual_signature:
             return HTTPStatus.BAD_REQUEST
-        return HTTPStatus.CREATED
+        return HTTPStatus.OK
     monkeypatch.setattr(endpoint, 'send_to_tl', mock_send_to_tl)
 
 
@@ -92,13 +92,13 @@ def test_run_tl_url(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
 @pytest.mark.usefixtures('mocked_tl_app')
 def test_run_tl(sample_salt: str, sample_salt_signature: str) -> None:
     return_val = endpoint.run_tl(dict(salt=sample_salt, signature=sample_salt_signature))
-    assert return_val == HTTPStatus.CREATED
+    assert return_val == HTTPStatus.OK
 
 
 @pytest.mark.usefixtures('mocked_tl_app')
 def test_run_tl_no_data() -> None:
     return_val = endpoint.run_tl()
-    assert return_val == HTTPStatus.CREATED
+    assert return_val == HTTPStatus.OK
 
 
 @pytest.mark.usefixtures('mocked_tl_app')
@@ -110,7 +110,7 @@ def test_run_tl_bad_data() -> None:
 @pytest.mark.usefixtures('mocked_tl_app')
 def test_run_tl_route(test_client: testing.FlaskClient, sample_salt: str, sample_salt_signature: str) -> None:
     return_val = test_client.post('/run_tl', data=dict(salt=sample_salt, signature=sample_salt_signature))
-    assert return_val.status_code == HTTPStatus.CREATED
+    assert return_val.status_code == HTTPStatus.OK
 
 
 @pytest.mark.usefixtures('mocked_tl_app', 'sample_secret_key')
@@ -154,7 +154,7 @@ def test_upload_with_timestamp(test_client: testing.FlaskClient,
     post_return = test_client.post('/upload_file', data=dict(salt=sample_salt, signature=sample_zipfile_signature,
                                                              timestamp=sample_timestamp,
                                                              file=(sample_zipfile, 'zipfile')))
-    assert post_return.status_code == HTTPStatus.CREATED
+    assert post_return.status_code == HTTPStatus.OK
 
 
 def test_upload_without_timestamp(test_client: testing.FlaskClient,


### PR DESCRIPTION
If there's an error connecting to or using the TL app,  just return `BAD_GATEWAY`, except the case where TL is processing (`TOO_MANY_REQUESTS`). Log the actual code returned from the TL app.