### PR TITLE
do azure upload in a thread

### DIFF
--- a/extract_endpoint/src/extract_endpoint/endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/endpoint.py
@@ -1,5 +1,8 @@
 import os
+import io
+import threading
 import hashlib
+import functools
 import secrets
 import typing
 from http import HTTPStatus
@@ -31,6 +34,24 @@ App.config.update(dict(
         domain=os.environ.get(azure_utils.EnvVariables.domain.value, None)
     )
 ))
+
+
+class ThreadRunner:
+    _running_thread: typing.Optional[threading.Thread] = None
+
+    @classmethod
+    def start_new_thread(cls, target: typing.Callable[[], None]) -> None:
+        cls._running_thread = threading.Thread(target=target)
+        cls._running_thread.start()
+
+    @classmethod
+    def is_thread_running(cls) -> bool:
+        return cls._running_thread is not None and cls._running_thread.is_alive()
+
+    @classmethod
+    def join(cls) -> None:
+        if cls._running_thread is not None:
+            cls._running_thread.join()
 
 
 def _run_tl_url() -> str:
@@ -102,6 +123,16 @@ def run_tl_route() -> typing.Tuple[str, int]:
     return '', HTTPStatus.BAD_GATEWAY
 
 
+def unzip_upload_run_tl(data: bytes) -> None:
+    file_z = zipfile.ZipFile(io.BytesIO(data))
+    for json_file in [file_z.open(zipinfo) for zipinfo in file_z.infolist()]:
+        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], json_file.read(),
+                                                 utils.secure_filename(json_file.name)):
+            LOGGER.warning("File upload to Azure storage failed")
+    LOGGER.info(f"{len(file_z.infolist())} json files uploaded to Azure")
+    run_tl()
+
+
 @App.route('/upload_file', methods=['POST'])
 def upload_file() -> typing.Tuple[str, int]:
     LOGGER.info("Received upload request")
@@ -126,28 +157,23 @@ def upload_file() -> typing.Tuple[str, int]:
         flask.abort(HTTPStatus.BAD_REQUEST)
 
     try:
-        file_z = zipfile.ZipFile(file)
+        zipfile.ZipFile(file)
+        file.seek(0)
     except zipfile.BadZipFile:
         LOGGER.warning("Bad zipfile")
         return "Bad Zipfile", HTTPStatus.BAD_REQUEST
 
-    for json_file in [file_z.open(zipinfo) for zipinfo in file_z.infolist()]:
-        if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], json_file.read(),
-                                                 utils.secure_filename(json_file.name)):
-            LOGGER.warning("File upload to Azure storage failed")
-            flask.abort(HTTPStatus.BAD_GATEWAY)
-    LOGGER.info(f"{len(file_z.infolist())} json files uploaded to Azure")
+    if ThreadRunner.is_thread_running():
+        LOGGER.warning("Still uploading to Azure, ignoring current upload")
+        flask.abort(HTTPStatus.TOO_MANY_REQUESTS)
 
     timestamp = flask.request.form['timestamp']
     if not azure_utils.upload_bytes_to_azure(App.config['AZURE_COORDINATES'], timestamp.encode(), TIMESTAMP_FILENAME):
         LOGGER.warning("Timestamp upload to Azure storage failed")
         flask.abort(HTTPStatus.BAD_GATEWAY)
 
-    run_tl_return_code = run_tl()
-    LOGGER.info(f"TL returned {run_tl_return_code}")
-    if run_tl_return_code in [HTTPStatus.OK, HTTPStatus.TOO_MANY_REQUESTS]:
-        return '', run_tl_return_code
-    return '', HTTPStatus.BAD_GATEWAY
+    ThreadRunner.start_new_thread(target=functools.partial(unzip_upload_run_tl, data=file.read()))
+    return 'Azure upload starting', HTTPStatus.OK
 
 
 if __name__ == "__main__":

