### PR TITLE
Remove *nix-y path from docs command

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -16,7 +16,7 @@
     "compile": "./node_modules/lingui-cli/dist/lingui.js compile",
     "lint": "eslint src/** test/** --ignore-pattern src/locale",
     "watch": "nodemon --watch \"src\" --ignore \"src/__tests__\" --ignore \"src/locale\" --exec \"yarn build && yarn start\"",
-    "docs": "./node_modules/graphql-markdown/src/index.js http://localhost:3000/graphql > docs.md"
+    "docs": "graphql-markdown http://localhost:3000/graphql > docs.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This path only works on *nix machines, and isn't required since yarn/npm
assume everything is in your node_modules folder anyway.