### PR TITLE
Add ersRating

### DIFF
--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -67,6 +67,18 @@ describe('Schema', () => {
     })
   })
 
+  describe('ErsRating Type', () => {
+    it('is defined', () => {
+      expect(typeMap).toHaveProperty('ErsRating')
+    })
+
+    it('has the expected fields', () => {
+      const ErsRating = typeMap.ErsRating
+      const fields = Object.keys(ErsRating.getFields())
+      expect(fields).toEqual(['measurement', 'upgrade'])
+    })
+  })
+
   describe('Wall Type', () => {
     it('is defined', () => {
       expect(typeMap).toHaveProperty('Wall')

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -105,7 +105,7 @@ const Schema = i18n => {
       # ${i18n.t`A list of upgrades that would improve energy efficiency`}
       energyUpgrades: [Upgrade]
       # ${i18n.t`The EnerGuide Rating calculated for this evaluation`}
-      ersRating: Int
+      ersRating: ErsRating
       walls: Wall
     }
 
@@ -123,6 +123,11 @@ const Schema = i18n => {
       forwardSortationArea: String
       # ${i18n.t`A list of evaluations of specific features of the dwelling`}
       evaluations: [Evaluation]
+    }
+
+    type ErsRating @cacheControl(maxAge: 90) {
+      measurement: Int
+      upgrade: Int
     }
 
     # ${i18n.t`The root query type`}

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -77,6 +77,29 @@ describe('queries', () => {
       })
     })
 
+    it('retrieves all keys for ersRating data', async () => {
+      let response = await request(server)
+        .post('/graphql')
+        .set('Content-Type', 'application/json; charset=utf-8')
+        .send({
+          query: `{
+            dwelling(houseId:1499786){
+              evaluations {
+                ersRating {
+                  measurement
+                  upgrade
+                }
+              }
+            }
+          }`,
+        })
+      expect(response.body).not.toHaveProperty('errors')
+      let { dwelling: { evaluations } } = response.body.data
+      let [first] = evaluations
+      let ersRating = first.ersRating
+      expect(ersRating.measurement).toEqual(133)
+    })
+
     it('retrieves all keys for wall data', async () => {
       let response = await request(server)
         .post('/graphql')


### PR DESCRIPTION
The branch name lies - this PR adds ersRating back to the api, in new (improved? who knows) form. Also with bonus unit & integration tests, modelled off of @pcraig3 's Wall PR from yesterday.

ersRating looks like this now:

```
ersRating: {
            measurement: 
            upgrade: 
}
```