### PR TITLE
use endpoint address environment variable

### DIFF
--- a/extract_endpoint/README.md
+++ b/extract_endpoint/README.md
@@ -231,10 +231,24 @@ The `energuide/flask_app.py` app must also have environment variables set pointi
 * ENERGUIDE_COLLECTION
 * ENERGUIDE_PRODUCTION (just set to '1')
 
-Finally, to upload files to production, trigger the tl manually, or check the status of the web apps we need to specify the url of the endpoint route
-```
-extract_endpoint upload ../etl/extract_out.zip 2018-03-14 --url=https://nrcan-endpoint.azurewebsites.net/upload_file
-extract_endpoint run_tl --url=https://nrcan-endpoint.azurewebsites.net/run_tl
-extract_endpoint status --url=https://nrcan-endpoint.azurewebsites.net/status
 
+There are three commands you can use on your local machine to interact with the web apps.
+First set the `ENERGUIDE_ENDPOINT_ADDRESS` variable on your local machine, for example
 ```
+export ENERGUIDE_ENDPOINT_ADDRESS=https://nrcan-endpoint.azurewebsites.net
+```
+
+To upload a new set of extracted data:
+```
+extract_endpoint upload ../etl/extract_out.zip 2018-03-14
+```
+The TL app runs when the files have finished uploading to Azure. If you want to start it manually:
+```
+extract_endpoint run_tl
+```
+To check the status of the web apps:
+```
+extract_endpoint status
+```
+
+Once the status of both Endpoint and TL are idle, the data you have uploaded should be available in the Mongo database.

--- a/extract_endpoint/README.md
+++ b/extract_endpoint/README.md
@@ -168,7 +168,7 @@ We should have three apps running: Azure, the endpoint, and the ETL web app.
 
 In the **Endpoint Post** terminal upload the extracted records (and a timestamp) via
 ```
-extract_endpoint upload ../etl/extract_out.zip 2018-03-14
+extract_endpoint upload ../etl/extract_out.zip "2011-03-08 15:47"
 ```
 
 All terminals should produce output.
@@ -240,7 +240,7 @@ export ENERGUIDE_ENDPOINT_ADDRESS=https://nrcan-endpoint.azurewebsites.net
 
 To upload a new set of extracted data:
 ```
-extract_endpoint upload ../etl/extract_out.zip 2018-03-14
+extract_endpoint upload ../etl/extract_out.zip "2011-03-08 15:47"
 ```
 The TL app runs when the files have finished uploading to Azure. If you want to start it manually:
 ```

--- a/extract_endpoint/README.md
+++ b/extract_endpoint/README.md
@@ -251,4 +251,4 @@ To check the status of the web apps:
 extract_endpoint status
 ```
 
-Once the status of both Endpoint and TL are idle, the data you have uploaded should be available in the Mongo database.
+Once both Endpoint and TL are idle the data you have uploaded should be available in the Mongo database.

--- a/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
+++ b/extract_endpoint/src/extract_endpoint/post_to_endpoint.py
@@ -9,9 +9,15 @@ import click
 
 DEFAULT_ETL_SECRET_KEY = 'no key'
 
+DEFAULT_ENERGUIDE_ENDPOINT_ADDRESS = 'http://127.0.0.1:5000'
+
 
 def _etl_secret_key() -> str:
     return os.environ.get('ETL_SECRET_KEY', DEFAULT_ETL_SECRET_KEY)
+
+
+def _endpoint_address() -> str:
+    return os.environ.get('ENERGUIDE_ENDPOINT_ADDRESS', DEFAULT_ENERGUIDE_ENDPOINT_ADDRESS)
 
 
 def post_stream(stream: typing.IO[bytes],
@@ -55,7 +61,7 @@ def main() -> None:
 @main.command()
 @click.argument('stream', type=click.File('rb'))
 @click.argument('timestamp')
-@click.option('--url', default='http://127.0.0.1:5000/upload_file')
+@click.option('--url', default=_endpoint_address() + '/upload_file')
 def upload(stream: typing.IO[bytes], timestamp: str, url: str) -> None:
     return_code = post_stream(stream=stream, timestamp=timestamp, url=url)
     click.echo(f"Response: {return_code}")
@@ -64,7 +70,7 @@ def upload(stream: typing.IO[bytes], timestamp: str, url: str) -> None:
 
 
 @main.command()
-@click.option('--url', default='http://127.0.0.1:5000/run_tl')
+@click.option('--url', default=_endpoint_address() + '/run_tl')
 def run_tl(url: str) -> None:
     return_code = trigger_tl(url)
     click.echo(f"Response: {return_code}")
@@ -73,7 +79,7 @@ def run_tl(url: str) -> None:
 
 
 @main.command()
-@click.option('--url', default='http://127.0.0.1:5000/status')
+@click.option('--url', default=_endpoint_address() + '/status')
 def status(url: str) -> None:
     try:
         system_status = requests.get(url).content.decode()

--- a/extract_endpoint/tests/test_post_to_endpoint.py
+++ b/extract_endpoint/tests/test_post_to_endpoint.py
@@ -103,6 +103,18 @@ def test_post_stream_cli(sample_timestamp: str,
     assert result.exit_code != HTTPStatus.BAD_REQUEST
 
 
+def test_etl_secret_key(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
+    assert post_to_endpoint._etl_secret_key() == post_to_endpoint.DEFAULT_ETL_SECRET_KEY
+    monkeypatch.setenv('ETL_SECRET_KEY', 'test_key')
+    assert post_to_endpoint._etl_secret_key() == 'test_key'
+
+
+def test_endpoint_address(monkeypatch: _pytest.monkeypatch.MonkeyPatch) -> None:
+    assert post_to_endpoint._endpoint_address() == post_to_endpoint.DEFAULT_ENERGUIDE_ENDPOINT_ADDRESS
+    monkeypatch.setenv('ENERGUIDE_ENDPOINT_ADDRESS', 'test_address')
+    assert post_to_endpoint._endpoint_address() == 'test_address'
+
+
 def test_post_stream_cli_no_stream(upload_url: str, sample_timestamp: str) -> None:
 
     runner = testing.CliRunner()


### PR DESCRIPTION
user can set an environment variable `ENERGUIDE_ENDPOINT_ADDRESS` to the Endpoint url and then not need the `--url` option to contact Endpoint in Azure.