### PR TITLE
Fix heated floor area

### DIFF
--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -161,7 +161,7 @@ class _Evaluation(typing.NamedTuple):
     modification_date: typing.Optional[datetime.datetime]
     house_type: str
     energy_upgrades: typing.List[upgrade.Upgrade]
-    heated_floor_area: measurement.Measurement
+    heated_floor_area: typing.Optional[float]
     egh_rating: measurement.Measurement
     ers_rating: measurement.Measurement
     greenhouse_gas_emissions: measurement.Measurement

--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -189,7 +189,6 @@ class Evaluation(_Evaluation):
             energy_intensity=data.energy_intensity,
             walls=data.walls,
             design_heat_loss=data.design_heat_loss,
-
         )
 
     def to_dict(self) -> typing.Dict[str, typing.Any]:


### PR DESCRIPTION
`heated_floor_area` is not a `measurement.Measurement`, the type hint now reflects this.

