### PR TITLE
Add element type for upgrade priorities

### DIFF
--- a/nrcan_etl/src/energuide/element.py
+++ b/nrcan_etl/src/energuide/element.py
@@ -1,0 +1,86 @@
+import typing
+from lxml import etree
+from energuide.exceptions import EnerguideError, ElementGetValueError
+
+
+class MalformedXmlError(EnerguideError):
+    pass
+
+
+T = typing.TypeVar('T', int, float, str)
+
+
+class Element:
+
+    _PARSER = etree.XMLParser(ns_clean=True, recover=True, encoding='utf-8')
+
+    def __init__(self, node: etree._Element) -> None:
+        self.__node = node
+
+    @classmethod
+    def new(cls, tag: str) -> 'Element':
+        return cls(etree.Element(tag))
+
+    @classmethod
+    def from_string(cls, data: str) -> 'Element':
+        output: typing.Optional[etree._Element] = etree.fromstring(data.encode('utf-8'), parser=cls._PARSER)
+        if output is None:
+            raise MalformedXmlError(f'Invalid XML fragment: {data}')
+        return cls(output)
+
+    @classmethod
+    def parse(cls, *args, **kwargs):
+        output = etree.parse(*args, **kwargs)
+        return cls(output.find('.'))
+
+    def findtext(self, *args, **kwargs) -> typing.Optional[str]:
+        return self.__node.findtext(*args, **kwargs)
+
+    def get_text(self, *args, **kwargs) -> str:
+        result: typing.Optional[str] = self.__node.findtext(*args, **kwargs)
+        if result is None:
+            error_message = (
+                f"Couldn't find text at path {args[0]} in tag {self.tag}"
+                if args
+                else "Couldn't find text in {self.tag}"
+            )
+            raise ElementGetValueError(error_message)
+        return result
+
+    @property
+    def attrib(self) -> typing.Dict[str, typing.Any]:
+        return self.__node.attrib
+
+    def xpath(self, *args, **kwargs) -> typing.List[typing.Any]:
+        output = self.__node.xpath(*args, **kwargs)
+        return [Element(node) if isinstance(node, etree._Element) else node for node in output]
+
+    def find(self, *args, **kwargs) -> typing.Optional['Element']:
+        output = self.__node.find(*args, **kwargs)
+        return Element(output) if output is not None else None
+
+    def to_string(self) -> str:
+        return etree.tostring(self.__node, encoding='unicode')
+
+    def __iter__(self) -> typing.Iterator[typing.Any]:
+        for child in self.__node.__iter__():
+            yield Element(child)
+
+    @property
+    def tag(self) -> str:
+        return self.__node.tag
+
+    def insert(self, index: int, element: 'Element') -> None:
+        self.__node.insert(index, element.__node)
+
+    def get(self, xpath: str, type_: typing.Type[T]) -> T:
+        try:
+            value = self.__node.xpath(xpath)[0]
+        except IndexError as ex:
+            raise ElementGetValueError(f"Couldn't find element at {xpath} in {self.tag}") from ex
+
+        try:
+            result = type_(value)
+        except ValueError as ex:
+            raise ElementGetValueError(f"Unable to cast {value} to {type_} in {self.tag}") from ex
+        return typing.cast(T, result)

--- a/nrcan_etl/src/energuide/exceptions.py
+++ b/nrcan_etl/src/energuide/exceptions.py
@@ -1,0 +1,27 @@
+import typing
+
+
+class EnerguideError(Exception):
+    pass
+
+
+class InvalidGroupSizeError(EnerguideError):
+    pass
+
+
+class InvalidInputDataError(EnerguideError):
+    pass
+
+
+class InvalidEmbeddedDataTypeError(EnerguideError):
+
+    def __init__(self, data_class: type, msg: typing.Optional[str] = None) -> None:
+        self.data_class = data_class
+
+        if msg is not None:
+            super().__init__(msg)
+        else:
+            super().__init__()
+
+class ElementGetValueError(EnerguideError):
+    pass

