### PR TITLE
Add extractor

### DIFF
--- a/nrcan_etl/src/energuide/extractor.py
+++ b/nrcan_etl/src/energuide/extractor.py
@@ -1,0 +1,156 @@
+import csv
+import json
+import typing
+import sys
+import zipfile
+import cerberus
+from tqdm import tqdm
+from energuide import logger
+from energuide import element
+from energuide import snippets
+from energuide.exceptions import InvalidInputDataError
+from energuide.exceptions import EnerguideError
+
+
+LOGGER = logger.get_logger(__name__)
+
+
+REQUIRED_FIELDS = [
+    'EVAL_ID',
+    'EVAL_TYPE',
+    'BUILDER',
+    'ENTRYDATE',
+    'CREATIONDATE',
+    'YEARBUILT',
+    'CLIENTCITY',
+    'HOUSEREGION',
+    'HOUSE_ID',
+]
+
+NULLABLE_FIELDS = [
+    'MODIFICATIONDATE',
+    'forwardSortationArea',
+    'HEATEDFLOORAREA',
+    'TYPEOFHOUSE',
+    'ERSRATING',
+    'UGRERSRATING',
+    'ERSGHG',
+    'UGRERSGHG',
+    'ERSENERGYINTENSITY',
+]
+
+INPUT_SCHEMA = {field: {'type': 'string', 'required': True} for field in REQUIRED_FIELDS}
+for field in NULLABLE_FIELDS:
+    INPUT_SCHEMA[field] = {'type': 'string', 'required': True, 'nullable': True}
+
+INPUT_SCHEMA['RAW_XML'] = {'type': 'string', 'required': False, 'nullable': True}
+INPUT_SCHEMA['upgrades'] = {
+    'type': 'list',
+    'required': True,
+    'nullable': True,
+    'schema': {
+        'type': 'string'
+    }
+}
+
+
+_WINDOWS_LONG_SIZE = (2 ** 31) - 1
+
+
+def _empty_to_none(row: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    for key, value in row.items():
+        if value == '':
+            row[key] = None
+    return row
+
+
+def _validated(
+        row: typing.Dict[str, typing.Any],
+        validator: cerberus.Validator) -> typing.Dict[str, typing.Optional[str]]:
+    if not validator.validate(row):
+        error_keys = ', '.join(validator.errors.keys())
+        raise InvalidInputDataError(f'Validator failed on keys: {error_keys} for {row.get("BUILDER")}')
+    return validator.document
+
+
+def _truncate_postal_code(row: typing.Dict[str, typing.Optional[str]]) -> typing.Dict[str, typing.Optional[str]]:
+    postal = row.get('MAIL_PCODE')
+    row['forwardSortationArea'] = postal[0:3] if postal else None
+    return row
+
+
+def _safe_merge(data: typing.Dict[str, typing.Any],
+                extra: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    for key, value in extra.items():
+        assert key not in data
+        data[key] = value
+    return data
+
+
+def _snip_upgrade_order(row: typing.Dict[str, typing.Optional[str]]) -> typing.Dict[str, typing.Optional[str]]:
+    if row.get('RAW_XML'):
+        xml = typing.cast(str, row['RAW_XML'])
+
+        doc = element.Element.from_string(xml)
+        upgrade_order = snippets.snip_energy_upgrade_order(doc)
+        _safe_merge(row, upgrade_order.to_dict())
+    else:
+        _safe_merge(row, snippets.EnergyUpgradesSnippet.EMPTY_SNIPPET)
+
+    return row
+
+
+def _drop_unwanted(row: typing.Dict[str, typing.Optional[str]]) -> typing.Dict[str, typing.Optional[str]]:
+    row.pop("RAW_XML", None)
+    return row
+
+
+def _read_csv(filepath: str, show_progress: bool) -> typing.Iterator[typing.Dict[str, str]]:
+    try:
+        csv.field_size_limit(sys.maxsize)
+    except OverflowError:
+        csv.field_size_limit(_WINDOWS_LONG_SIZE)
+
+    with open(filepath, 'r', encoding='utf-8', newline='') as file:
+        total_lines = sum(1 for _ in file)
+
+    with tqdm(open(filepath, 'r', encoding='utf-8', newline=''),
+              total=total_lines, unit=' lines', disable=not show_progress) as file:
+        csv_reader = csv.DictReader(file)
+        for row in csv_reader:
+            yield row
+
+
+def extract_data(input_path: str,
+                 show_progress: bool = False) -> typing.Iterator[typing.Optional[typing.Dict[str, typing.Any]]]:
+    validator = cerberus.Validator(INPUT_SCHEMA, purge_unknown=True)
+    rows = _read_csv(input_path, show_progress)
+
+    for row in rows:
+        try:
+            patched = _empty_to_none(row)
+            filtered = _truncate_postal_code(patched)
+            ordered = _snip_upgrade_order(filtered)
+            validated_data = _validated(ordered, validator)
+            cleaned = _drop_unwanted(validated_data)
+            yield cleaned
+        except EnerguideError as ex:
+            LOGGER.error(f"Error extracting data from row {row.get('BUILDER', 'Unknown ID')}. Details: {ex}")
+            yield None
+
+
+def write_data(data: typing.Iterable[typing.Optional[typing.Dict[str, typing.Any]]],
+               output_path: str) -> typing.Tuple[int, int]:
+    records_written, records_failed = 0, 0
+    with zipfile.ZipFile(output_path, mode='w', compression=zipfile.ZIP_DEFLATED) as output_zip:
+        for blob in data:
+            if blob is None or not all((blob.get('BUILDER'), blob.get('EVAL_ID'), blob.get('HOUSE_ID'))):
+                records_failed += 1
+            else:
+                blob_id = blob.get('BUILDER')
+                eval_id = blob.get('EVAL_ID')
+                house_id = blob.get('HOUSE_ID')
+                output_zip.writestr(f'{house_id}-{eval_id}-{blob_id}', json.dumps(blob))
+                records_written += 1
+
+    return records_written, records_failed

--- a/nrcan_etl/tests/test_extractor.py
+++ b/nrcan_etl/tests/test_extractor.py
@@ -1,0 +1,146 @@
+import csv
+import json
+import os
+import typing
+import zipfile
+import _pytest.fixtures
+import py._path.local
+import pytest
+from energuide import extractor
+
+
+def _write_csv(filepath: str, data: typing.Mapping[str, typing.Optional[str]]) -> None:
+    with open(filepath, 'w') as file:
+        writer = csv.DictWriter(file, fieldnames=list(data.keys()))
+        writer.writeheader()
+        writer.writerow(dict(data))
+
+
+@pytest.fixture
+def base_data() -> typing.Dict[str, str]:
+    return {
+        'EVAL_ID': '123',
+        'HOUSE_ID': '456',
+        'EVAL_TYPE': 'D',
+        'BUILDER': '4K13D01404',
+        'ENTRYDATE': '2012-02-25',
+        'CREATIONDATE': '2012-06-08 09:26:10',
+        'MODIFICATIONDATE': '2012-06-09 09:26:10',
+        'YEARBUILT': '1894',
+        'CLIENTCITY': 'Brooks',
+        'HOUSEREGION': 'AB',
+        'MAIL_PCODE': 'L1R5C7',
+        'HEATEDFLOORAREA': '201.1351',
+        'TYPEOFHOUSE': 'Single detached',
+        'ERSRATING': '164',
+        'UGRERSRATING': '115',
+        'ERSGHG': '7.8',
+        'UGRERSGHG': '5.4',
+        'ERSENERGYINTENSITY': '0.82',
+
+        'RAW_XML': '',
+    }
+
+
+@pytest.fixture
+def extra_data() -> typing.Dict[str, str]:
+    data = base_data()
+    data['other_1'] = 'foo'
+    data['other_2'] = 'bar'
+    return data
+
+
+@pytest.fixture
+def missing_data() -> typing.Dict[str, str]:
+    data = base_data()
+    data.pop('BUILDER')
+    return data
+
+
+@pytest.fixture
+def nullable_data() -> typing.Dict[str, typing.Optional[str]]:
+    data = base_data()
+    data['MODIFICATIONDATE'] = None
+    return data
+
+
+@pytest.fixture(params=[base_data(), extra_data()])
+def valid_filepath(tmpdir: py._path.local.LocalPath, request: _pytest.fixtures.SubRequest) -> str:
+    data_dict = typing.cast(typing.Dict[str, str], request.param)
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    _write_csv(filepath, data_dict)
+    return filepath
+
+
+@pytest.fixture
+def missing_filepath(tmpdir: py._path.local.LocalPath, missing_data: typing.Dict[str, str]) -> str:
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    _write_csv(filepath, missing_data)
+    return filepath
+
+
+@pytest.fixture
+def extra_filepath(tmpdir: py._path.local.LocalPath, extra_data: typing.Dict[str, str]) -> str:
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    _write_csv(filepath, extra_data)
+    return filepath
+
+
+def test_extract_valid(valid_filepath: str) -> None:
+    output = next(extractor.extract_data(valid_filepath))
+    assert output
+    item = dict(output)
+    assert 'EVAL_ID' in item
+
+
+def test_purge_unknown(extra_filepath: str) -> None:
+    output = next(extractor.extract_data(extra_filepath))
+    assert output
+    item = dict(output)
+    assert 'other_1' not in item
+
+
+def test_extract_missing(missing_filepath: str) -> None:
+    output = extractor.extract_data(missing_filepath)
+    result = [x for x in output]
+    assert result == [None]
+
+
+def test_empty_to_none(tmpdir: py._path.local.LocalPath, nullable_data: typing.Dict[str, typing.Optional[str]]) -> None:
+    filepath = os.path.join(tmpdir, 'sample.csv')
+    _write_csv(filepath, nullable_data)
+    output = extractor.extract_data(filepath)
+    row = next(output)
+    assert row
+    assert row['MODIFICATIONDATE'] is None
+
+
+def test_write_data(tmpdir: py._path.local.LocalPath) -> None:
+    output_path = os.path.join(tmpdir, 'output.zip')
+
+    data = [
+        {'foo': 1, 'BUILDER': '4K02E90020', 'EVAL_ID': '12149', 'HOUSE_ID': '15678'},
+        {'bar': 2, 'baz': 3, 'BUILDER': '4K13D01404', 'EVAL_ID': '12148', 'HOUSE_ID': '15678'},
+    ]
+
+    result = extractor.write_data(data, output_path)
+    assert result == (2, 0)
+
+    with zipfile.ZipFile(output_path, 'r') as output_file:
+        files = [output_file.read('15678-12149-4K02E90020'), output_file.read('15678-12148-4K13D01404')]
+
+    assert [json.loads(file) for file in files] == data
+
+
+def test_write_bad_data(tmpdir: py._path.local.LocalPath) -> None:
+    output_path = os.path.join(tmpdir, 'output.zip')
+
+    data: typing.List[typing.Dict[str, typing.Any]] = [
+        {'foo': 1, 'BUILDER': '4K02E90020', 'EVAL_ID': '12148', 'HOUSE_ID': '15678'},
+        {'bar': 2, 'baz': 3},
+    ]
+
+    extractor.write_data(data, output_path)
+
+    with zipfile.ZipFile(output_path, 'r') as output:
+        assert len(output.namelist()) == 1


### PR DESCRIPTION
This PR is the first in the line of #392 changes that makes real changes.

It adds in an extractor similar to the one in `etl`, but with most xml extraction removed, and some additional TSV fields extracted.

This should be all that is needed to be extracted to satisfy the information in the priority data fields.