### PR TITLE
Test dummy evaluations are filtered out

### DIFF
--- a/nrcan_etl/src/energuide/embedded/evaluation_type.py
+++ b/nrcan_etl/src/energuide/embedded/evaluation_type.py
@@ -14,6 +14,6 @@ class EvaluationType(enum.Enum):
             return EvaluationType.PRE_RETROFIT
         elif code == cls.POST_RETROFIT.value:
             return EvaluationType.POST_RETROFIT
-        elif code == cls.INCENTIVE_PROGRAM:
+        elif code == cls.INCENTIVE_PROGRAM.value:
             return EvaluationType.INCENTIVE_PROGRAM
         raise InvalidInputDataError(f'Invalid code: {code}')

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -326,9 +326,9 @@ class TestDwelling:
 
     @pytest.fixture
     def dummy_sample(self,
-               sample_input_d: typing.Dict[str, typing.Any],
-               sample_input_e: typing.Dict[str, typing.Any],
-              ) -> typing.List[typing.Dict[str, typing.Any]]:
+                     sample_input_d: typing.Dict[str, typing.Any],
+                     sample_input_e: typing.Dict[str, typing.Any],
+                    ) -> typing.List[typing.Dict[str, typing.Any]]:
         dummy_d = sample_input_e.copy()
         dummy_d['EVAL_TYPE'] = 'D'
 

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -324,6 +324,22 @@ class TestDwelling:
               ) -> typing.List[typing.Dict[str, typing.Any]]:
         return [sample_input_d, sample_input_e].copy()
 
+    @pytest.fixture
+    def dummy_sample(self,
+               sample_input_d: typing.Dict[str, typing.Any],
+               sample_input_e: typing.Dict[str, typing.Any],
+              ) -> typing.List[typing.Dict[str, typing.Any]]:
+        dummy_d = sample_input_e.copy()
+        dummy_d['EVAL_TYPE'] = 'D'
+
+        new_e = sample_input_e.copy()
+        new_e['ENTRYDATE'] = '2018-06-01'
+
+        new_f = sample_input_e.copy()
+        new_f['ENTRYDATE'] = '2018-08-01'
+
+        return [sample_input_d, sample_input_e, dummy_d, new_e, new_f].copy()
+
     def test_house_id(self, sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
         output = dwelling.Dwelling.from_group(sample)
         assert output.house_id == 456
@@ -361,3 +377,7 @@ class TestDwelling:
 
         assert 'postalCode' not in output
         assert len(evaluations) == 2
+
+    def test_filter_dummies(self, dummy_sample: typing.List[typing.Dict[str, typing.Any]]) -> None:
+        output = dwelling.Dwelling.from_group(dummy_sample)
+        assert len(output.evaluations) == 4

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -336,6 +336,7 @@ class TestDwelling:
         new_e['ENTRYDATE'] = '2018-06-01'
 
         new_f = sample_input_e.copy()
+        new_f['EVAL_TYPE'] = 'F'
         new_f['ENTRYDATE'] = '2018-08-01'
 
         return [sample_input_d, sample_input_e, dummy_d, new_e, new_f].copy()


### PR DESCRIPTION
This PR adds some a missing test to ensure that dwellings throw away "dummy" pre-evaluations (defined as pre-evaluations that have the same ENTRYDATE as another post-evaluation)