### PR TITLE
Keep F evaluations

### DIFF
--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -212,8 +212,11 @@ class Evaluation(_Evaluation):
 
 
 def _filter_dummy_evaluations(data: typing.List[ParsedDwellingDataRow]) -> typing.List[ParsedDwellingDataRow]:
-    def split(data: typing.List[ParsedDwellingDataRow]) -> typing.List[typing.List[ParsedDwellingDataRow]]:
-        groups = {
+
+    def split(data: typing.List[ParsedDwellingDataRow]
+        ) -> typing.List[typing.Dict[datetime.date, ParsedDwellingDataRow]]:
+
+        groups: typing.Dict[EvaluationType, typing.Dict[datetime.date, ParsedDwellingDataRow]] = {
             eval_type: {}
             for eval_type in EvaluationType
         }

--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -212,20 +212,20 @@ class Evaluation(_Evaluation):
 
 
 def _filter_dummy_evaluations(data: typing.List[ParsedDwellingDataRow]) -> typing.List[ParsedDwellingDataRow]:
-    pre_evals = {
-        evaluation.entry_date: evaluation
-        for evaluation in data if evaluation.eval_type is EvaluationType.PRE_RETROFIT
-    }
-    post_evals = {
-        evaluation.entry_date: evaluation
-        for evaluation in data if evaluation.eval_type is EvaluationType.POST_RETROFIT
-    }
-    incentive_evals = [
-        evaluation
-        for evaluation in data if evaluation.eval_type is EvaluationType.INCENTIVE_PROGRAM
-    ]
+    def split(data: typing.List[ParsedDwellingDataRow]) -> typing.List[typing.List[ParsedDwellingDataRow]]:
+        groups = {
+            eval_type: {}
+            for eval_type in EvaluationType
+        }
 
-    return incentive_evals + list(post_evals.values()) + \
+        for evaluation in data:
+            groups[evaluation.eval_type][evaluation.entry_date] = evaluation
+
+        return [groups[eval_type] for eval_type in EvaluationType]
+
+    pre_evals, post_evals, incentive_evals = split(data)
+
+    return list(incentive_evals.values()) + list(post_evals.values()) + \
            [evaluation for date, evaluation in pre_evals.items() if date not in post_evals.keys()]
 
 

--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -214,7 +214,7 @@ class Evaluation(_Evaluation):
 def _filter_dummy_evaluations(data: typing.List[ParsedDwellingDataRow]) -> typing.List[ParsedDwellingDataRow]:
 
     def split(data: typing.List[ParsedDwellingDataRow]
-        ) -> typing.List[typing.Dict[datetime.date, ParsedDwellingDataRow]]:
+             ) -> typing.List[typing.Dict[datetime.date, ParsedDwellingDataRow]]:
 
         groups: typing.Dict[EvaluationType, typing.Dict[datetime.date, ParsedDwellingDataRow]] = {
             eval_type: {}

--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -220,8 +220,12 @@ def _filter_dummy_evaluations(data: typing.List[ParsedDwellingDataRow]) -> typin
         evaluation.entry_date: evaluation
         for evaluation in data if evaluation.eval_type is EvaluationType.POST_RETROFIT
     }
+    incentive_evals = [
+        evaluation
+        for evaluation in data if evaluation.eval_type is EvaluationType.INCENTIVE_PROGRAM
+    ]
 
-    return list(post_evals.values()) + \
+    return incentive_evals + list(post_evals.values()) + \
            [evaluation for date, evaluation in pre_evals.items() if date not in post_evals.keys()]
 
 


### PR DESCRIPTION
This PR refactors `_filter_dummy_evaluations` to...
1. Not filter out `F` evaluations
2. Be prettier