### PR TITLE
Update to version node:9-alpine

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:9.0-alpine
+FROM node:9-alpine
 MAINTAINER Mike Williamson <mike.williamson@tbs-sct.gc.ca>
 LABEL Description="Node API" Vendor="Canadian Digital Service"
 
 WORKDIR /app
-#USER node
 ADD . .
 RUN yarn install && yarn build
 


### PR DESCRIPTION
This fixes the build, since yarn no longer produces a warning (which CI
treats as a failure) about working with node 9.