### PR TITLE
Add house type to evaluation

### DIFF
--- a/api/src/schema/__tests__/schema.test.js
+++ b/api/src/schema/__tests__/schema.test.js
@@ -40,6 +40,7 @@ describe('Schema', () => {
         'evaluationType',
         'entryDate',
         'fileId',
+        'houseType',
         'creationDate',
         'modificationDate',
         'energyUpgrades',

--- a/api/src/schema/index.js
+++ b/api/src/schema/index.js
@@ -98,6 +98,7 @@ const Schema = i18n => {
       # ${i18n.t`Date the evaluation was made`}
       entryDate: String
       fileId: String
+      houseType: String
       # ${i18n.t`Date the record was first created`}
       creationDate: String
       # ${i18n.t`Date the record was last modified`}

--- a/api/test/queries.test.js
+++ b/api/test/queries.test.js
@@ -61,6 +61,7 @@ describe('queries', () => {
               creationDate
               modificationDate
               fileId
+              houseType
             }
           }
         }`,
@@ -74,6 +75,7 @@ describe('queries', () => {
         evaluationType: 'D',
         modificationDate: null,
         fileId: '1B07D10023',
+        houseType: 'Single detached',
       })
     })
 


### PR DESCRIPTION
This PR adds houseType to Evaluation, which is a string that describes the type of house being evaluated. We decided to add this to Evaluation instead of Dwelling due to the fact that major renovations can lead to a changed house type between evaluations.