### PR TITLE
Report failing master on python_integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,6 +334,7 @@ jobs:
           paths:
             - mongo_dump
           root: workspace
+      - run:
           command: ~/repo/scripts/notify_failure.sh
           name: "Report failing Master"
           when: on_fail


### PR DESCRIPTION
Noticed today that at some point the circleci config got slightly broken in such a way that if `python_integtation` fails, we won't get the failure notification.

This PR fixes that error.