--- a/nrcan_etl/tests/test_element.py
+++ b/nrcan_etl/tests/test_element.py
@@ -1,0 +1,137 @@
+import py._path.local
+import pytest
+from energuide import element
+from energuide.exceptions import ElementGetValueError
+
+
+@pytest.fixture
+def fragment() -> str:
+    return "<Foo><Bar id='1'>baz</Bar><Bar id='2'>qux</Bar></Foo>"
+
+
+@pytest.fixture
+def fragment_file_path(fragment: str, tmpdir: py._path.local.LocalPath) -> str:
+    file = tmpdir.join('data.xml')
+    file.write_text('<?xml version="1.0" encoding="UTF-8" ?>', encoding='utf-8')
+    file.write_text(fragment, encoding='utf-8')
+    return str(file)
+
+
+@pytest.fixture
+def fragment_node(fragment: str) -> element.Element:
+    return element.Element.from_string(fragment)
+
+
+def test_from_string(fragment: str) -> None:
+    output = element.Element.from_string(fragment)
+    assert isinstance(output, element.Element)
+    assert output.tag == 'Foo'
+
+
+def test_findtext(fragment_node: element.Element) -> None:
+    assert fragment_node.findtext('Bar') == 'baz'
+    assert fragment_node.findtext('Baz') is None
+
+
+def test_get_text(fragment_node: element.Element) -> None:
+    assert fragment_node.get_text('Bar') == 'baz'
+
+
+def test_get_text_raises_when_not_found(fragment_node: element.Element) -> None:
+    with pytest.raises(ElementGetValueError):
+        fragment_node.get_text('Baz')
+
+
+def test_attrib(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.attrib['id'] == '1'
+    assert 'baz' not in bar_node.attrib
+
+
+def test_xpath_returns_elements(fragment_node: element.Element) -> None:
+    output = fragment_node.xpath('Bar')
+    assert len(output) == 2
+    assert all([isinstance(bar_node, element.Element) for bar_node in output])
+    assert output[0].attrib['id'] == '1'
+
+
+def test_parse(fragment_file_path: str) -> None:
+    with open(fragment_file_path) as xml_file:
+        node = element.Element.parse(xml_file)
+    assert node.tag == 'Foo'
+
+
+def test_iter(fragment_node: element.Element) -> None:
+    child_nodes = [child for child in fragment_node]
+    assert len(child_nodes) == 2
+    assert all([isinstance(child, element.Element) for child in child_nodes])
+    assert all([child.tag == 'Bar' for child in child_nodes])
+
+
+def test_find(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.tag == 'Bar'
+    assert bar_node.attrib['id'] == '1'
+
+
+def test_find_returns_none(fragment_node: element.Element) -> None:
+    assert fragment_node.find('Baz') is None
+
+
+def test_to_string(fragment_node: element.Element) -> None:
+    bar_node = fragment_node.find('Bar')
+    assert bar_node
+    assert bar_node.to_string() == '<Bar id="1">baz</Bar>'
+
+
+def test_tag(fragment_node: element.Element) -> None:
+    assert fragment_node.tag == 'Foo'
+
+
+def test_new() -> None:
+    output = element.Element.new('Foo')
+    assert output.tag == 'Foo'
+
+
+def test_from_malformed_string() -> None:
+    with pytest.raises(element.MalformedXmlError):
+        element.Element.from_string('</Foo></Foo>')
+
+
+def test_insert_node() -> None:
+    root = element.Element.new('Root')
+    child1 = element.Element.new('Child1')
+    child2 = element.Element.new('Child2')
+    root.insert(0, child1)
+    root.insert(0, child2)
+    assert len(root.xpath('*')) == 2
+
+
+def test_get_int(fragment_node: element.Element) -> None:
+    result = fragment_node.get('Bar/@id', int)
+    assert result == 1
+    assert isinstance(result, int)
+
+
+def test_get_float(fragment_node: element.Element) -> None:
+    result = fragment_node.get('Bar/@id', float)
+    assert result == 1.0
+    assert isinstance(result, float)
+
+
+def test_get_str(fragment_node: element.Element) -> None:
+    result = fragment_node.get('Bar/@id', str)
+    assert result == '1'
+    assert isinstance(result, str)
+
+
+def test_get_raises_when_not_found(fragment_node: element.Element) -> None:
+    with pytest.raises(ElementGetValueError):
+        fragment_node.get('Bar/@foo', int)
+
+
+def test_get_raises_when_cant_cast(fragment_node: element.Element) -> None:
+    with pytest.raises(ElementGetValueError):
+        fragment_node.get('Bar/text()', int)


### PR DESCRIPTION
This PR extracts the next piece of #392 

It adds in the `Element` datatype and the exceptions from `etl`, unchanged from their implementation in `etl`