### PR TITLE
Add endpoints for liveness and readiness probes

### DIFF
--- a/api/src/server.js
+++ b/api/src/server.js
@@ -38,6 +38,23 @@ function Server(context = {}, ...middlewares) {
   server.get('/', function(req, res) {
     res.redirect('/graphiql')
   })
+  server.get('/alive', (req, res) => {
+    res.send('yes')
+  })
+  server.get('/ready', async (req, res) => {
+    try {
+      const result = await context.client.findOne()
+      if (result) {
+        res.send('yes')
+      } else {
+        res.status(500).json({
+          error: 'Database check failed. No data returned.',
+        })
+      }
+    } catch (error) {
+      res.status(500).json({ error: error.toString() })
+    }
+  })
   return server
 }
 


### PR DESCRIPTION
Kubernetes will determine if pods are healthy or capable of handling
traffic based on the result of probes. These endpoints are intended to
allow this service to be queried by Kubernetes so it can be managed more
easily.