### PR TITLE
Add new Wall type to API

### DIFF
--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -44,6 +44,7 @@ describe('Schema', () => {
         'modificationDate',
         'energyUpgrades',
         'ersRating',
+        'walls',
       ])
     })
   })
@@ -63,6 +64,42 @@ describe('Schema', () => {
         'previous',
         'results',
       ])
+    })
+  })
+
+  describe('Wall Type', () => {
+    it('is defined', () => {
+      expect(typeMap).toHaveProperty('Wall')
+    })
+
+    it('has the expected fields', () => {
+      const Wall = typeMap.Wall
+      const fields = Object.keys(Wall.getFields())
+      expect(fields).toEqual(['measurement'])
+    })
+  })
+
+  describe('WallMeasurement Type', () => {
+    it('is defined', () => {
+      expect(typeMap).toHaveProperty('WallMeasurement')
+    })
+
+    it('has the expected fields', () => {
+      const WallMeasurement = typeMap.WallMeasurement
+      const fields = Object.keys(WallMeasurement.getFields())
+      expect(fields).toEqual(['insulation', 'heatLost'])
+    })
+  })
+
+  describe('Insulation Type', () => {
+    it('is defined', () => {
+      expect(typeMap).toHaveProperty('Insulation')
+    })
+
+    it('has the expected fields', () => {
+      const Insulation = typeMap.Insulation
+      const fields = Object.keys(Insulation.getFields())
+      expect(fields).toEqual(['percentage', 'rValue'])
     })
   })
 

--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -75,7 +75,7 @@ describe('Schema', () => {
     it('has the expected fields', () => {
       const Wall = typeMap.Wall
       const fields = Object.keys(Wall.getFields())
-      expect(fields).toEqual(['measurement'])
+      expect(fields).toEqual(['measurement', 'upgrade'])
     })
   })
 

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -78,6 +78,7 @@ const Schema = i18n => {
 
     type Wall @cacheControl(maxAge: 90) {
       measurement: WallMeasurement
+      upgrade: WallMeasurement
     }
 
     type WallMeasurement @cacheControl(maxAge: 90) {

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -76,6 +76,20 @@ const Schema = i18n => {
       areaBelowGradeFeet: Float
     }
 
+    type Wall @cacheControl(maxAge: 90) {
+      measurement: WallMeasurement
+    }
+
+    type WallMeasurement @cacheControl(maxAge: 90) {
+      insulation: [Insulation]
+      heatLost: Float
+    }
+
+    type Insulation @cacheControl(maxAge: 90) {
+      percentage: Float
+      rValue: Float
+    }
+
     # ${i18n.t`Detailed information about specific features of a given dwelling`}
     type Evaluation @cacheControl(maxAge: 90) {
       # ${i18n.t`Evaluation type codes are used to define the type of evaluation performed and to distinguish the house type (i.e. newly built or existing)`}
@@ -91,6 +105,7 @@ const Schema = i18n => {
       energyUpgrades: [Upgrade]
       # ${i18n.t`The EnerGuide Rating calculated for this evaluation`}
       ersRating: Int
+      walls: Wall
     }
 
     # ${i18n.t`A residential building evaluted under the Energuide program`}

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -77,6 +77,61 @@ describe('queries', () => {
       })
     })
 
+    it('retrieves all keys for wall data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+            dwelling(houseId: 1024170) {
+            evaluations {
+              walls {
+                measurement {
+                  insulation {
+                    percentage
+                    rValue
+                  }
+                  heatLost
+                }
+                upgrade {
+                  insulation {
+                    percentage
+                    rValue
+                  }
+                  heatLost
+                }
+              }
+            }
+          }
+        }`,
+        })
+
+      expect(response.body).not.toHaveProperty('errors')
+      let { dwelling: { evaluations } } = response.body.data
+      let [first] = evaluations
+      let wall = first.walls
+      expect(wall).toEqual({
+        measurement: {
+          heatLost: 16997.4,
+          insulation: [
+            {
+              percentage: 100,
+              rValue: 12,
+            },
+          ],
+        },
+        upgrade: {
+          heatLost: 11082.7,
+          insulation: [
+            {
+              percentage: 100,
+              rValue: 18,
+            },
+          ],
+        },
+      })
+    })
+
     it('retrieves all top level keys of the upgrade data', async () => {
       let response = await request(server)
         .post('/graphql')


### PR DESCRIPTION
Walls are now modelled differently, so I'm changing the API to return the new data format.

Also added unit tests and an integration test. Should be good to merge. 👍 

***

(this is how walls look now)

```
"walls": {
  "measurement": {
    "insulation": [
      {
        "percentage": 45.3,
        "rValue": 12.0
      },
      {
        "percentage": 4.7,
        "rValue": 12.0
      }
    ],
    "heatLost": 27799.9
  },
  "upgrade": {
    "insulation": [
      {
        "percentage": 45.3,
        "rValue": 12.0
      },
      {
        "percentage": 4.7,
       "rValue": 12.0
      }
    ],
     "heatLost": 27799.9
  }
}
```