### PR TITLE
Add Sort localFileReader change from etl that was missed in transfer

### DIFF
--- a/nrcan_etl/src/energuide/transform.py
+++ b/nrcan_etl/src/energuide/transform.py
@@ -48,7 +48,7 @@ class LocalExtractReader:
 
     def extracted_rows(self) -> typing.Iterator[typing.Dict[str, typing.Any]]:
         with zipfile.ZipFile(self._zip_filename) as zip_input:
-            for file in zip_input.namelist():
+            for file in sorted(zip_input.namelist()):
                 content = zip_input.read(file)
                 house = json.loads(content)
                 house['jsonFileName'] = file

--- a/nrcan_etl/tests/test_transform.py
+++ b/nrcan_etl/tests/test_transform.py
@@ -1,4 +1,5 @@
 import time
+import typing
 import zipfile
 import _pytest
 import pytest
@@ -23,6 +24,15 @@ def test_reader(local_reader: transform.LocalExtractReader) -> None:
     assert len(output) == 21
     assert output[0]['BUILDER'] == '1521D00144'
     assert len(unique_builders) == 21
+
+
+def test_reader_sorted_by_eval_id(local_reader: transform.LocalExtractReader) -> None:
+    output = list(local_reader.extracted_rows())
+
+    assert all(
+        typing.cast(str, current_row.get('HOUSE_ID')) <= typing.cast(str, next_row.get('HOUSE_ID'))
+        for current_row, next_row in zip(output, output[1:])
+    )
 
 
 def test_reader_num_rows(local_reader: transform.LocalExtractReader) -> None:

--- a/nrcan_etl/tests/test_transform.py
+++ b/nrcan_etl/tests/test_transform.py
@@ -26,7 +26,7 @@ def test_reader(local_reader: transform.LocalExtractReader) -> None:
     assert len(unique_builders) == 21
 
 
-def test_reader_sorted_by_eval_id(local_reader: transform.LocalExtractReader) -> None:
+def test_reader_sorted_by_house_id(local_reader: transform.LocalExtractReader) -> None:
     output = list(local_reader.extracted_rows())
 
     assert all(


### PR DESCRIPTION
This PR adds in the functionality of #351 that seemed to have been missed in the transition from `etl` to `nrcan_etl`