### PR TITLE
change heat_lost to heat_loss

### DIFF
--- a/nrcan_etl/src/energuide/embedded/walls.py
+++ b/nrcan_etl/src/energuide/embedded/walls.py
@@ -5,14 +5,15 @@ from energuide.embedded import composite
 
 class _Wall(typing.NamedTuple):
     insulation: typing.List[composite.CompositeValue]
-    heat_lost: typing.Optional[float]
+    heat_loss: typing.Optional[float]
+
 
 class Wall(_Wall):
 
     @classmethod
     def from_data(cls,
                   insulation: typing.Optional[str],
-                  heat_lost: typing.Optional[float]) -> 'Wall':
+                  heat_loss: typing.Optional[float]) -> 'Wall':
 
         if insulation:
             args = [iter(insulation.split(';'))] * 2
@@ -30,7 +31,7 @@ class Wall(_Wall):
 
         return Wall(
             insulation=composition_insulation,
-            heat_lost=heat_lost
+            heat_loss=heat_lost
         )
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
@@ -38,5 +39,5 @@ class Wall(_Wall):
             'insulation': [
                 insulation.to_dict() for insulation in self.insulation
             ],
-            'heatLost': self.heat_lost,
+            'heatLoss': self.heat_lost,
         }

--- a/nrcan_etl/src/energuide/embedded/walls.py
+++ b/nrcan_etl/src/energuide/embedded/walls.py
@@ -31,7 +31,7 @@ class Wall(_Wall):
 
         return Wall(
             insulation=composition_insulation,
-            heat_loss=heat_lost
+            heat_loss=heat_loss
         )
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:
@@ -39,5 +39,5 @@ class Wall(_Wall):
             'insulation': [
                 insulation.to_dict() for insulation in self.insulation
             ],
-            'heatLoss': self.heat_lost,
+            'heatLoss': self.heat_loss,
         }

--- a/nrcan_etl/tests/embedded/test_walls.py
+++ b/nrcan_etl/tests/embedded/test_walls.py
@@ -4,9 +4,9 @@ from energuide.embedded import composite
 
 def test_from_data() -> None:
     insulation = '50;2;50;5'
-    heat_lost = 10
+    heat_loss = 10
 
-    wall = walls.Wall.from_data(insulation, heat_lost)
+    wall = walls.Wall.from_data(insulation, heat_loss)
     assert wall == walls.Wall(
         insulation=[
             composite.CompositeValue(
@@ -20,7 +20,7 @@ def test_from_data() -> None:
                 value_name='rValue'
             ),
         ],
-        heat_lost=10
+        heat_loss=10
     )
 
 
@@ -38,7 +38,7 @@ def test_to_dict() -> None:
                 value_name='rValue'
             ),
         ],
-        heat_lost=10
+        heat_loss=10
     )
 
     assert wall.to_dict() == {
@@ -51,7 +51,7 @@ def test_to_dict() -> None:
                 'rValue': 5.0,
             }
         ],
-        'heatLost': 10
+        'heatLoss': 10
     }
 
 
@@ -59,6 +59,6 @@ def test_wall_missing_accepted() -> None:
     wall = walls.Wall.from_data(None, None)
     assert wall.to_dict() == {
         'insulation': [],
-        'heatLost': None,
+        'heatLoss': None,
     }
 

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -160,7 +160,7 @@ class TestParsedDwellingDataRow:
                             value_name='rValue'
                         ),
                     ],
-                    heat_lost=27799.9
+                    heat_loss=27799.9
                 ),
                 upgrade=walls.Wall(
                     insulation=[
@@ -180,7 +180,7 @@ class TestParsedDwellingDataRow:
                             value_name='rValue'
                         ),
                     ],
-                    heat_lost=27799.9
+                    heat_loss=27799.9
                 )
             ),
             design_heat_loss=measurement.Measurement(
@@ -287,7 +287,7 @@ class TestDwellingEvaluation:
                             'rValue': 12.0,
                         },
                     ],
-                    'heatLost': 27799.9
+                    'heatLoss': 27799.9
                 },
                 'upgrade': {
                     'insulation': [
@@ -304,7 +304,7 @@ class TestDwellingEvaluation:
                             'rValue': 10.0,
                         },
                     ],
-                    'heatLost': 27799.9
+                    'heatLoss': 27799.9
                 }
             },
             'designHeatLoss': {


### PR DESCRIPTION
This PR changes the name for heat loss in walls from `heat_lost` to `heat_loss`.