### PR TITLE
Add dwellings

### DIFF
--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -1,0 +1,293 @@
+import datetime
+import enum
+import typing
+from dateutil import parser
+from energuide import validator
+from energuide.embedded import upgrade
+from energuide.exceptions import InvalidGroupSizeError
+from energuide.exceptions import InvalidInputDataError
+
+
+@enum.unique
+class EvaluationType(enum.Enum):
+    PRE_RETROFIT = 'D'
+    POST_RETROFIT = 'E'
+
+    @classmethod
+    def from_code(cls, code: str) -> 'EvaluationType':
+        if code == cls.PRE_RETROFIT.value:
+            return EvaluationType.PRE_RETROFIT
+        elif code == cls.POST_RETROFIT.value:
+            return EvaluationType.POST_RETROFIT
+        else:
+            raise InvalidInputDataError(f'Invalid code: {code}')
+
+
+@enum.unique
+class Region(enum.Enum):
+    BRITISH_COLUMBIA = 'BC'
+    ALBERTA = 'AB'
+    SASKATCHEWAN = 'SK'
+    MANITOBA = 'MB'
+    ONTARIO = 'ON'
+    QUEBEC = 'QC'
+    NEW_BRUNSWICK = 'NB'
+    PRINCE_EDWARD_ISLAND = 'PE'
+    NOVA_SCOTIA = 'NS'
+    NEWFOUNDLAND_AND_LABRADOR = 'NL'
+    YUKON = 'YT'
+    NORTHWEST_TERRITORIES = 'NT'
+    NUNAVUT = 'NU'
+    UNKNOWN = '??'
+
+    @classmethod
+    def _from_name(cls, name: str) -> typing.Optional['Region']:
+        snake_name = name.upper().replace(' ', '_')
+        return Region[snake_name] if snake_name in Region.__members__ else None
+
+    @classmethod
+    def _from_code(cls, code: str) -> typing.Optional['Region']:
+        code = code.upper()
+        for region in Region:
+            if code == region.value:
+                return region
+        return None
+
+    @classmethod
+    def from_data(cls, data: str) -> 'Region':
+        output = cls._from_name(data)
+        if not output:
+            output = cls._from_code(data)
+        if not output:
+            output = Region.UNKNOWN
+        return output
+
+
+class _ParsedDwellingDataRow(typing.NamedTuple):
+    house_id: int
+    eval_id: int
+    file_id: str
+    eval_type: EvaluationType
+    entry_date: datetime.date
+    creation_date: datetime.datetime
+    modification_date: typing.Optional[datetime.datetime]
+    year_built: int
+    city: str
+    region: Region
+    forward_sortation_area: str
+    ers_rating: typing.Optional[int]
+    energy_upgrades: typing.List[upgrade.Upgrade]
+
+
+class ParsedDwellingDataRow(_ParsedDwellingDataRow):
+
+    _SCHEMA = {
+        'EVAL_ID': {'type': 'integer', 'required': True, 'coerce': int},
+        'HOUSE_ID': {'type': 'integer', 'required': True, 'coerce': int},
+        'EVAL_TYPE': {'type': 'string', 'required': True, 'allowed': [eval_type.value for eval_type in EvaluationType]},
+        'ENTRYDATE': {'type': 'date', 'required': True, 'coerce': parser.parse},
+        'CREATIONDATE': {'type': 'datetime', 'required': True, 'coerce': parser.parse},
+        'YEARBUILT': {'type': 'integer', 'required': True, 'coerce': int},
+        'CLIENTCITY': {'type': 'string', 'required': True},
+        'forwardSortationArea': {'type': 'string', 'required': True, 'regex': '[A-Z][0-9][A-Z]'},
+        'HOUSEREGION': {'type': 'string', 'required': True},
+        'BUILDER': {'type': 'string', 'required': True},
+
+        'upgrades': {
+            'type': 'list',
+            'required': True,
+            'schema': {
+                'type': 'xml',
+                'coerce': 'parse_xml',
+            }
+        },
+
+        'MODIFICATIONDATE': {'type': 'datetime', 'nullable': True, 'required': True, 'coerce': parser.parse},
+
+        'HEATEDFLOORAREA': {'type': 'float', 'nullable': True, 'coerce': float},
+        'TYPEOFHOUSE': {'type': 'string', 'nullable': True},
+        'ERSRATING': {'type': 'integer', 'nullable': True, 'coerce': int},
+        'UGRERSRATING': {'type': 'integer', 'nullable': True, 'coerce': int},
+        'ERSGHG': {'type': 'float', 'nullable': True, 'coerce': float},
+        'UGRERSGHG': {'type': 'float', 'nullable': True, 'coerce': float},
+        'ERSENERGYINTENSITY': {'type': 'float', 'nullable': True, 'coerce': float},
+    }
+
+    @classmethod
+    def from_row(cls, row: typing.Dict[str, typing.Any]) -> 'ParsedDwellingDataRow':
+        checker = validator.DwellingValidator(cls._SCHEMA, allow_unknown=True)
+        if not checker.validate(row):
+            error_keys = ', '.join(checker.errors.keys())
+            raise InvalidInputDataError(f'Validator failed on keys: {error_keys}')
+
+        parsed = checker.document
+
+        return ParsedDwellingDataRow(
+            house_id=parsed['HOUSE_ID'],
+            eval_id=parsed['EVAL_ID'],
+            file_id=parsed['BUILDER'],
+            eval_type=EvaluationType.from_code(parsed['EVAL_TYPE']),
+            entry_date=parsed['ENTRYDATE'].date(),
+            creation_date=parsed['CREATIONDATE'],
+            modification_date=parsed['MODIFICATIONDATE'],
+            year_built=parsed['YEARBUILT'],
+            city=parsed['CLIENTCITY'],
+            region=Region.from_data(parsed['HOUSEREGION']),
+            forward_sortation_area=parsed['forwardSortationArea'],
+
+            ers_rating=parsed['ERSRATING'],
+            energy_upgrades=[upgrade.Upgrade.from_data(upgrade_node) for upgrade_node in parsed['upgrades']],
+        )
+
+
+class Evaluation:
+
+    def __init__(self, *,
+                 file_id: str,
+                 evaluation_id: int,
+                 evaluation_type: EvaluationType,
+                 entry_date: datetime.date,
+                 creation_date: datetime.datetime,
+                 modification_date: typing.Optional[datetime.datetime],
+                 ers_rating: typing.Optional[int],
+                 energy_upgrades: typing.List[upgrade.Upgrade],
+                ) -> None:
+        self._file_id = file_id
+        self._evaluation_id = evaluation_id
+        self._evaluation_type = evaluation_type
+        self._entry_date = entry_date
+        self._creation_date = creation_date
+        self._modification_date = modification_date
+        self._ers_rating = ers_rating
+        self._energy_upgrades = energy_upgrades
+
+
+    @classmethod
+    def from_data(cls, data: ParsedDwellingDataRow) -> 'Evaluation':
+        return Evaluation(
+            file_id=data.file_id,
+            evaluation_id=data.eval_id,
+            evaluation_type=data.eval_type,
+            entry_date=data.entry_date,
+            creation_date=data.creation_date,
+            modification_date=data.modification_date,
+            ers_rating=data.ers_rating,
+            energy_upgrades=data.energy_upgrades,
+        )
+
+    @property
+    def evaluation_type(self) -> EvaluationType:
+        return self._evaluation_type
+
+    @property
+    def evaluation_id(self) -> int:
+        return self._evaluation_id
+
+    @property
+    def entry_date(self) -> datetime.date:
+        return self._entry_date
+
+    @property
+    def ers_rating(self) -> typing.Optional[int]:
+        return self._ers_rating
+
+    @property
+    def creation_date(self) -> datetime.datetime:
+        return self._creation_date
+
+    @property
+    def modification_date(self) -> typing.Optional[datetime.datetime]:
+        return self._modification_date
+
+    @property
+    def file_id(self) -> str:
+        return self._file_id
+
+    @property
+    def energy_upgrades(self) -> typing.List[upgrade.Upgrade]:
+        return self._energy_upgrades
+
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'fileId': self.file_id,
+            'evaluationId': self.evaluation_id,
+            'evaluationType': self.evaluation_type.value,
+            'entryDate': self.entry_date.isoformat(),
+            'creationDate': self.creation_date.isoformat(),
+            'modificationDate': self.modification_date.isoformat() if self.modification_date is not None else None,
+            'ersRating': self.ers_rating,
+            'energyUpgrades': [upgrade.to_dict() for upgrade in self.energy_upgrades],
+        }
+
+
+class Dwelling:
+
+    GROUPING_FIELD = 'HOUSE_ID'
+
+    def __init__(self, *,
+                 house_id: int,
+                 year_built: int,
+                 city: str,
+                 region: Region,
+                 forward_sortation_area: str,
+                 evaluations: typing.List[Evaluation]) -> None:
+        self._house_id = house_id
+        self._year_built = year_built
+        self._city = city
+        self._region = region
+        self._forward_sortation_area = forward_sortation_area
+        self._evaluations = evaluations
+
+    @classmethod
+    def _from_parsed_group(cls, data: typing.List[ParsedDwellingDataRow]) -> 'Dwelling':
+        if not data:
+            raise InvalidGroupSizeError('Empty groups are invalid')
+        evaluations = [Evaluation.from_data(row) for row in data]
+        return Dwelling(
+            house_id=data[0].house_id,
+            year_built=data[0].year_built,
+            city=data[0].city,
+            region=data[0].region,
+            forward_sortation_area=data[0].forward_sortation_area,
+            evaluations=evaluations,
+        )
+
+    @classmethod
+    def from_group(cls, data: typing.List[typing.Dict[str, typing.Any]]) -> 'Dwelling':
+        parsed_data = [ParsedDwellingDataRow.from_row(row) for row in data]
+        return cls._from_parsed_group(parsed_data)
+
+    @property
+    def house_id(self) -> int:
+        return self._house_id
+
+    @property
+    def year_built(self) -> int:
+        return self._year_built
+
+    @property
+    def city(self) -> str:
+        return self._city
+
+    @property
+    def region(self) -> Region:
+        return self._region
+
+    @property
+    def forward_sortation_area(self) -> str:
+        return self._forward_sortation_area
+
+    @property
+    def evaluations(self) -> typing.List[Evaluation]:
+        return self._evaluations
+
+    def to_dict(self) -> typing.Dict[str, typing.Any]:
+        return {
+            'houseId': self.house_id,
+            'yearBuilt': self.year_built,
+            'city': self.city,
+            'region': self.region.value,
+            'forwardSortationArea': self.forward_sortation_area,
+            'evaluations': [evaluation.to_dict() for evaluation in self.evaluations]
+        }

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -1,0 +1,240 @@
+import copy
+import datetime
+import typing
+import pytest
+from energuide import dwelling
+from energuide.embedded import upgrade
+from energuide.exceptions import InvalidInputDataError
+from energuide.exceptions import InvalidGroupSizeError
+
+
+# pylint: disable=no-self-use
+
+
+@pytest.fixture
+def upgrades_input() -> typing.List[str]:
+    return [
+        '<Ceilings cost="0" priority="12" />',
+        '<MainWalls cost="1" priority="2" />',
+        '<Foundation cost="2" priority="3" />',
+        ]
+
+
+@pytest.fixture
+def sample_input_d(upgrades_input: typing.List[str]) -> typing.Dict[str, typing.Any]:
+
+    return {
+        'HOUSE_ID': '456',
+        'EVAL_ID': '123',
+        'EVAL_TYPE': 'D',
+        'ENTRYDATE': '2018-01-01',
+        'CREATIONDATE': '2018-01-08 09:00:00',
+        'MODIFICATIONDATE': '2018-06-01 09:00:00',
+        'CLIENTCITY': 'Ottawa',
+        'forwardSortationArea': 'K1P',
+        'HOUSEREGION': 'Ontario',
+        'YEARBUILT': '2000',
+        'BUILDER': '4K13D01404',
+        'HEATEDFLOORAREA': None,
+        'TYPEOFHOUSE': 'Single detached',
+        'ERSRATING': '567',
+        'UGRERSRATING': '565',
+        'ERSGHG': None,
+        'UGRERSGHG': None,
+        'ERSENERGYINTENSITY': None,
+        'upgrades': upgrades_input,
+    }
+
+
+@pytest.fixture
+def sample_input_e(sample_input_d: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    output = copy.deepcopy(sample_input_d)
+    output['EVAL_TYPE'] = 'E'
+    return output
+
+
+@pytest.fixture
+def sample_input_missing(sample_input_d: typing.Dict[str, typing.Any]) -> typing.Dict[str, typing.Any]:
+    output = copy.deepcopy(sample_input_d)
+    output['MODIFICATIONDATE'] = None
+    output['ERSRATING'] = None
+    return output
+
+
+@pytest.fixture
+def sample_parsed_d(sample_input_d: typing.Dict[str, typing.Any]) -> dwelling.ParsedDwellingDataRow:
+    return dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
+
+
+@pytest.fixture
+def sample_parsed_e(sample_input_e: typing.Dict[str, typing.Any]) -> dwelling.ParsedDwellingDataRow:
+    return dwelling.ParsedDwellingDataRow.from_row(sample_input_e)
+
+
+class TestEvaluationType:
+
+    def test_from_code(self):
+        code = dwelling.EvaluationType.PRE_RETROFIT.value
+        output = dwelling.EvaluationType.from_code(code)
+        assert output == dwelling.EvaluationType.PRE_RETROFIT
+
+
+class TestRegion:
+
+    def test_from_name(self):
+        data = [
+            'Ontario',
+            'british columbia',
+            'NOVA SCOTIA',
+        ]
+        output = [dwelling.Region.from_data(row) for row in data]
+
+        assert output == [
+            dwelling.Region.ONTARIO,
+            dwelling.Region.BRITISH_COLUMBIA,
+            dwelling.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_name(self):
+        assert dwelling.Region.from_data('foo') == dwelling.Region.UNKNOWN
+
+    def test_from_code(self):
+        data = [
+            'ON',
+            'bc',
+            'Ns',
+        ]
+        output = [dwelling.Region.from_data(row) for row in data]
+        assert output == [
+            dwelling.Region.ONTARIO,
+            dwelling.Region.BRITISH_COLUMBIA,
+            dwelling.Region.NOVA_SCOTIA,
+        ]
+
+    def test_from_unknown_code(self):
+        assert dwelling.Region.from_data('CA') == dwelling.Region.UNKNOWN
+
+
+class TestParsedDwellingDataRow:
+
+    def test_from_row(self, sample_input_d: typing.Dict[str, typing.Any]) -> None:
+        output = dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
+
+        assert output == dwelling.ParsedDwellingDataRow(
+            house_id=456,
+            eval_id=123,
+            file_id='4K13D01404',
+            eval_type=dwelling.EvaluationType.PRE_RETROFIT,
+            entry_date=datetime.date(2018, 1, 1),
+            creation_date=datetime.datetime(2018, 1, 8, 9),
+            modification_date=datetime.datetime(2018, 6, 1, 9),
+            year_built=2000,
+            city='Ottawa',
+            region=dwelling.Region.ONTARIO,
+            forward_sortation_area='K1P',
+            ers_rating=567,
+            energy_upgrades=[
+                upgrade.Upgrade(
+                    upgrade_type='Ceilings',
+                    cost=0,
+                    priority=12,
+                ),
+                upgrade.Upgrade(
+                    upgrade_type='MainWalls',
+                    cost=1,
+                    priority=2,
+                ),
+                upgrade.Upgrade(
+                    upgrade_type='Foundation',
+                    cost=2,
+                    priority=3,
+                ),
+            ]
+        )
+
+    def test_null_fields_are_accepted(self, sample_input_missing: typing.Dict[str, typing.Any]) -> None:
+        output = dwelling.ParsedDwellingDataRow.from_row(sample_input_missing)
+
+        assert output.modification_date == output.ers_rating == None
+
+    def test_bad_postal_code(self, sample_input_d: typing.Dict[str, typing.Any]) -> None:
+        sample_input_d['forwardSortationArea'] = 'K16'
+        with pytest.raises(InvalidInputDataError):
+            dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
+
+    def test_from_bad_row(self) -> None:
+        input_data = {
+            'EVAL_ID': 123
+        }
+        with pytest.raises(InvalidInputDataError) as ex:
+            dwelling.ParsedDwellingDataRow.from_row(input_data)
+        assert 'EVAL_TYPE' in ex.exconly()
+        assert 'EVAL_ID' not in ex.exconly()
+
+    def test_missing_ers(self, sample_input_d: typing.Dict[str, typing.Any]) -> None:
+        sample_input_d['ERSRATING'] = None
+        output = dwelling.ParsedDwellingDataRow.from_row(sample_input_d)
+        assert output.ers_rating is None
+
+
+class TestDwellingEvaluation:
+
+    def test_eval_type(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d)
+        assert output.evaluation_type == dwelling.EvaluationType.PRE_RETROFIT
+
+    def test_entry_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d)
+        assert output.entry_date == datetime.date(2018, 1, 1)
+
+    def test_creation_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d)
+        assert output.creation_date == datetime.datetime(2018, 1, 8, 9)
+
+    def test_modification_date(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d)
+        assert output.modification_date == datetime.datetime(2018, 6, 1, 9)
+
+    def test_to_dict(self, sample_parsed_d: dwelling.ParsedDwellingDataRow) -> None:
+        output = dwelling.Evaluation.from_data(sample_parsed_d).to_dict()
+        assert output['evaluationType'] == dwelling.EvaluationType.PRE_RETROFIT.value
+
+
+class TestDwelling:
+
+    @pytest.fixture
+    def sample(self,
+               sample_input_d: typing.Dict[str, typing.Any],
+               sample_input_e: typing.Dict[str, typing.Any],
+              ) -> typing.List[typing.Dict[str, typing.Any]]:
+        return [sample_input_d, sample_input_e].copy()
+
+    def test_house_id(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(sample)
+        assert output.house_id == 456
+
+    def test_year_built(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(sample)
+        assert output.year_built == 2000
+
+    def test_address_data(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(sample)
+        assert output.city == 'Ottawa'
+        assert output.region == dwelling.Region.ONTARIO
+        assert output.forward_sortation_area == 'K1P'
+
+    def test_evaluations(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(sample)
+        assert len(output.evaluations) == 2
+
+    def test_no_data(self) -> None:
+        data: typing.List[typing.Any] = []
+        with pytest.raises(InvalidGroupSizeError):
+            dwelling.Dwelling.from_group(data)
+
+    def test_to_dict(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(sample).to_dict()
+        assert output['houseId'] == 456
+        assert len(output['evaluations']) == 2
+        assert 'postalCode' not in output
+        assert output['region'] == dwelling.Region.ONTARIO.value


### PR DESCRIPTION
One of the last PRs in the series for #392 

This PR adds in Dwellings, copied from `etl` but with a lot of it removed, and some added.

It is in a stable position, but does not yet incorporate all the priority data fields, but does do schema verification that they are all there.