--- a/extract_endpoint/tests/test_endpoint.py
+++ b/extract_endpoint/tests/test_endpoint.py
@@ -84,6 +84,36 @@ def mocked_tl_app(monkeypatch: _pytest.monkeypatch.MonkeyPatch, sample_secret_ke
     monkeypatch.setattr(endpoint, 'send_to_tl', mock_send_to_tl)
 
 
+@pytest.fixture()
+def thread_runner() -> typing.Generator:
+    yield endpoint.ThreadRunner
+    endpoint.ThreadRunner.join()
+
+
+def test_threadrunner(thread_runner: endpoint.ThreadRunner) -> None:
+    stay_asleep = True
+
+    def sleeper() -> None:
+        while stay_asleep:
+            pass
+
+    thread_runner.start_new_thread(sleeper)
+    assert thread_runner.is_thread_running()
+    stay_asleep = False
+    thread_runner.join()
+    assert not thread_runner.is_thread_running()
+
+
+def check_file_in_azure(azure_service: blob.BlockBlobService,
+                        azure_emulator_coords: azure_utils.StorageCoordinates,
+                        filename: str,
+                        contents: str) -> None:
+
+    assert filename in [blob.name for blob in azure_service.list_blobs(azure_emulator_coords.container)]
+    actual_blob = azure_service.get_blob_to_text(azure_emulator_coords.container, filename)
+    assert actual_blob.content == contents
+
+
 def test_run_tl_url(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
     monkeypatch.setenv('TL_ADDRESS', 'https://www.nrcan.ca:4000')
     assert endpoint._run_tl_url() == 'https://www.nrcan.ca:4000/run_tl'
@@ -144,8 +174,12 @@ def test_timestamp_no_file(test_client: testing.FlaskClient) -> None:
     assert get_return.status_code == HTTPStatus.BAD_GATEWAY
 
 
-@pytest.mark.usefixtures('azure_service', 'mocked_tl_app')
-def test_upload_with_timestamp(test_client: testing.FlaskClient,
+def test_upload_with_timestamp(azure_service: blob.BlockBlobService,
+                               azure_emulator_coords: azure_utils.StorageCoordinates,
+                               sample_filenames: typing.Tuple[str, str],
+                               sample_file_contents: typing.Tuple[str, str],
+                               test_client: testing.FlaskClient,
+                               thread_runner: endpoint.ThreadRunner,
                                sample_timestamp: str,
                                sample_salt: str,
                                sample_zipfile_signature: str,
@@ -155,6 +189,10 @@ def test_upload_with_timestamp(test_client: testing.FlaskClient,
                                                              timestamp=sample_timestamp,
                                                              file=(sample_zipfile, 'zipfile')))
     assert post_return.status_code == HTTPStatus.OK
+    thread_runner.join()
+    check_file_in_azure(azure_service, azure_emulator_coords, endpoint.TIMESTAMP_FILENAME, sample_timestamp)
+    for name, contents in zip(sample_filenames, sample_file_contents):
+        check_file_in_azure(azure_service, azure_emulator_coords, name, contents)
 
 
 def test_upload_without_timestamp(test_client: testing.FlaskClient,

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -89,11 +89,7 @@ def check_file_in_azure(azure_service: blob.BlockBlobService,
 
 
 @pytest.mark.usefixtures('run_endpoint')
-def test_post_stream_cli(azure_service: blob.BlockBlobService,
-                         azure_emulator_coords: azure_utils.StorageCoordinates,
-                         sample_timestamp: str,
-                         sample_file_contents: str,
-                         sample_filenames: str,
+def test_post_stream_cli(sample_timestamp: str,
                          sample_zipfile_fixture: str,
                          upload_url: str) -> None:
 
@@ -105,9 +101,6 @@ def test_post_stream_cli(azure_service: blob.BlockBlobService,
         '--url', upload_url
     ])
     assert result.exit_code != HTTPStatus.BAD_REQUEST
-    check_file_in_azure(azure_service, azure_emulator_coords, endpoint.TIMESTAMP_FILENAME, sample_timestamp)
-    for name, contents in zip(sample_filenames, sample_file_contents):
-        check_file_in_azure(azure_service, azure_emulator_coords, name, contents)
 
 
 def test_post_stream_cli_no_stream(upload_url: str, sample_timestamp: str) -> None:
@@ -134,11 +127,7 @@ def test_post_stream_cli_no_timestamp(sample_zipfile_fixture: str, upload_url: s
 
 
 @pytest.mark.usefixtures('run_endpoint')
-def test_post_stream_cli_no_url(azure_service: blob.BlockBlobService,
-                                azure_emulator_coords: azure_utils.StorageCoordinates,
-                                sample_timestamp: str,
-                                sample_file_contents: str,
-                                sample_filenames: str,
+def test_post_stream_cli_no_url(sample_timestamp: str,
                                 sample_zipfile_fixture: str) -> None:
     runner = testing.CliRunner()
     result = runner.invoke(post_to_endpoint.main, args=[
@@ -148,9 +137,6 @@ def test_post_stream_cli_no_url(azure_service: blob.BlockBlobService,
         '--url', None
     ])
     assert result.exit_code != HTTPStatus.BAD_REQUEST
-    check_file_in_azure(azure_service, azure_emulator_coords, endpoint.TIMESTAMP_FILENAME, sample_timestamp)
-    for name, contents in zip(sample_filenames, sample_file_contents):
-        check_file_in_azure(azure_service, azure_emulator_coords, name, contents)
 
 
 @pytest.mark.usefixtures('run_endpoint')


### PR DESCRIPTION
Local post sometimes hangs when doing a big upload to Endpoint, despite Endpoint and TL App working correctly. Solution: have Endpoint return `OK` when it receives and validates the post, and run the Azure upload on a new thread. This is similar to how the TL App works.