### PR TITLE
adapt README and Makefile(s) to nrcan_etl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ check_mongodb:
 		[ "`command -v brew`" ] && [ "`brew ls mongodb --versions`" ] && brew services start mongo || (echo "ERROR: You need to install MongoDB to run the API." && exit 1); \
 	fi
 setup_python:
-	$(MAKE) -C etl setup_python
+	$(MAKE) -C nrcan_etl setup_python
 import_data:
-	$(MAKE) -C etl import_data
+	$(MAKE) -C nrcan_etl import_data
 setup: check_mongodb
-	$(MAKE) -C etl setup_python import_data
+	$(MAKE) -C nrcan_etl setup_python import_data
 
 .PHONY: run build test watch
 run:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Once the script runs through, you'll need to import the data into your database,
 
 #### importing data
 
-The Python code in `/etl` transforms the data from the default formatting set by NRCAN, and then inserts it into our Mongo database. More details can be found in the [README](https://github.com/cds-snc/nrcan_api/blob/master/etl/README.md).
+The Python code in `/nrcan_etl` transforms the data from the default formatting set by NRCAN, and then inserts it into our Mongo database. More details can be found in the [README](https://github.com/cds-snc/nrcan_api/blob/master/nrcan_etl/README.md).
 
 For local development, run
 ```

--- a/nrcan_etl/Makefile
+++ b/nrcan_etl/Makefile
@@ -14,7 +14,7 @@ setup_python:  virtualenv requirements.txt
 import_data: virtualenv
 	echo "Removing all NRCAN data"
 	mongo energuide --eval "db.dwellings.drop()"
-	${VIRTUALENV_ROOT}/bin/energuide extract --infile tests/randomized_energuide_data.csv --outfile allthedata.zip
+	${VIRTUALENV_ROOT}/bin/energuide extract --infile tests/scrubbed_random_sample_xml.csv --outfile allthedata.zip
 	echo "Importing new NRCAN data"
 	${VIRTUALENV_ROOT}/bin/energuide load --filename allthedata.zip
 	rm allthedata.zip


### PR DESCRIPTION
This PR fixes some missing changes to the README referencing the old `etl`, and also changes the makefile(s) to now work with the new `nrcan_etl`