### PR TITLE
Clean house type

### DIFF
--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -24,7 +24,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     city: str
     region: Region
     forward_sortation_area: str
-    house_type: str 
+    house_type: str
 
     energy_upgrades: typing.List[upgrade.Upgrade]
     heated_floor_area: typing.Optional[float]
@@ -161,7 +161,7 @@ class _Evaluation(typing.NamedTuple):
     entry_date: datetime.date
     creation_date: datetime.datetime
     modification_date: typing.Optional[datetime.datetime]
-    house_type: str 
+    house_type: str
     energy_upgrades: typing.List[upgrade.Upgrade]
     heated_floor_area: typing.Optional[float]
     egh_rating: measurement.Measurement

--- a/nrcan_etl/src/energuide/dwelling.py
+++ b/nrcan_etl/src/energuide/dwelling.py
@@ -6,6 +6,7 @@ from energuide.embedded import upgrade
 from energuide.embedded import measurement
 from energuide.embedded import walls
 from energuide.embedded.region import Region
+from energuide.embedded.house_type import HouseType
 from energuide.embedded.evaluation_type import EvaluationType
 from energuide.exceptions import InvalidGroupSizeError
 from energuide.exceptions import InvalidInputDataError
@@ -23,7 +24,7 @@ class _ParsedDwellingDataRow(typing.NamedTuple):
     city: str
     region: Region
     forward_sortation_area: str
-    house_type: str
+    house_type: str 
 
     energy_upgrades: typing.List[upgrade.Upgrade]
     heated_floor_area: typing.Optional[float]
@@ -114,7 +115,7 @@ class ParsedDwellingDataRow(_ParsedDwellingDataRow):
 
             energy_upgrades=[upgrade.Upgrade.from_data(upgrade_node) for upgrade_node in parsed['upgrades']],
             heated_floor_area=parsed['HEATEDFLOORAREA'],
-            house_type=parsed['TYPEOFHOUSE'],
+            house_type=HouseType.normalize(parsed['TYPEOFHOUSE']),
 
             egh_rating=measurement.Measurement(
                 measurement=parsed['EGHRATING'],
@@ -160,7 +161,7 @@ class _Evaluation(typing.NamedTuple):
     entry_date: datetime.date
     creation_date: datetime.datetime
     modification_date: typing.Optional[datetime.datetime]
-    house_type: str
+    house_type: str 
     energy_upgrades: typing.List[upgrade.Upgrade]
     heated_floor_area: typing.Optional[float]
     egh_rating: measurement.Measurement

--- a/nrcan_etl/src/energuide/embedded/house_type.py
+++ b/nrcan_etl/src/energuide/embedded/house_type.py
@@ -2,7 +2,7 @@ import re
 
 
 class HouseType():
-    
+
     @classmethod
     def normalize(cls, unclean_string) -> str:
         lowercase = unclean_string.lower()

--- a/nrcan_etl/src/energuide/embedded/house_type.py
+++ b/nrcan_etl/src/energuide/embedded/house_type.py
@@ -1,0 +1,12 @@
+import re
+
+
+class HouseType():
+    
+    @classmethod
+    def normalize(cls, unclean_string) -> str:
+        lowercase = unclean_string.lower()
+        alpha = re.sub('[^a-zA-Z/ _-]', '', lowercase)
+        separated = re.sub('[_-]', ' ', alpha)
+
+        return separated.capitalize()

--- a/nrcan_etl/tests/embedded/test_house_type.py
+++ b/nrcan_etl/tests/embedded/test_house_type.py
@@ -32,4 +32,4 @@ def house_types() -> typing.List[typing.Tuple[str, str]]:
 def test_normalize(dirty, clean):
 
     assert house_type.HouseType.normalize(dirty) == clean
-    
+

--- a/nrcan_etl/tests/embedded/test_house_type.py
+++ b/nrcan_etl/tests/embedded/test_house_type.py
@@ -1,0 +1,35 @@
+import typing
+import pytest
+from energuide.embedded import house_type
+
+
+def house_types() -> typing.List[typing.Tuple[str, str]]:
+    return [
+        ("Single detached", "Single detached"),
+        ("Detached Duplex", 'Detached duplex'),
+        ("Single Detached", 'Single detached'),
+        ("Row, end unit", 'Row end unit'),
+        ("Row house, end unit", 'Row house end unit'),
+        ("Row house, middle unit", 'Row house middle unit'),
+        ("Double/Semi-detached", 'Double/semi detached'),
+        ("Mobile home", 'Mobile home'),
+        ("Apartment Row", 'Apartment row'),
+        ("Apartment", 'Apartment'),
+        ("Attached Triplex", 'Attached triplex'),
+        ("Detached Triplex", 'Detached triplex'),
+        ("Attached Duplex", 'Attached duplex'),
+        ("Mobile Home", 'Mobile home'),
+        ("Double/Semi Detached", 'Double/semi detached'),
+        ("Triplex (non-MURB)", 'Triplex non murb'),
+        ("Duplex (non-MURB)", 'Duplex non murb'),
+        ("Row, middle unit", 'Row middle unit'),
+        ("Double/Semi-Detached", 'Double/semi detached'),
+        ("Apartment (non-MURB)", 'Apartment non murb'),
+    ]
+
+
+@pytest.mark.parametrize("dirty, clean", house_types())
+def test_normalize(dirty, clean):
+
+    assert house_type.HouseType.normalize(dirty) == clean
+    

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -8,6 +8,7 @@ from energuide.embedded import measurement
 from energuide.embedded import composite
 from energuide.embedded import walls
 from energuide.embedded import region
+from energuide.embedded import house_type
 from energuide.embedded import evaluation_type
 from energuide.exceptions import InvalidInputDataError
 from energuide.exceptions import InvalidGroupSizeError

--- a/nrcan_etl/tests/test_dwelling.py
+++ b/nrcan_etl/tests/test_dwelling.py
@@ -8,7 +8,6 @@ from energuide.embedded import measurement
 from energuide.embedded import composite
 from energuide.embedded import walls
 from energuide.embedded import region
-from energuide.embedded import house_type
 from energuide.embedded import evaluation_type
 from energuide.exceptions import InvalidInputDataError
 from energuide.exceptions import InvalidGroupSizeError


### PR DESCRIPTION
This PR adds some data cleaning to the parsing of the TYPEOFHOUSE TSV field to make it more consistent.

Observation of the data yields that all the current values of houseType are:
```
[
    "Single detached",
    "Detached Duplex",
    "Single Detached",
    "Row, end unit",
    "Row house, end unit",
    "Row house, middle unit",
    "Double/Semi-detached",
    "Mobile home",
    "Apartment Row",
    "Apartment",
    "Attached Triplex",
    "Detached Triplex",
    "Attached Duplex",
    "Mobile Home",
    "Double/Semi Detached",
    "Triplex (non-MURB)",
    "Duplex (non-MURB)",
    "Row, middle unit",
    "Double/Semi-Detached",
    "Apartment (non-MURB)"
]
```

Some of these are obviously the same but different by case, but some (such as "Row, end unit" and "Row house, end unit") seem like they could be the same, but is hard to tell.

We are leaving the cleaning to just make casing/word separation/etc consistent, and not attempting to determine differently worded duplicates as we do not know if they are in fact duplicates.