### PR TITLE
Move house_type to Evaluation

### DIFF
--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -197,6 +197,7 @@ class Evaluation(_Evaluation):
             'fileId': self.file_id,
             'evaluationId': self.evaluation_id,
             'evaluationType': self.evaluation_type.value,
+            'houseType': self.house_type,
             'entryDate': self.entry_date.isoformat(),
             'creationDate': self.creation_date.isoformat(),
             'modificationDate': self.modification_date.isoformat() if self.modification_date is not None else None,
@@ -227,7 +228,6 @@ def _filter_dummy_evaluations(data: typing.List[ParsedDwellingDataRow]) -> typin
 
 class _Dwelling(typing.NamedTuple):
     house_id: int
-    house_type: str
     year_built: int
     city: str
     region: Region
@@ -249,7 +249,6 @@ class Dwelling(_Dwelling):
         evaluations = [Evaluation.from_data(row) for row in _filter_dummy_evaluations(data)]
         return Dwelling(
             house_id=data[0].house_id,
-            house_type=data[0].house_type,
             year_built=data[0].year_built,
             city=data[0].city,
             region=data[0].region,
@@ -266,7 +265,6 @@ class Dwelling(_Dwelling):
     def to_dict(self) -> typing.Dict[str, typing.Any]:
         return {
             'houseId': self.house_id,
-            'houseType': self.house_type,
             'yearBuilt': self.year_built,
             'city': self.city,
             'region': self.region.value,

--- a/nrcan_etl/tests/test_database.py
+++ b/nrcan_etl/tests/test_database.py
@@ -11,7 +11,6 @@ def load_data() -> typing.List[dwelling.Dwelling]:
     return [
         dwelling.Dwelling(
             house_id=1,
-            house_type='Single detached',
             year_built=2000,
             city='Ottawa',
             region=region.Region.ONTARIO,
@@ -20,7 +19,6 @@ def load_data() -> typing.List[dwelling.Dwelling]:
         ),
         dwelling.Dwelling(
             house_id=2,
-            house_type='Single detached',
             year_built=2000,
             city='Ottawa',
             region=region.Region.ONTARIO,
@@ -29,7 +27,6 @@ def load_data() -> typing.List[dwelling.Dwelling]:
         ),
         dwelling.Dwelling(
             house_id=3,
-            house_type='Single detached',
             year_built=2000,
             city='Ottawa',
             region=region.Region.ONTARIO,
@@ -70,7 +67,6 @@ def test_load_update(database_coordinates: database.DatabaseCoordinates,
     assert mongo_client[database_name][collection].count() == 3
     load_data[0] = dwelling.Dwelling(
         house_id=1,
-        house_type='Single detached',
         year_built=2001, city='Ottawa',
         region=region.Region.ONTARIO,
         forward_sortation_area='K1P',
@@ -79,7 +75,6 @@ def test_load_update(database_coordinates: database.DatabaseCoordinates,
     load_data.append(
         dwelling.Dwelling(
             house_id=4,
-            house_type='Single detached',
             year_built=2001,
             city='Ottawa',
             region=region.Region.ONTARIO,


### PR DESCRIPTION
After some thought, a house could change house types between evaluations if massive renovations were done, so house_type is being moved from a dwelling level piece of data to the evaluation level.

